### PR TITLE
Updated Change Log for 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Starting at three.js revision 47.0, the aim is to recreate all of the existing t
 [![controls_first_person](http://threedart.github.com/three.dart/example/controls_first_person/thumb_small.png)](http://threedart.github.com/three.dart/example/controls_first_person/controls_first_person.html)
 
 ### Change Log ###
+2013 04 29 - **v 0.2.5**
+
+* Added hop runner, tested here: https://drone.io/github.com/threeDart/three.dart/41
+* Bug fixes for dart-sdk version 0.5.0.1_r21823
+* Adding Quaternion rotationBetween method
+* Added customDepthMaterial to Object3D
+* Added ShadowCaster
+* Added ShadowMapPlugin
+* Added materials list to MeshFaceMaterial
+* Added WebGL_Materials example
+* Added shininess and specular to WebGLMaterial
+
 2013 01 30 - **v 0.2.4**
 
 * Minor refactoring to M3 ([adam](https://github.com/financeCoding))


### PR DESCRIPTION
- closes #53 

I compiled a rough list from the commit logs, so hopefully I didn't miss too much. Let me know of any changes that need to be made.

On a related note, is there any reason why the changelog is manually updated in the README instead of either in tag comments (like [three.js](https://github.com/mrdoob/three.js/releases)) or in a `Changelog.md`? I think the former is a better way to go and would *hopefully* make it more likely to actually tag the releases (nothing before 0.2.5 is tagged AFAICT).

Also, before I open an issue for it, is there any chance in getting a new release any time soon? I'd very much like to see #162 land in a new release so I can lock my app to it. :smile: If there's no major reason why a release hasn't been cut, I'll open an issue for it.

