### PR TITLE
Fixed texture flip issue.

### DIFF
--- a/lib/src/textures/texture.dart
+++ b/lib/src/textures/texture.dart
@@ -61,7 +61,7 @@ class Texture {
 
     generateMipmaps = true;
     premultiplyAlpha = false;
-    flipY = true;
+    flipY = false;
 
     needsUpdate = false;
     onUpdate = null;


### PR DESCRIPTION
Resolve #124, textures are flipped on the y-axis by default.
