### PR TITLE
Dart library changes.

### DIFF
--- a/lib/extras/core/SplineCurve3.dart
+++ b/lib/extras/core/SplineCurve3.dart
@@ -14,7 +14,7 @@ class SplineCurve3 extends Curve3D {
   Vector3 getPoint( t ) {
 
     var v = new Vector3();
-    var c = new List<int>.fixedLength(4);
+    var c = new List<int>(4);
     var point = ( points.length - 1 ) * t,
         intPoint = point.floor().toInt(),
         weight = point - intPoint;

--- a/lib/src/core/Geometry.dart
+++ b/lib/src/core/Geometry.dart
@@ -372,7 +372,7 @@ class Geometry {
   void computeBoundingSphere() {
     num radiusSq;
 
-    var maxRadiusSq = vertices.reduce(0, (num curMaxRadiusSq, Vector3 vertex) {
+    var maxRadiusSq = vertices.fold(0, (num curMaxRadiusSq, Vector3 vertex) {
       radiusSq = vertex.lengthSq();
       return ( radiusSq > curMaxRadiusSq ) ?  radiusSq : curMaxRadiusSq;
     });


### PR DESCRIPTION
Dart changes on the library. "List.reduce" no longer exists, and when an array is given the size, it is now fixed length.
