### PR TITLE
Fixes DirectionalLight and examples. 

### DIFF
--- a/example/web_gl_custom_attributes/web_gl_custom_attributes.dart
+++ b/example/web_gl_custom_attributes/web_gl_custom_attributes.dart
@@ -99,7 +99,7 @@ render() {
   sphere.rotation.y = sphere.rotation.z = 0.01 * time;
 
   amplitude.value = 2.5 * Math.sin( sphere.rotation.y * 0.125 );
-  color.value.offsetHSL( 0.0005, 0, 0 );
+  color.value.offsetHSL( 0.0005, 0.0, 0.0 );
 
   for ( var i = 0; i < displacement.value.length; i ++ ) {
 

--- a/example/web_gl_interactive_cubes/web_gl_interactive_cubes.dart
+++ b/example/web_gl_interactive_cubes/web_gl_interactive_cubes.dart
@@ -34,7 +34,7 @@ void init() {
 
   var light;
 
-  light = new DirectionalLight( 0xffffff, 2 );
+  light = new DirectionalLight( 0xffffff, 2.0 );
   light.position.setValues( 1.0, 1.0, 1.0 ).normalize();
   scene.add( light );
 

--- a/example/web_gl_morph_targets_horse/web_gl_morph_targets_horse.dart
+++ b/example/web_gl_morph_targets_horse/web_gl_morph_targets_horse.dart
@@ -29,11 +29,11 @@ void init() {
 
   var light;
 
-  light = new DirectionalLight( 0xefefff, 2 );
+  light = new DirectionalLight( 0xefefff, 2.0 );
   light.position.setValues( 1.0, 1.0, 1.0 ).normalize();
   scene.add( light );
 
-  light = new DirectionalLight( 0xffefef, 2 );
+  light = new DirectionalLight( 0xffefef, 2.0 );
   light.position.setValues( -1.0, -1.0, -1.0 ).normalize();
   scene.add( light );
 

--- a/lib/src/lights/directional_light.dart
+++ b/lib/src/lights/directional_light.dart
@@ -18,7 +18,7 @@ class DirectionalLight extends ShadowCaster {
   /// Target used for shadow camera orientation.
   Object3D target;
   /// Light's intensity (default: 1.0)
-  num intensity;
+  double intensity;
   num distance;
 
   /// Orthographic shadow camera frustum parameter (default: -500)
@@ -48,7 +48,7 @@ class DirectionalLight extends ShadowCaster {
   /// produced from it are all parallel.
   /// The best analogy would be a light source that acts like the sun: the sun
   /// is so far away that all sunlight hitting objects comes from the same angle.
-  DirectionalLight( num hex, [this.intensity = 1, this.distance = 0]) : super( hex ) {
+  DirectionalLight( num hex, [this.intensity = 1.0, this.distance = 0]) : super( hex ) {
 
     position = new Vector3( 0.0, 1.0, 0.0 );
     target = new Object3D();


### PR DESCRIPTION
After recent merges to master, WebGLRenderer now expects a double for DirectionalLight intensity. However the intensity's default value was int, thus resulting in an error when using DirectionalLight's default intensity value. So, I changed it to double and changed the examples to pass a double instead of an int for intensity value.

This also fixes custom attributes example. Color.value.offsetHSL parameters were also changed to doubles, so I changed the example to pass doubles instead of ints as arguments to that method.