### PR TITLE
Use Markdown syntax rather than HTML for image links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,21 @@ Starting at three.js revision 47.0, the aim is to recreate all of the existing t
 
 #### WebGL examples ####
 
-
-<a href="http://threedart.github.com/three.dart/example/webgl_nyan_cat/nyan_cat.html"><img src="http://threedart.github.com/three.dart/example/webgl_nyan_cat/thumb_small.png"></a>
-<a href="http://threedart.github.com/three.dart/example/webgl_geometries/WebGL_Geometries.html"><img src="http://threedart.github.com/three.dart/example/webgl_geometries/thumb_small.png"></a>
-<a href="http://threedart.github.com/three.dart/example/webgl_geometry_cube/WebGL_Geometry_Cube.html"><img src="http://threedart.github.com/three.dart/example/webgl_geometry_cube/thumb_small.png" alt="webgl_geometry_cube"></a>
-<a href="http://threedart.github.com/three.dart/example/webgl_geometry_extrude_shapes/WebGL_Geometry_Extrude_Shapes.html"><img src="http://threedart.github.com/three.dart/example/webgl_geometry_extrude_shapes/thumb_small.png"></a>
-<a href="http://threedart.github.com/three.dart/example/webgl_geometry_hierarchy/WebGL_Geometry_Hierarchy.html"><img src="http://threedart.github.com/three.dart/example/webgl_geometry_hierarchy/thumb_small.png" alt="webgl_geometry_hierarchy"></a>    
-<a href="http://threedart.github.com/three.dart/example/webgl_geometry_shapes/WebGL_Geometry_Shapes.html"><img src="http://threedart.github.com/three.dart/example/webgl_geometry_shapes/thumb_small.png"></a>
-<a href="http://threedart.github.com/three.dart/example/webgl_interactive_cubes/WebGL_Interactive_Cubes.html"><img src="http://threedart.github.com/three.dart/example/webgl_interactive_cubes/thumb_small.png" alt="webgl_interactive_cubes"></a>
+[![nyan_cat](http://threedart.github.com/three.dart/example/webgl_nyan_cat/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_nyan_cat/nyan_cat.html)
+[![webgl_geometries](http://threedart.github.com/three.dart/example/webgl_geometries/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_geometries/WebGL_Geometries.html)
+[![webgl_geometry_cube](http://threedart.github.com/three.dart/example/webgl_geometry_cube/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_geometry_cube/WebGL_Geometry_Cube.html)
+[![webgl_geometry_extrude_shapes](http://threedart.github.com/three.dart/example/webgl_geometry_extrude_shapes/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_geometry_extrude_shapes/WebGL_Geometry_Extrude_Shapes.html)
+[![webgl_geometry_hierarchy](http://threedart.github.com/three.dart/example/webgl_geometry_hierarchy/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_geometry_hierarchy/WebGL_Geometry_Hierarchy.html)
+[![webgl_geometry_shapes](http://threedart.github.com/three.dart/example/webgl_geometry_shapes/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_geometry_shapes/WebGL_Geometry_Shapes.html)
+[![webgl_interactive_cubes](http://threedart.github.com/three.dart/example/webgl_interactive_cubes/thumb_small.png)](http://threedart.github.com/three.dart/example/webgl_interactive_cubes/WebGL_Interactive_Cubes.html)
 
 #### Canvas examples ####
 
-
-<a href="http://threedart.github.com/three.dart/example/canvas_geometry_cube/Canvas_Geometry_Cube.html"><img src="http://threedart.github.com/three.dart/example/canvas_geometry_cube/thumb_small.png" width="104" height="78" alt="canvas_geometry_cube"></a>
-<a href="http://threedart.github.com/three.dart/example/canvas_geometry_hierarchy/Canvas_Geometry_Hierarchy.html"><img src="http://threedart.github.com/three.dart/example/canvas_geometry_hierarchy/thumb_small.png" width="104" height="78" alt="canvas_geometry_hierarchy"></a>
-<a href="http://threedart.github.com/three.dart/example/canvas_interactive_cubes/Canvas_Interactive_Cubes.html"><img src="http://threedart.github.com/three.dart/example/canvas_interactive_cubes/thumb_small.png" width="104" height="78" alt="canvas_interactive_cubes"></a>
-<a href="http://threedart.github.com/three.dart/example/canvas_lines/Canvas_Lines.html"><img src="http://threedart.github.com/three.dart/example/canvas_lines/thumb_small.png"></a>
-<a href="http://threedart.github.com/three.dart/example/canvas_camera_orthographic/Canvas_Camera_Orthographic.html"><img src="http://threedart.github.com/three.dart/example/canvas_camera_orthographic/thumb_small.png"></a>
+[![canvas_geometry_cube](http://threedart.github.com/three.dart/example/canvas_geometry_cube/thumb_small.png)](http://threedart.github.com/three.dart/example/canvas_geometry_cube/Canvas_Geometry_Cube.html)
+[![canvas_geometry_hierarchy](http://threedart.github.com/three.dart/example/canvas_geometry_hierarchy/thumb_small.png)](http://threedart.github.com/three.dart/example/canvas_geometry_hierarchy/Canvas_Geometry_Hierarchy.html)
+[![canvas_interactive_cubes](http://threedart.github.com/three.dart/example/canvas_interactive_cubes/thumb_small.png)](http://threedart.github.com/three.dart/example/canvas_interactive_cubes/Canvas_Interactive_Cubes.html)
+[![canvas_lines](http://threedart.github.com/three.dart/example/canvas_lines/thumb_small.png)](http://threedart.github.com/three.dart/example/canvas_lines/Canvas_Lines.html)
+[![canvas_camera_orthographic](http://threedart.github.com/three.dart/example/canvas_camera_orthographic/thumb_small.png)](http://threedart.github.com/three.dart/example/canvas_camera_orthographic/Canvas_Camera_Orthographic.html)
 
 ### Change Log ###
 


### PR DESCRIPTION
At some point pub.dartlang.org will support literal `<a>` and `<img>` tags, but
using Markdown links will get the readme displayed correctly for now.
