### PR TITLE
Add set vertexShader for ShaderMaterial.

### DIFF
--- a/lib/src/materials/shader_material.dart
+++ b/lib/src/materials/shader_material.dart
@@ -88,4 +88,18 @@ class ShaderMaterial extends Material implements Morphing, Skinning, Wireframe {
                       this._vertexShader = vertexShader;
                     }
 
+  set vertexShader(String value) {
+    _vertexShader = value;
+    needsUpdate = true;
+  }
+
+  set fragmentShader(String value) {
+    _fragmentShader = value;
+    needsUpdate = true;
+  }
+
+  set uniforms(Map<String, Uniform> value) {
+    _uniforms = value;
+    needsUpdate = true;
+  }
 }


### PR DESCRIPTION
I need this setter for my application.

WebGLRenderer.setMaterialShaders does not suit my purpose, as it clones the uniforms, and adds unnecessary overhead.
