### PR TITLE
Fixed list indexing in closed spline curve

### DIFF
--- a/lib/extras/core/closed_spline_curve3.dart
+++ b/lib/extras/core/closed_spline_curve3.dart
@@ -11,7 +11,7 @@ class ClosedSplineCurve3 extends Curve3D {
   Vector3 getPoint( t ) {
 
     var v = new Vector3.zero();
-    var c = [];
+    var c = new List<int>(4);
     var point,
         intPoint,
         weight;


### PR DESCRIPTION
The closed spline was broken since the automatic growing of lists is no more possible in dart. This copies the fix that was applied in the open spline.
