### PR TITLE
Cast JSONLoader Ints to Doubles Where Needed

### DIFF
--- a/lib/src/loaders/json_loader.dart
+++ b/lib/src/loaders/json_loader.dart
@@ -268,9 +268,9 @@ class JSONLoader extends Loader {
 
         normal = new Vector3.zero();
 
-        normal.x = normals[ normalIndex ++ ];
-        normal.y = normals[ normalIndex ++ ];
-        normal.z = normals[ normalIndex ];
+        normal.x = normals[ normalIndex ++ ].toDouble();
+        normal.y = normals[ normalIndex ++ ].toDouble();
+        normal.z = normals[ normalIndex ].toDouble();
 
         face.normal = normal;
 
@@ -284,9 +284,9 @@ class JSONLoader extends Loader {
 
           normal = new Vector3.zero();
 
-          normal.x = normals[ normalIndex ++ ];
-          normal.y = normals[ normalIndex ++ ];
-          normal.z = normals[ normalIndex ];
+          normal.x = normals[ normalIndex ++ ].toDouble();
+          normal.y = normals[ normalIndex ++ ].toDouble();
+          normal.z = normals[ normalIndex ].toDouble();
 
           face.vertexNormals.add( normal );
 
@@ -338,7 +338,7 @@ class JSONLoader extends Loader {
         z = 0.0;
         w = 0.0;
 
-        geometry.skinWeights.add( new Vector4( x, y, z, w ) );
+        geometry.skinWeights.add( new Vector4( x.toDouble(), y.toDouble(), z.toDouble(), w.toDouble() ) );
 
       }
 
@@ -354,7 +354,7 @@ class JSONLoader extends Loader {
         c = 0.0;
         d = 0.0;
 
-        geometry.skinIndices.add( new Vector4( a, b, c, d ) );
+        geometry.skinIndices.add( new Vector4( a.toDouble(), b.toDouble(), c.toDouble(), d.toDouble() ) );
 
       }
 


### PR DESCRIPTION
I don't know anything. I just took the web_gl_morph_targets_horse example and tried to load [this free model](http://www.blendswap.com/blends/view/74387) after using the threej.js exporter on it. I got a casting error, "type 'int' is not a subtype of type 'double' of 'd'," when doing so. The same model worked fine in the three.js editor.

This PR alleviates the symptoms but I don't know if it's a good fix. Please feel free to disregard it for a more appropriate change.
