### PR TITLE
alphaTest should be a num, not an int.

### DIFF
--- a/lib/src/materials/Material.dart
+++ b/lib/src/materials/Material.dart
@@ -15,7 +15,7 @@ class Material implements IMaterial
 
   num opacity;
   int blending, blendSrc, blendDst, blendEquation;
-  int alphaTest;
+  num alphaTest;
   bool polygonOffset;
   int polygonOffsetFactor, polygonOffsetUnits;
   bool transparent, depthTest, depthWrite, overdraw;

--- a/lib/src/renderers/WebGLRenderer.dart
+++ b/lib/src/renderers/WebGLRenderer.dart
@@ -5941,7 +5941,7 @@ class WebGLRenderer implements Renderer {
 		      bool useFog = false,
 		      int maxMorphTargets = 8,
 		      int maxMorphNormals = 4,
-		      int alphaTest = 0,
+		      num alphaTest = 0,
 		      bool metal = false] ) {
 
 		var p, pl, glprogram, code;
@@ -7200,7 +7200,7 @@ class WebGLMaterial { // implements Material {
   int get blendSrc => _material.blendSrc;
   int get blendDst => _material.blendDst;
   int get blendEquation => _material.blendEquation;
-  int get alphaTest => _material.alphaTest;
+  num get alphaTest => _material.alphaTest;
   int get polygonOffsetFactor => _material.polygonOffsetFactor;
   int get polygonOffsetUnits => _material.polygonOffsetUnits;
   bool get transparent => _material.transparent;


### PR DESCRIPTION
alphaTest is a transparency threshold for materials between 0 and 1,  but was set as an int. I changed some places where it was defined as an int.
