### PR TITLE
Tabs -> spaces (part of #166)

### DIFF
--- a/lib/extras/core/curve.dart
+++ b/lib/extras/core/curve.dart
@@ -1,7 +1,7 @@
 part of three;
 
 /**************************************************************
- *	Abstract Curve base class
+ *  Abstract Curve base class
  **************************************************************/
 abstract class Curve<V> {
 
@@ -9,47 +9,47 @@ abstract class Curve<V> {
   List cacheArcLengths = null;
   bool needsUpdate = false;
 
-	// Virtual base class method to overwrite and implement in subclasses
-	//	- t [0 .. 1]
+  // Virtual base class method to overwrite and implement in subclasses
+  //  - t [0 .. 1]
   V getPoint(t);
 
-	// Get point at relative position in curve according to arc length
-	// - u [0 .. 1]
+  // Get point at relative position in curve according to arc length
+  // - u [0 .. 1]
   V getPointAt( u ) {
-		var t = getUtoTmapping( u );
-		return getPoint( t );
-	}
+    var t = getUtoTmapping( u );
+    return getPoint( t );
+  }
 
-	// Get sequence of points using getPoint( t )
+  // Get sequence of points using getPoint( t )
   // TODO(nelsonsilva) - closedPath is only used in Path
-	List<V> getPoints( [num divisions = null, closedPath = false] ) {
+  List<V> getPoints( [num divisions = null, closedPath = false] ) {
 
-	  if (divisions == null) divisions = 5;
+    if (divisions == null) divisions = 5;
 
-		var d, pts = [];
+    var d, pts = [];
 
-		for ( d = 0; d <= divisions; d ++ ) {
-			pts.add( this.getPoint( d / divisions ) );
-		}
+    for ( d = 0; d <= divisions; d ++ ) {
+      pts.add( this.getPoint( d / divisions ) );
+    }
 
-		return pts;
-	}
+    return pts;
+  }
 
-	// Get sequence of points using getPointAt( u )
+  // Get sequence of points using getPointAt( u )
   // TODO(nelsonsilva) - closedPath is only used in Path
-	List<V> getSpacedPoints( [num divisions = 5, closedPath = false] ) {
+  List<V> getSpacedPoints( [num divisions = 5, closedPath = false] ) {
 
 
-		var d, pts = [];
+    var d, pts = [];
 
-		for ( d = 0; d <= divisions; d ++ ) {
-			pts.add( this.getPointAt( d / divisions ) );
-		}
+    for ( d = 0; d <= divisions; d ++ ) {
+      pts.add( this.getPointAt( d / divisions ) );
+    }
 
-		return pts;
-	}
+    return pts;
+  }
 
-	 // Get sequence of points using getPointAt( u )
+   // Get sequence of points using getPointAt( u )
   // TODO(tiagocardoso) - closedPath is only used in Path
   List<V> getUPoints( [List uList , closedPath = false] ) {
     var pts = [];
@@ -62,165 +62,165 @@ abstract class Curve<V> {
   }
 
 
-	// Get total curve arc length
-	num get length => getLengths().last;
+  // Get total curve arc length
+  num get length => getLengths().last;
 
-	// Get list of cumulative segment lengths
-	List getLengths( {num divisions: null} ) {
+  // Get list of cumulative segment lengths
+  List getLengths( {num divisions: null} ) {
 
-		if (divisions == null) divisions = (_arcLengthDivisions != null) ? (_arcLengthDivisions): 200;
+    if (divisions == null) divisions = (_arcLengthDivisions != null) ? (_arcLengthDivisions): 200;
 
-		if ( cacheArcLengths != null
-			&& ( cacheArcLengths.length == divisions + 1 )
-			&& !needsUpdate) {
+    if ( cacheArcLengths != null
+      && ( cacheArcLengths.length == divisions + 1 )
+      && !needsUpdate) {
 
-			//console.log( "cached", this.cacheArcLengths );
-			return cacheArcLengths;
-		}
+      //console.log( "cached", this.cacheArcLengths );
+      return cacheArcLengths;
+    }
 
-		needsUpdate = false;
+    needsUpdate = false;
 
-		var cache = [];
-		var current;
-		var last = getPoint( 0.0 );
-		var sum = 0;
+    var cache = [];
+    var current;
+    var last = getPoint( 0.0 );
+    var sum = 0;
 
-		cache.add( 0 );
+    cache.add( 0 );
 
-		for ( var p = 1; p <= divisions; p ++ ) {
+    for ( var p = 1; p <= divisions; p ++ ) {
 
-			current = getPoint ( p / divisions );
+      current = getPoint ( p / divisions );
 
-			var distance;
+      var distance;
 
-			// TODO(nelsonsilva) - Must move distanceTo to IVector interface os create a new IHasDistance
-			if (current is Vector3) {
-			  distance = (current as Vector3).absoluteError( last as Vector3 );
-			} else {
+      // TODO(nelsonsilva) - Must move distanceTo to IVector interface os create a new IHasDistance
+      if (current is Vector3) {
+        distance = (current as Vector3).absoluteError( last as Vector3 );
+      } else {
         distance = (current as Vector2).absoluteError( last as Vector2);
       }
 
-			sum += distance;
-			cache.add( sum );
-			last = current;
+      sum += distance;
+      cache.add( sum );
+      last = current;
 
-		}
+    }
 
-		cacheArcLengths = cache;
+    cacheArcLengths = cache;
 
-		return cache; // { sums: cache, sum:sum }; Sum is in the last element.
-	}
-
-
-	updateArcLengths() {
-		needsUpdate = true;
-		getLengths();
-	}
-
-	// Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equi distance
-	getUtoTmapping( u, {distance: null} ) {
-
-		var arcLengths = getLengths();
-
-		int i = 0, il = arcLengths.length;
-
-		var targetArcLength; // The targeted u distance value to get
-
-		if (distance != null) {
-			targetArcLength = distance;
-		} else {
-			targetArcLength = u * arcLengths[ il - 1 ];
-		}
-
-		//var time = Date.now();
-
-		// binary search for the index with largest value smaller than target u distance
-
-		var low = 0, high = il - 1, comparison;
-
-		while ( low <= high ) {
-
-			i = ( low + ( high - low ) / 2 ).floor().toInt(); // less likely to overflow, though probably not issue here, JS doesn't really have integers, all numbers are floats
-
-			comparison = arcLengths[ i ] - targetArcLength;
-
-			if ( comparison < 0 ) {
-
-				low = i + 1;
-				continue;
-
-			} else if ( comparison > 0 ) {
-
-				high = i - 1;
-				continue;
-
-			} else {
-
-				high = i;
-				break;
-
-				// DONE
-
-			}
-
-		}
-
-		i = high;
-
-		//console.log('b' , i, low, high, Date.now()- time);
-
-		if ( arcLengths[ i ] == targetArcLength ) {
-
-			var t = i / ( il - 1 );
-			return t;
-
-		}
-
-		// we could get finer grain at lengths, or use simple interpolatation between two points
-
-		var lengthBefore = arcLengths[ i ];
-	    var lengthAfter = arcLengths[ i + 1 ];
-
-	    var segmentLength = lengthAfter - lengthBefore;
-
-	    // determine where we are between the 'before' and 'after' points
-
-	    var segmentFraction = ( targetArcLength - lengthBefore ) / segmentLength;
-
-	    // add that fractional amount to t
-
-	    var t = ( i + segmentFraction ) / ( il -1 );
-
-		return t;
-	}
+    return cache; // { sums: cache, sum:sum }; Sum is in the last element.
+  }
 
 
-	// Returns a unit vector tangent at t
-	// In case any sub curve does not implement its tangent / normal finding,
-	// we get 2 points with a small delta and find a gradient of the 2 points
-	// which seems to make a reasonable approximation
-	V getTangent( t ) {
+  updateArcLengths() {
+    needsUpdate = true;
+    getLengths();
+  }
 
-		var delta = 0.0001;
-		var t1 = t - delta;
-		var t2 = t + delta;
+  // Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equi distance
+  getUtoTmapping( u, {distance: null} ) {
 
-		// Capping in case of danger
+    var arcLengths = getLengths();
 
-		if ( t1 < 0 ) t1 = 0;
-		if ( t2 > 1 ) t2 = 1;
+    int i = 0, il = arcLengths.length;
 
-		var pt1 = getPoint( t1 );
-		var pt2 = getPoint( t2 );
+    var targetArcLength; // The targeted u distance value to get
 
-		var vec = pt2 - pt1;
-		return vec.normalize();
-	}
+    if (distance != null) {
+      targetArcLength = distance;
+    } else {
+      targetArcLength = u * arcLengths[ il - 1 ];
+    }
 
-	V getTangentAt( u ) {
-		var t = getUtoTmapping( u );
-		return getTangent( t );
-	}
+    //var time = Date.now();
+
+    // binary search for the index with largest value smaller than target u distance
+
+    var low = 0, high = il - 1, comparison;
+
+    while ( low <= high ) {
+
+      i = ( low + ( high - low ) / 2 ).floor().toInt(); // less likely to overflow, though probably not issue here, JS doesn't really have integers, all numbers are floats
+
+      comparison = arcLengths[ i ] - targetArcLength;
+
+      if ( comparison < 0 ) {
+
+        low = i + 1;
+        continue;
+
+      } else if ( comparison > 0 ) {
+
+        high = i - 1;
+        continue;
+
+      } else {
+
+        high = i;
+        break;
+
+        // DONE
+
+      }
+
+    }
+
+    i = high;
+
+    //console.log('b' , i, low, high, Date.now()- time);
+
+    if ( arcLengths[ i ] == targetArcLength ) {
+
+      var t = i / ( il - 1 );
+      return t;
+
+    }
+
+    // we could get finer grain at lengths, or use simple interpolatation between two points
+
+    var lengthBefore = arcLengths[ i ];
+      var lengthAfter = arcLengths[ i + 1 ];
+
+      var segmentLength = lengthAfter - lengthBefore;
+
+      // determine where we are between the 'before' and 'after' points
+
+      var segmentFraction = ( targetArcLength - lengthBefore ) / segmentLength;
+
+      // add that fractional amount to t
+
+      var t = ( i + segmentFraction ) / ( il -1 );
+
+    return t;
+  }
+
+
+  // Returns a unit vector tangent at t
+  // In case any sub curve does not implement its tangent / normal finding,
+  // we get 2 points with a small delta and find a gradient of the 2 points
+  // which seems to make a reasonable approximation
+  V getTangent( t ) {
+
+    var delta = 0.0001;
+    var t1 = t - delta;
+    var t2 = t + delta;
+
+    // Capping in case of danger
+
+    if ( t1 < 0 ) t1 = 0;
+    if ( t2 > 1 ) t2 = 1;
+
+    var pt1 = getPoint( t1 );
+    var pt2 = getPoint( t2 );
+
+    var vec = pt2 - pt1;
+    return vec.normalize();
+  }
+
+  V getTangentAt( u ) {
+    var t = getUtoTmapping( u );
+    return getTangent( t );
+  }
 
 }
 

--- a/lib/extras/core/curve_path.dart
+++ b/lib/extras/core/curve_path.dart
@@ -6,292 +6,292 @@ part of three;
  **/
 
 /**************************************************************
- *	Curved Path - a curve path is simply a array of connected
+ *  Curved Path - a curve path is simply a array of connected
  *  curves, but retains the api of a curve
  **************************************************************/
 
 class CurvePath extends Curve {
 
-	List curves;
-	List _bends;
+  List curves;
+  List _bends;
 
-	bool autoClose; // Automatically closes the path
+  bool autoClose; // Automatically closes the path
 
-	List cacheLengths = null;
+  List cacheLengths = null;
 
-	CurvePath()
-		:	curves = [],
-			_bends = [],
-			autoClose = false,
-			super();
+  CurvePath()
+    :  curves = [],
+      _bends = [],
+      autoClose = false,
+      super();
 
-	add( curve ) => curves.add( curve );
+  add( curve ) => curves.add( curve );
 
-	checkConnection() {
-		// TODO
-		// If the ending of curve is not connected to the starting
-		// or the next curve, then, this is not a real path
-	}
+  checkConnection() {
+    // TODO
+    // If the ending of curve is not connected to the starting
+    // or the next curve, then, this is not a real path
+  }
 
-	closePath() {
-		// TODO Test
-		// and verify for vector3 (needs to implement equals)
-		// Add a line curve if start and end of lines are not connected
-		var startPoint = curves[0].getPoint(0);
-		var endPoint = curves[curves.length-1].getPoint(1);
+  closePath() {
+    // TODO Test
+    // and verify for vector3 (needs to implement equals)
+    // Add a line curve if start and end of lines are not connected
+    var startPoint = curves[0].getPoint(0);
+    var endPoint = curves[curves.length-1].getPoint(1);
 
-		if (!startPoint.equals(endPoint)) {
-			this.curves.add( new LineCurve(endPoint, startPoint) );
-		}
+    if (!startPoint.equals(endPoint)) {
+      this.curves.add( new LineCurve(endPoint, startPoint) );
+    }
 
-	}
+  }
 
-	// To get accurate point with reference to
-	// entire path distance at time t,
-	// following has to be done:
+  // To get accurate point with reference to
+  // entire path distance at time t,
+  // following has to be done:
 
-	// 1. Length of each sub path have to be known
-	// 2. Locate and identify type of curve
-	// 3. Get t for the curve
-	// 4. Return curve.getPointAt(t')
-	getPoint( num t ) {
+  // 1. Length of each sub path have to be known
+  // 2. Locate and identify type of curve
+  // 3. Get t for the curve
+  // 4. Return curve.getPointAt(t')
+  getPoint( num t ) {
 
-		var d = t * this.length;
-		var curveLengths = this.getCurveLengths();
-		var i = 0, diff;
-		Curve curve;
+    var d = t * this.length;
+    var curveLengths = this.getCurveLengths();
+    var i = 0, diff;
+    Curve curve;
 
-		// To think about boundaries points.
+    // To think about boundaries points.
 
-		while ( i < curveLengths.length ) {
+    while ( i < curveLengths.length ) {
 
-			if ( curveLengths[ i ] >= d ) {
+      if ( curveLengths[ i ] >= d ) {
 
-				diff = curveLengths[ i ] - d;
-				curve = this.curves[ i ];
+        diff = curveLengths[ i ] - d;
+        curve = this.curves[ i ];
 
-				var u = 1 - diff / curve.length;
+        var u = 1 - diff / curve.length;
 
-				return curve.getPointAt( u );
+        return curve.getPointAt( u );
 
-			}
+      }
 
-			i ++;
+      i ++;
 
-		}
+    }
 
-		return null;
+    return null;
 
-		// loop where sum != 0, sum > d , sum+1 <d
+    // loop where sum != 0, sum > d , sum+1 <d
 
-	}
+  }
 
 
-	// We cannot use the default THREE.Curve getPoint() with getLength() because in
-	// THREE.Curve, getLength() depends on getPoint() but in THREE.CurvePath
-	// getPoint() depends on getLength
-	num get length => getCurveLengths().last;
+  // We cannot use the default THREE.Curve getPoint() with getLength() because in
+  // THREE.Curve, getLength() depends on getPoint() but in THREE.CurvePath
+  // getPoint() depends on getLength
+  num get length => getCurveLengths().last;
 
-	// Compute lengths and cache them
-	// We cannot overwrite getLengths() because UtoT mapping uses it.
+  // Compute lengths and cache them
+  // We cannot overwrite getLengths() because UtoT mapping uses it.
 
-	List<num> getCurveLengths() {
+  List<num> getCurveLengths() {
 
-		// We use cache values if curves and cache array are same length
+    // We use cache values if curves and cache array are same length
 
-		if ( this.cacheLengths != null && this.cacheLengths.length == this.curves.length ) {
+    if ( this.cacheLengths != null && this.cacheLengths.length == this.curves.length ) {
 
-			return this.cacheLengths;
+      return this.cacheLengths;
 
-		}
+    }
 
-		// Get length of subsurve
-		// Push sums into cached array
+    // Get length of subsurve
+    // Push sums into cached array
 
-		var lengths = [], sums = 0;
-		var i, il = this.curves.length;
+    var lengths = [], sums = 0;
+    var i, il = this.curves.length;
 
-		for ( i = 0; i < il; i ++ ) {
+    for ( i = 0; i < il; i ++ ) {
 
-			sums += this.curves[ i ].length;
-			lengths.add( sums );
+      sums += this.curves[ i ].length;
+      lengths.add( sums );
 
-		}
+    }
 
-		this.cacheLengths = lengths;
+    this.cacheLengths = lengths;
 
-		return lengths;
+    return lengths;
 
-	}
+  }
 
 
-	// Returns min and max coordinates, as well as centroid
-	getBoundingBox() {
+  // Returns min and max coordinates, as well as centroid
+  getBoundingBox() {
 
-		var points = getPoints();
+    var points = getPoints();
 
-		var maxX, maxY, maxZ;
-		var minX, minY, minZ;
+    var maxX, maxY, maxZ;
+    var minX, minY, minZ;
 
-		maxX = maxY = double.NEGATIVE_INFINITY;
-		minX = minY = double.INFINITY;
+    maxX = maxY = double.NEGATIVE_INFINITY;
+    minX = minY = double.INFINITY;
 
-		var p, i, sum;
+    var p, i, sum;
 
-		var v3 = points[0] is Vector3;
+    var v3 = points[0] is Vector3;
 
-		sum = (v3) ? new Vector3.zero() : new Vector2.zero();
+    sum = (v3) ? new Vector3.zero() : new Vector2.zero();
 
-		int il = points.length;
-		for ( i = 0; i < il; i ++ ) {
+    int il = points.length;
+    for ( i = 0; i < il; i ++ ) {
 
-			p = points[ i ];
+      p = points[ i ];
 
-			if ( p.x > maxX ) { maxX = p.x;
-			} else if ( p.x < minX ) minX = p.x;
+      if ( p.x > maxX ) { maxX = p.x;
+      } else if ( p.x < minX ) minX = p.x;
 
-			if ( p.y > maxY ) { maxY = p.y;
-			} else if ( p.y < minY ) minY = p.y;
+      if ( p.y > maxY ) { maxY = p.y;
+      } else if ( p.y < minY ) minY = p.y;
 
-			if (v3) {
-			  p = p as Vector3;
-	      if ( p.z > maxZ ) { maxZ = p.z;
-	      } else if ( p.z < minZ ) minZ = p.z;
+      if (v3) {
+        p = p as Vector3;
+        if ( p.z > maxZ ) { maxZ = p.z;
+        } else if ( p.z < minZ ) minZ = p.z;
 
-	      (sum as Vector3).add( p );
-	    } else {
-	      (sum as Vector2).add( p );
-	    }
+        (sum as Vector3).add( p );
+      } else {
+        (sum as Vector2).add( p );
+      }
 
 
 
-		}
+    }
 
-		var ret = {
+    var ret = {
 
-			"minX": minX,
-			"minY": minY,
-			"maxX": maxX,
-			"maxY": maxY,
-			"centroid": (sum as dynamic).scale( 1.0 / il )
+      "minX": minX,
+      "minY": minY,
+      "maxX": maxX,
+      "maxY": maxY,
+      "centroid": (sum as dynamic).scale( 1.0 / il )
 
-		};
+    };
 
-		if (v3) {
+    if (v3) {
 
-	    ret["maxZ"] = maxZ;
-	    ret["minZ"] = minZ;
+      ret["maxZ"] = maxZ;
+      ret["minZ"] = minZ;
 
-	  }
+    }
 
-	  return ret;
-	}
+    return ret;
+  }
 
-	/**************************************************************
-	 *	Create Geometries Helpers
-	 **************************************************************/
+  /**************************************************************
+   *  Create Geometries Helpers
+   **************************************************************/
 
-	/// Generate geometry from path points (for Line or ParticleSystem objects)
-	createPointsGeometry( {divisions} ) {
-		var pts = this.getPoints( divisions, true );
-		return this.createGeometry( pts );
-	}
+  /// Generate geometry from path points (for Line or ParticleSystem objects)
+  createPointsGeometry( {divisions} ) {
+    var pts = this.getPoints( divisions, true );
+    return this.createGeometry( pts );
+  }
 
-	// Generate geometry from equidistance sampling along the path
-	createSpacedPointsGeometry( [divisions] ) {
-		var pts = this.getSpacedPoints( divisions, true );
-		return this.createGeometry( pts );
-	}
+  // Generate geometry from equidistance sampling along the path
+  createSpacedPointsGeometry( [divisions] ) {
+    var pts = this.getSpacedPoints( divisions, true );
+    return this.createGeometry( pts );
+  }
 
-	createGeometry( points ) {
+  createGeometry( points ) {
 
-		var geometry = new Geometry();
+    var geometry = new Geometry();
 
-		for ( var i = 0; i < points.length; i ++ ) {
-		  var z = (points[i] is Vector3) ? points[ i ].z : 0.0;
-			geometry.vertices.add( new Vector3( points[ i ].x, points[ i ].y, z) );
-		}
+    for ( var i = 0; i < points.length; i ++ ) {
+      var z = (points[i] is Vector3) ? points[ i ].z : 0.0;
+      geometry.vertices.add( new Vector3( points[ i ].x, points[ i ].y, z) );
+    }
 
-		return geometry;
-	}
+    return geometry;
+  }
 
 
-	/**************************************************************
-	 *	Bend / Wrap Helper Methods
-	 **************************************************************/
+  /**************************************************************
+   *  Bend / Wrap Helper Methods
+   **************************************************************/
 
-	// Wrap path / Bend modifiers?
+  // Wrap path / Bend modifiers?
 
-	addWrapPath( bendpath ) => _bends.add( bendpath );
+  addWrapPath( bendpath ) => _bends.add( bendpath );
 
-	getTransformedPoints( segments, {List bends: null} ) {
+  getTransformedPoints( segments, {List bends: null} ) {
 
-		var oldPts = this.getPoints( segments ); // getPoints getSpacedPoints
-		var i, il;
+    var oldPts = this.getPoints( segments ); // getPoints getSpacedPoints
+    var i, il;
 
-		if (bends == null) {
-			bends = _bends;
-		}
+    if (bends == null) {
+      bends = _bends;
+    }
 
-		for ( i = 0; i < bends.length; i ++ ) {
-			oldPts = this.getWrapPoints( oldPts, bends[ i ] );
-		}
+    for ( i = 0; i < bends.length; i ++ ) {
+      oldPts = this.getWrapPoints( oldPts, bends[ i ] );
+    }
 
-		return oldPts;
+    return oldPts;
 
-	}
+  }
 
-	getTransformedSpacedPoints( [num segments, List bends = null] ) {
+  getTransformedSpacedPoints( [num segments, List bends = null] ) {
 
-		var oldPts = getSpacedPoints( segments );
+    var oldPts = getSpacedPoints( segments );
 
-		var i, il;
+    var i, il;
 
-		if (bends == null) {
-			bends = _bends;
-		}
+    if (bends == null) {
+      bends = _bends;
+    }
 
-		for ( i = 0; i < bends.length; i ++ ) {
-			oldPts = this.getWrapPoints( oldPts, bends[ i ] );
-		}
+    for ( i = 0; i < bends.length; i ++ ) {
+      oldPts = this.getWrapPoints( oldPts, bends[ i ] );
+    }
 
-		return oldPts;
-	}
+    return oldPts;
+  }
 
-	// This returns getPoints() bend/wrapped around the contour of a path.
-	// Read http://www.planetclegg.com/projects/WarpingTextToSplines.html
+  // This returns getPoints() bend/wrapped around the contour of a path.
+  // Read http://www.planetclegg.com/projects/WarpingTextToSplines.html
 
-	getWrapPoints( oldPts, path ) {
+  getWrapPoints( oldPts, path ) {
 
-		var bounds = getBoundingBox();
+    var bounds = getBoundingBox();
 
-		var i, il, p, oldX, oldY, xNorm;
+    var i, il, p, oldX, oldY, xNorm;
 
-		for ( i = 0; i < oldPts.length; i ++ ) {
+    for ( i = 0; i < oldPts.length; i ++ ) {
 
-			p = oldPts[ i ];
+      p = oldPts[ i ];
 
-			oldX = p.x;
-			oldY = p.y;
+      oldX = p.x;
+      oldY = p.y;
 
-			xNorm = oldX / bounds.maxX;
+      xNorm = oldX / bounds.maxX;
 
-			// If using actual distance, for length > path, requires line extrusions
-			//xNorm = path.getUtoTmapping(xNorm, oldX); // 3 styles. 1) wrap stretched. 2) wrap stretch by arc length 3) warp by actual distance
+      // If using actual distance, for length > path, requires line extrusions
+      //xNorm = path.getUtoTmapping(xNorm, oldX); // 3 styles. 1) wrap stretched. 2) wrap stretch by arc length 3) warp by actual distance
 
-			xNorm = path.getUtoTmapping( xNorm, oldX );
+      xNorm = path.getUtoTmapping( xNorm, oldX );
 
-			// check for out of bounds?
+      // check for out of bounds?
 
-			var pathPt = path.getPoint( xNorm );
-			var normal = path.getNormalVector( xNorm ).scale( oldY );
+      var pathPt = path.getPoint( xNorm );
+      var normal = path.getNormalVector( xNorm ).scale( oldY );
 
-			p.x = pathPt.x + normal.x;
-			p.y = pathPt.y + normal.y;
+      p.x = pathPt.x + normal.x;
+      p.y = pathPt.y + normal.y;
 
-		}
+    }
 
-		return oldPts;
+    return oldPts;
 
-	}
+  }
 }

--- a/lib/extras/core/path.dart
+++ b/lib/extras/core/path.dart
@@ -7,18 +7,18 @@ part of three;
  **/
 
 class PathAction {
-	static const String MOVE_TO = 'moveTo';
-	static const String LINE_TO = 'lineTo';
-	static const String QUADRATIC_CURVE_TO = 'quadraticCurveTo';    // Bezier quadratic curve
-	static const String BEZIER_CURVE_TO = 'bezierCurveTo';  		// Bezier cubic curve
-	static const String CSPLINE_THRU = 'splineThru';				// Catmull-rom spline
-	static const String ARC = 'arc';								// Circle
-	static const String ELLIPSE = 'ellipse';
+  static const String MOVE_TO = 'moveTo';
+  static const String LINE_TO = 'lineTo';
+  static const String QUADRATIC_CURVE_TO = 'quadraticCurveTo';    // Bezier quadratic curve
+  static const String BEZIER_CURVE_TO = 'bezierCurveTo';      // Bezier cubic curve
+  static const String CSPLINE_THRU = 'splineThru';        // Catmull-rom spline
+  static const String ARC = 'arc';                // Circle
+  static const String ELLIPSE = 'ellipse';
 
-	String action;
-	var args;
+  String action;
+  var args;
 
-	PathAction(this.action, this.args);
+  PathAction(this.action, this.args);
 }
 
 class Path extends CurvePath {
@@ -28,11 +28,11 @@ class Path extends CurvePath {
   List _points;
   List<PathAction> actions;
 
-	Path( [List points] ) : actions = [],  super(){
-	  if (points != null) {
-	    _fromPoints(points);
-	  }
-	}
+  Path( [List points] ) : actions = [],  super(){
+    if (points != null) {
+      _fromPoints(points);
+    }
+  }
 
   // Create path using straight lines to connect all points
   // - vectors: array of Vector2
@@ -55,74 +55,74 @@ class Path extends CurvePath {
 
   lineTo( x, y ) {
 
-  	var args = [x, y];
+    var args = [x, y];
 
-  	var lastargs = actions.last.args;
+    var lastargs = actions.last.args;
 
-  	var x0 = lastargs[ lastargs.length - 2 ];
-  	var y0 = lastargs[ lastargs.length - 1 ];
+    var x0 = lastargs[ lastargs.length - 2 ];
+    var y0 = lastargs[ lastargs.length - 1 ];
 
-  	var curve = new LineCurve( new Vector2( x0, y0 ), new Vector2( x, y ) );
-  	curves.add( curve );
+    var curve = new LineCurve( new Vector2( x0, y0 ), new Vector2( x, y ) );
+    curves.add( curve );
 
-  	addAction( PathAction.LINE_TO, args);
+    addAction( PathAction.LINE_TO, args);
   }
 
   quadraticCurveTo( aCPx, aCPy, aX, aY ) {
 
-  	var args = [aCPx, aCPy, aX, aY];
+    var args = [aCPx, aCPy, aX, aY];
 
-  	var lastargs = actions.last.args;
+    var lastargs = actions.last.args;
 
-  	var x0 = lastargs[ lastargs.length - 2 ].toDouble();
-  	var y0 = lastargs[ lastargs.length - 1 ].toDouble();
+    var x0 = lastargs[ lastargs.length - 2 ].toDouble();
+    var y0 = lastargs[ lastargs.length - 1 ].toDouble();
 
-  	var curve = new QuadraticBezierCurve( new Vector2( x0, y0 ),
-  												new Vector2( aCPx.toDouble(), aCPy.toDouble() ),
-  												new Vector2( aX.toDouble(), aY.toDouble() ) );
-  	curves.add( curve );
+    var curve = new QuadraticBezierCurve( new Vector2( x0, y0 ),
+                          new Vector2( aCPx.toDouble(), aCPy.toDouble() ),
+                          new Vector2( aX.toDouble(), aY.toDouble() ) );
+    curves.add( curve );
 
-  	addAction( PathAction.QUADRATIC_CURVE_TO, args );
+    addAction( PathAction.QUADRATIC_CURVE_TO, args );
   }
 
   bezierCurveTo( aCP1x, aCP1y,
                  aCP2x, aCP2y,
                  aX, aY ) {
 
-  	var args = [aCP1x, aCP1y,
+    var args = [aCP1x, aCP1y,
                  aCP2x, aCP2y,
                  aX, aY];
 
-  	var lastargs = actions.last.args;
+    var lastargs = actions.last.args;
 
-  	var x0 = lastargs[ lastargs.length - 2 ].toDouble();
-  	var y0 = lastargs[ lastargs.length - 1 ].toDouble();
+    var x0 = lastargs[ lastargs.length - 2 ].toDouble();
+    var y0 = lastargs[ lastargs.length - 1 ].toDouble();
 
-  	var curve = new CubicBezierCurve( new Vector2( x0, y0 ),
-  											new Vector2( aCP1x.toDouble(), aCP1y.toDouble() ),
-  											new Vector2( aCP2x.toDouble(), aCP2y.toDouble() ),
-  											new Vector2( aX.toDouble(), aY.toDouble() ) );
-  	curves.add( curve );
+    var curve = new CubicBezierCurve( new Vector2( x0, y0 ),
+                        new Vector2( aCP1x.toDouble(), aCP1y.toDouble() ),
+                        new Vector2( aCP2x.toDouble(), aCP2y.toDouble() ),
+                        new Vector2( aX.toDouble(), aY.toDouble() ) );
+    curves.add( curve );
 
-  	addAction( PathAction.BEZIER_CURVE_TO, args );
+    addAction( PathAction.BEZIER_CURVE_TO, args );
 
   }
 
   splineThru( List<Vector2> pts) {
 
-  	var args = [pts];
-  	var lastargs = actions.last.args;
+    var args = [pts];
+    var lastargs = actions.last.args;
 
-  	var x0 = lastargs[ lastargs.length - 2 ];
-  	var y0 = lastargs[ lastargs.length - 1 ];
+    var x0 = lastargs[ lastargs.length - 2 ];
+    var y0 = lastargs[ lastargs.length - 1 ];
   //---
-  	var npts = [ new Vector2( x0, y0 ) ];
-  	npts.addAll(pts); //Array.prototype.push.apply( npts, pts );
+    var npts = [ new Vector2( x0, y0 ) ];
+    npts.addAll(pts); //Array.prototype.push.apply( npts, pts );
 
-  	var curve = new SplineCurve( npts );
-  	curves.add( curve );
+    var curve = new SplineCurve( npts );
+    curves.add( curve );
 
-  	addAction( PathAction.CSPLINE_THRU, args);
+    addAction( PathAction.CSPLINE_THRU, args);
 
   }
 
@@ -130,7 +130,7 @@ class Path extends CurvePath {
   // TODO ARC ( x, y, x - radius, y - radius, startAngle, endAngle )
 
   arc( aX, aY, aRadius,
-  								aStartAngle, aEndAngle, aClockwise ) {
+                  aStartAngle, aEndAngle, aClockwise ) {
 
     var lastargs = actions[ actions.length - 1].args;
     var x0 = lastargs[ lastargs.length - 2 ];
@@ -173,204 +173,204 @@ class Path extends CurvePath {
 
   getSpacedPoints( [int divisions = 5, bool closedPath = false] ) {
 
-  	if ( divisions == null ) divisions = 40;
+    if ( divisions == null ) divisions = 40;
 
-  	var points = [];
+    var points = [];
 
-  	for ( var i = 0; i < divisions; i ++ ) {
+    for ( var i = 0; i < divisions; i ++ ) {
 
-  		points.add( this.getPoint( i / divisions ) );
+      points.add( this.getPoint( i / divisions ) );
 
-  		//if( !this.getPoint( i / divisions ) ) throw "DIE";
+      //if( !this.getPoint( i / divisions ) ) throw "DIE";
 
-  	}
+    }
 
-  	// if ( closedPath ) {
-  	//
-  	// 	points.push( points[ 0 ] );
-  	//
-  	// }
+    // if ( closedPath ) {
+    //
+    //   points.push( points[ 0 ] );
+    //
+    // }
 
-  	return points;
+    return points;
 
   }
 
   /* Return an array of vectors based on contour of the path */
   getPoints( [int divisions = null, closedPath = false] ) {
 
-  	if (useSpacedPoints) {
-  		return getSpacedPoints( divisions, closedPath );
-  	}
+    if (useSpacedPoints) {
+      return getSpacedPoints( divisions, closedPath );
+    }
 
-  	if (divisions == null) divisions =  12;
+    if (divisions == null) divisions =  12;
 
-  	List<Vector2> points = [];
+    List<Vector2> points = [];
 
-  	var i, il, item, action, args;
-  	var cpx, cpy, cpx2, cpy2, cpx1, cpy1, cpx0, cpy0,
-  		laste, j,
-  		t, tx, ty;
+    var i, il, item, action, args;
+    var cpx, cpy, cpx2, cpy2, cpx1, cpy1, cpx0, cpy0,
+      laste, j,
+      t, tx, ty;
 
-  	for ( i = 0; i < actions.length; i ++ ) {
+    for ( i = 0; i < actions.length; i ++ ) {
 
-  		item = actions[ i ];
+      item = actions[ i ];
 
-  		action = item.action;
-  		args = item.args;
+      action = item.action;
+      args = item.args;
 
-  		switch( action ) {
+      switch( action ) {
 
-  		case PathAction.MOVE_TO:
+      case PathAction.MOVE_TO:
 
-  			points.add( new Vector2( args[ 0 ], args[ 1 ] ) );
+        points.add( new Vector2( args[ 0 ], args[ 1 ] ) );
 
-  			break;
+        break;
 
-  		case PathAction.LINE_TO:
+      case PathAction.LINE_TO:
 
-  			points.add( new Vector2( args[ 0 ], args[ 1 ] ) );
+        points.add( new Vector2( args[ 0 ], args[ 1 ] ) );
 
-  			break;
+        break;
 
-  		case PathAction.QUADRATIC_CURVE_TO:
+      case PathAction.QUADRATIC_CURVE_TO:
 
-  			cpx  = args[ 2 ];
-  			cpy  = args[ 3 ];
+        cpx  = args[ 2 ];
+        cpy  = args[ 3 ];
 
-  			cpx1 = args[ 0 ];
-  			cpy1 = args[ 1 ];
+        cpx1 = args[ 0 ];
+        cpy1 = args[ 1 ];
 
-  			if ( points.length > 0 ) {
+        if ( points.length > 0 ) {
 
-  				laste = points[ points.length - 1 ];
+          laste = points[ points.length - 1 ];
 
-  				cpx0 = laste.x;
-  				cpy0 = laste.y;
+          cpx0 = laste.x;
+          cpy0 = laste.y;
 
-  			} else {
+        } else {
 
-  				laste = actions[ i - 1 ].args;
+          laste = actions[ i - 1 ].args;
 
-  				cpx0 = laste[ laste.length - 2 ];
-  				cpy0 = laste[ laste.length - 1 ];
+          cpx0 = laste[ laste.length - 2 ];
+          cpy0 = laste[ laste.length - 1 ];
 
-  			}
+        }
 
-  			for ( j = 1; j <= divisions; j ++ ) {
+        for ( j = 1; j <= divisions; j ++ ) {
 
-  				t = j / divisions;
+          t = j / divisions;
 
-  				tx = ShapeUtils.b2( t, cpx0, cpx1, cpx );
-  				ty = ShapeUtils.b2( t, cpy0, cpy1, cpy );
+          tx = ShapeUtils.b2( t, cpx0, cpx1, cpx );
+          ty = ShapeUtils.b2( t, cpy0, cpy1, cpy );
 
-  				points.add( new Vector2( tx, ty ) );
+          points.add( new Vector2( tx, ty ) );
 
-  		  	}
+          }
 
-  			break;
+        break;
 
-  		case PathAction.BEZIER_CURVE_TO:
+      case PathAction.BEZIER_CURVE_TO:
 
-  			cpx  = args[ 4 ];
-  			cpy  = args[ 5 ];
+        cpx  = args[ 4 ];
+        cpy  = args[ 5 ];
 
-  			cpx1 = args[ 0 ];
-  			cpy1 = args[ 1 ];
+        cpx1 = args[ 0 ];
+        cpy1 = args[ 1 ];
 
-  			cpx2 = args[ 2 ];
-  			cpy2 = args[ 3 ];
+        cpx2 = args[ 2 ];
+        cpy2 = args[ 3 ];
 
-  			if ( points.length > 0 ) {
+        if ( points.length > 0 ) {
 
-  				laste = points[ points.length - 1 ];
+          laste = points[ points.length - 1 ];
 
-  				cpx0 = laste.x;
-  				cpy0 = laste.y;
+          cpx0 = laste.x;
+          cpy0 = laste.y;
 
-  			} else {
+        } else {
 
-  				laste = actions[ i - 1 ].args;
+          laste = actions[ i - 1 ].args;
 
-  				cpx0 = laste[ laste.length - 2 ];
-  				cpy0 = laste[ laste.length - 1 ];
+          cpx0 = laste[ laste.length - 2 ];
+          cpy0 = laste[ laste.length - 1 ];
 
-  			}
+        }
 
 
-  			for ( j = 1; j <= divisions; j ++ ) {
+        for ( j = 1; j <= divisions; j ++ ) {
 
-  				t = j / divisions;
+          t = j / divisions;
 
-  				tx = ShapeUtils.b3( t, cpx0, cpx1, cpx2, cpx );
-  				ty = ShapeUtils.b3( t, cpy0, cpy1, cpy2, cpy );
+          tx = ShapeUtils.b3( t, cpx0, cpx1, cpx2, cpx );
+          ty = ShapeUtils.b3( t, cpy0, cpy1, cpy2, cpy );
 
-  				points.add( new Vector2( tx, ty ) );
+          points.add( new Vector2( tx, ty ) );
 
-  			}
+        }
 
-  			break;
+        break;
 
-  		case PathAction.CSPLINE_THRU:
+      case PathAction.CSPLINE_THRU:
 
-  			laste = actions[ i - 1 ].args;
+        laste = actions[ i - 1 ].args;
 
-  			var last = new Vector2( laste[ laste.length - 2 ], laste[ laste.length - 1 ] );
-  			var spts = [ last ];
+        var last = new Vector2( laste[ laste.length - 2 ], laste[ laste.length - 1 ] );
+        var spts = [ last ];
 
-  			var n = divisions * args[ 0 ].length;
+        var n = divisions * args[ 0 ].length;
 
-  			spts.addAll( args[ 0 ] );
+        spts.addAll( args[ 0 ] );
 
-  			var spline = new SplineCurve( spts );
+        var spline = new SplineCurve( spts );
 
-  			for ( j = 1; j <= n; j ++ ) {
+        for ( j = 1; j <= n; j ++ ) {
 
-  				points.add( spline.getPointAt( j / n ) ) ;
+          points.add( spline.getPointAt( j / n ) ) ;
 
-  			}
+        }
 
-  			break;
+        break;
 
-  		case PathAction.ARC:
+      case PathAction.ARC:
 
-  			laste = actions[ i - 1 ].args;
+        laste = actions[ i - 1 ].args;
 
-  			var aX = args[ 0 ], aY = args[ 1 ],
-  				aRadius = args[ 2 ],
-  				aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
-  				aClockwise = !!args[ 5 ];
+        var aX = args[ 0 ], aY = args[ 1 ],
+          aRadius = args[ 2 ],
+          aStartAngle = args[ 3 ], aEndAngle = args[ 4 ],
+          aClockwise = !!args[ 5 ];
 
 
-  			var deltaAngle = aEndAngle - aStartAngle;
-  			var angle;
-  			var tdivisions = divisions * 2;
+        var deltaAngle = aEndAngle - aStartAngle;
+        var angle;
+        var tdivisions = divisions * 2;
 
-  			for ( j = 1; j <= tdivisions; j ++ ) {
+        for ( j = 1; j <= tdivisions; j ++ ) {
 
-  				t = j / tdivisions;
+          t = j / tdivisions;
 
-  				if ( ! aClockwise ) {
+          if ( ! aClockwise ) {
 
-  					t = 1 - t;
+            t = 1 - t;
 
-  				}
+          }
 
-  				angle = aStartAngle + t * deltaAngle;
+          angle = aStartAngle + t * deltaAngle;
 
-  				tx = aX + aRadius * Math.cos( angle );
-  				ty = aY + aRadius * Math.sin( angle );
+          tx = aX + aRadius * Math.cos( angle );
+          ty = aY + aRadius * Math.sin( angle );
 
-  				//console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
+          //console.log('t', t, 'angle', angle, 'tx', tx, 'ty', ty);
 
-  				points.add( new Vector2( tx, ty ) );
+          points.add( new Vector2( tx, ty ) );
 
-  			}
+        }
 
-  			//console.log(points);
+        //console.log(points);
 
-  		  break;
+        break;
 
-  		case PathAction.ELLIPSE:
+      case PathAction.ELLIPSE:
 
         var aX = args[ 0 ], aY = args[ 1 ],
         xRadius = args[ 2 ],
@@ -407,24 +407,24 @@ class Path extends CurvePath {
       //console.log(points);
 
       break;
-  		} // end switch
+      } // end switch
 
-  	}
+    }
 
 
 
-  	// Normalize to remove the closing point by default.
-  	var lastPoint = points[ points.length - 1];
-  	var EPSILON = 0.0000000001;
-  	if ( (lastPoint.x - points[ 0 ].x).abs() < EPSILON &&
+    // Normalize to remove the closing point by default.
+    var lastPoint = points[ points.length - 1];
+    var EPSILON = 0.0000000001;
+    if ( (lastPoint.x - points[ 0 ].x).abs() < EPSILON &&
           (lastPoint.y - points[ 0 ].y).abs() < EPSILON) {
-  	  points.removeLast();
-  	}
-  	if ( closedPath ) {
-  		points.add( points[ 0 ] );
-  	}
+      points.removeLast();
+    }
+    if ( closedPath ) {
+      points.add( points[ 0 ] );
+    }
 
-  	return points;
+    return points;
 
   }
 
@@ -433,133 +433,133 @@ class Path extends CurvePath {
   // This was used for testing purposes. Should be removed soon.
   transform ( path, segments ) {
 
-  	var bounds = getBoundingBox();
-  	var oldPts = getPoints( segments ); // getPoints getSpacedPoints
+    var bounds = getBoundingBox();
+    var oldPts = getPoints( segments ); // getPoints getSpacedPoints
 
-  	//console.log( path.cacheArcLengths() );
-  	//path.getLengths(400);
-  	//segments = 40;
+    //console.log( path.cacheArcLengths() );
+    //path.getLengths(400);
+    //segments = 40;
 
-  	return getWrapPoints( oldPts, path );
+    return getWrapPoints( oldPts, path );
 
   }
 
   // Breaks path into shapes
   List<Shape> toShapes() {
 
-  	var i, il, item, action, args;
+    var i, il, item, action, args;
 
-  	List<Path> subPaths = [];
-  	var lastPath = new Path();
+    List<Path> subPaths = [];
+    var lastPath = new Path();
 
-  	for ( i = 0; i < actions.length; i ++ ) {
+    for ( i = 0; i < actions.length; i ++ ) {
 
-  		item = actions[ i ];
+      item = actions[ i ];
 
-  		args = item.args;
-  		action = item.action;
+      args = item.args;
+      action = item.action;
 
-  		if ( action == PathAction.MOVE_TO ) {
+      if ( action == PathAction.MOVE_TO ) {
 
-  			if ( lastPath.actions.length != 0 ) {
+        if ( lastPath.actions.length != 0 ) {
 
-  				subPaths.add( lastPath );
-  				lastPath = new Path();
+          subPaths.add( lastPath );
+          lastPath = new Path();
 
-  			}
+        }
 
-  		}
+      }
 
-  		lastPath._applyAction( action, args);
+      lastPath._applyAction( action, args);
 
-  	}
+    }
 
-  	if ( lastPath.actions.length != 0 ) {
+    if ( lastPath.actions.length != 0 ) {
 
-  		subPaths.add( lastPath );
+      subPaths.add( lastPath );
 
-  	}
+    }
 
-  	// console.log(subPaths);
+    // console.log(subPaths);
 
-  	if ( subPaths.length == 0 ) return [];
+    if ( subPaths.length == 0 ) return [];
 
-  	var tmpPath;
-  	Shape tmpShape;
-  	List<Shape> shapes = [];
+    var tmpPath;
+    Shape tmpShape;
+    List<Shape> shapes = [];
 
-  	var holesFirst = !ShapeUtils.isClockWise( subPaths[ 0 ].getPoints() );
-  	// console.log("Holes first", holesFirst);
+    var holesFirst = !ShapeUtils.isClockWise( subPaths[ 0 ].getPoints() );
+    // console.log("Holes first", holesFirst);
 
-  	if ( subPaths.length == 1) {
-  		tmpPath = subPaths[0];
-  		tmpShape = new Shape();
-  		tmpShape.actions = tmpPath.actions;
-  		tmpShape.curves = tmpPath.curves;
-  		shapes.add( tmpShape );
-  		return shapes;
-  	};
+    if ( subPaths.length == 1) {
+      tmpPath = subPaths[0];
+      tmpShape = new Shape();
+      tmpShape.actions = tmpPath.actions;
+      tmpShape.curves = tmpPath.curves;
+      shapes.add( tmpShape );
+      return shapes;
+    };
 
-  	if ( holesFirst ) {
+    if ( holesFirst ) {
 
-  		tmpShape = new Shape();
+      tmpShape = new Shape();
 
-  		for ( i = 0; i < subPaths.length; i ++ ) {
+      for ( i = 0; i < subPaths.length; i ++ ) {
 
-  			tmpPath = subPaths[ i ];
+        tmpPath = subPaths[ i ];
 
-  			if ( ShapeUtils.isClockWise( tmpPath.getPoints() ) ) {
+        if ( ShapeUtils.isClockWise( tmpPath.getPoints() ) ) {
 
-  				tmpShape.actions = tmpPath.actions;
-  				tmpShape.curves = tmpPath.curves;
+          tmpShape.actions = tmpPath.actions;
+          tmpShape.curves = tmpPath.curves;
 
-  				shapes.add( tmpShape );
-  				tmpShape = new Shape();
+          shapes.add( tmpShape );
+          tmpShape = new Shape();
 
-  				//console.log('cw', i);
+          //console.log('cw', i);
 
-  			} else {
+        } else {
 
-  				tmpShape.holes.add( tmpPath );
+          tmpShape.holes.add( tmpPath );
 
-  				//console.log('ccw', i);
+          //console.log('ccw', i);
 
-  			}
+        }
 
-  		}
+      }
 
-  	} else {
+    } else {
 
-  		// Shapes first
+      // Shapes first
 
-  		for ( i = 0; i < subPaths.length; i ++ ) {
+      for ( i = 0; i < subPaths.length; i ++ ) {
 
-  			tmpPath = subPaths[ i ];
+        tmpPath = subPaths[ i ];
 
-  			if ( ShapeUtils.isClockWise( tmpPath.getPoints() ) ) {
+        if ( ShapeUtils.isClockWise( tmpPath.getPoints() ) ) {
 
 
-  				if (tmpShape != null) shapes.add( tmpShape );
+          if (tmpShape != null) shapes.add( tmpShape );
 
-  				tmpShape = new Shape();
-  				tmpShape.actions = tmpPath.actions;
-  				tmpShape.curves = tmpPath.curves;
+          tmpShape = new Shape();
+          tmpShape.actions = tmpPath.actions;
+          tmpShape.curves = tmpPath.curves;
 
-  			} else {
+        } else {
 
-  				tmpShape.holes.add( tmpPath );
+          tmpShape.holes.add( tmpPath );
 
-  			}
+        }
 
-  		}
+      }
 
-  		shapes.add( tmpShape );
+      shapes.add( tmpShape );
 
-  	}
+    }
 
-  	//console.log("shape", shapes);
+    //console.log("shape", shapes);
 
-  	return shapes;
+    return shapes;
 
   }
 

--- a/lib/extras/core/shape.dart
+++ b/lib/extras/core/shape.dart
@@ -15,7 +15,7 @@ class Shape extends Path {
 
   List holes;
 
-	Shape([List points]) : holes = [], super(points);
+  Shape([List points]) : holes = [], super(points);
 
   // Convenience method to return ExtrudeGeometry
   extrude( {amount: 100,
@@ -49,32 +49,32 @@ class Shape extends Path {
   // Get points of holes
   getPointsHoles( divisions ) {
 
-  	var i, il = holes.length;
-  	var holesPts = new List(il);
+    var i, il = holes.length;
+    var holesPts = new List(il);
 
-  	for ( i = 0; i < il; i ++ ) {
+    for ( i = 0; i < il; i ++ ) {
 
-  		holesPts[ i ] = holes[ i ].getTransformedPoints( divisions, bends: _bends );
+      holesPts[ i ] = holes[ i ].getTransformedPoints( divisions, bends: _bends );
 
-  	}
+    }
 
-  	return holesPts;
+    return holesPts;
 
   }
 
   // Get points of holes (spaced by regular distance)
   getSpacedPointsHoles ( divisions ) {
 
-  	var i, il = holes.length;
-  	var holesPts = new List(il);
+    var i, il = holes.length;
+    var holesPts = new List(il);
 
-  	for ( i = 0; i < il; i ++ ) {
+    for ( i = 0; i < il; i ++ ) {
 
-  		holesPts[ i ] = holes[ i ].getTransformedSpacedPoints( divisions, _bends );
+      holesPts[ i ] = holes[ i ].getTransformedSpacedPoints( divisions, _bends );
 
-  	}
+    }
 
-  	return holesPts;
+    return holesPts;
 
   }
 
@@ -82,44 +82,44 @@ class Shape extends Path {
   // Get points of shape and holes (keypoints based on segments parameter)
   extractAllPoints( divisions ) {
 
-  	return {
+    return {
 
-  		"shape": getTransformedPoints( divisions ),
-  		"holes": getPointsHoles( divisions )
+      "shape": getTransformedPoints( divisions ),
+      "holes": getPointsHoles( divisions )
 
-  	};
+    };
 
   }
 
   extractPoints( [num divisions] ) {
 
-  	if (useSpacedPoints) {
-  		return extractAllSpacedPoints(divisions);
-  	}
+    if (useSpacedPoints) {
+      return extractAllSpacedPoints(divisions);
+    }
 
-  	return extractAllPoints(divisions);
+    return extractAllPoints(divisions);
 
   }
 
   //
   // THREE.Shape.prototype.extractAllPointsWithBend = function ( divisions, bend ) {
   //
-  // 	return {
+  //   return {
   //
-  // 		shape: this.transform( bend, divisions ),
-  // 		holes: this.getPointsHoles( divisions, bend )
+  //     shape: this.transform( bend, divisions ),
+  //     holes: this.getPointsHoles( divisions, bend )
   //
-  // 	};
+  //   };
   //
   // };
 
   // Get points of shape and holes (spaced by regular distance)
   extractAllSpacedPoints( [num divisions] ) {
-  	return {
-  		"shape": getTransformedSpacedPoints( divisions ),
-  		"holes": getSpacedPointsHoles( divisions )
+    return {
+      "shape": getTransformedSpacedPoints( divisions ),
+      "holes": getSpacedPointsHoles( divisions )
 
-  	};
+    };
   }
 
 }

--- a/lib/extras/image_utils.dart
+++ b/lib/extras/image_utils.dart
@@ -10,30 +10,30 @@ var crossOrigin = 'anonymous';
 
 Texture loadTexture ( String url, {mapping, Function onLoad(Texture texture), Function onError(String message)} ) {
 
-	var image = new ImageElement();
-	var texture = new Texture( image, mapping );
+  var image = new ImageElement();
+  var texture = new Texture( image, mapping );
 
-	var loader = new ImageLoader();
+  var loader = new ImageLoader();
 
-	loader.addEventListener( 'load',  ( event ) {
+  loader.addEventListener( 'load',  ( event ) {
 
-		texture.image = event.content;
-		texture.needsUpdate = true;
+    texture.image = event.content;
+    texture.needsUpdate = true;
 
-		if ( onLoad != null ) onLoad( texture );
+    if ( onLoad != null ) onLoad( texture );
 
-	} );
+  } );
 
-	loader.addEventListener( 'error',  ( event ) {
+  loader.addEventListener( 'error',  ( event ) {
 
-		if ( onError != null ) onError( event.message );
+    if ( onError != null ) onError( event.message );
 
-	} );
+  } );
 
-	loader.crossOrigin = crossOrigin;
-	loader.load( url, image );
+  loader.crossOrigin = crossOrigin;
+  loader.load( url, image );
 
-	return texture;
+  return texture;
 
 }
 
@@ -80,38 +80,38 @@ Texture loadCompressedTexture( String url, {mapping, Function onLoad(Texture tex
 
 Texture loadTextureCube ( List<String> array, [mapping, Function onLoad() ]) {
 
-	var i, l;
-	l = array.length;
-	ImageList images = new ImageList(l);
-	var texture = new Texture( images );
-	mapping = (mapping == null)? texture.mapping:mapping;
+  var i, l;
+  l = array.length;
+  ImageList images = new ImageList(l);
+  var texture = new Texture( images );
+  mapping = (mapping == null)? texture.mapping:mapping;
 
-	texture.flipY = false;
+  texture.flipY = false;
 
-	images.loadCount = 0;
+  images.loadCount = 0;
 
-	for ( i = 0; i < l; ++ i ) {
+  for ( i = 0; i < l; ++ i ) {
 
-		images[ i ] = new ImageElement();
-		images[ i ].onLoad.listen((_) {
+    images[ i ] = new ImageElement();
+    images[ i ].onLoad.listen((_) {
 
-		  images.loadCount += 1;
+      images.loadCount += 1;
 
-			if ( images.loadCount == 6 ) {
+      if ( images.loadCount == 6 ) {
 
-				texture.needsUpdate = true;
-				if ( onLoad != null ) onLoad();
+        texture.needsUpdate = true;
+        if ( onLoad != null ) onLoad();
 
-			}
+      }
 
-		});
+    });
 
-		images[ i ].crossOrigin = crossOrigin;
-		images[ i ].src = array[ i ];
+    images[ i ].crossOrigin = crossOrigin;
+    images[ i ].src = array[ i ];
 
-	}
+  }
 
-	return texture;
+  return texture;
 
 }
 
@@ -263,127 +263,127 @@ Map parseDDS( ByteBuffer buffer, bool loadMipmaps ) {
 
 CanvasElement getNormalMap ( image, int depth ) {
 
-	// Adapted from http://www.paulbrunt.co.uk/lab/heightnormal/
+  // Adapted from http://www.paulbrunt.co.uk/lab/heightnormal/
 
-	var cross = ( a, b ) {
+  var cross = ( a, b ) {
 
-		return [ a[ 1 ] * b[ 2 ] - a[ 2 ] * b[ 1 ], a[ 2 ] * b[ 0 ] - a[ 0 ] * b[ 2 ], a[ 0 ] * b[ 1 ] - a[ 1 ] * b[ 0 ] ];
+    return [ a[ 1 ] * b[ 2 ] - a[ 2 ] * b[ 1 ], a[ 2 ] * b[ 0 ] - a[ 0 ] * b[ 2 ], a[ 0 ] * b[ 1 ] - a[ 1 ] * b[ 0 ] ];
 
-	};
+  };
 
-	var subtract = ( a, b ) {
+  var subtract = ( a, b ) {
 
-		return [ a[ 0 ] - b[ 0 ], a[ 1 ] - b[ 1 ], a[ 2 ] - b[ 2 ] ];
+    return [ a[ 0 ] - b[ 0 ], a[ 1 ] - b[ 1 ], a[ 2 ] - b[ 2 ] ];
 
-	};
+  };
 
-	var normalize = ( a ) {
+  var normalize = ( a ) {
 
-		var l = Math.sqrt( a[ 0 ] * a[ 0 ] + a[ 1 ] * a[ 1 ] + a[ 2 ] * a[ 2 ] );
-		return [ a[ 0 ] / l, a[ 1 ] / l, a[ 2 ] / l ];
+    var l = Math.sqrt( a[ 0 ] * a[ 0 ] + a[ 1 ] * a[ 1 ] + a[ 2 ] * a[ 2 ] );
+    return [ a[ 0 ] / l, a[ 1 ] / l, a[ 2 ] / l ];
 
-	};
+  };
 
-	depth = depth | 1;
+  depth = depth | 1;
 
-	var width = image.width;
-	var height = image.height;
+  var width = image.width;
+  var height = image.height;
 
-	var canvas = new CanvasElement();;
-	canvas.width = width;
-	canvas.height = height;
+  var canvas = new CanvasElement();;
+  canvas.width = width;
+  canvas.height = height;
 
-	var context = canvas.context2D;
-	context.drawImage( image, 0, 0 );
+  var context = canvas.context2D;
+  context.drawImage( image, 0, 0 );
 
-	var data = context.getImageData( 0, 0, width, height ).data;
-	var imageData = context.createImageData( width, height );
-	var output = imageData.data;
+  var data = context.getImageData( 0, 0, width, height ).data;
+  var imageData = context.createImageData( width, height );
+  var output = imageData.data;
 
-	for ( var x = 0; x < width; x ++ ) {
+  for ( var x = 0; x < width; x ++ ) {
 
-		for ( var y = 0; y < height; y ++ ) {
+    for ( var y = 0; y < height; y ++ ) {
 
-			num ly = y - 1 < 0 ? 0 : y - 1;
-			num uy = y + 1 > height - 1 ? height - 1 : y + 1;
-			num lx = x - 1 < 0 ? 0 : x - 1;
-			num ux = x + 1 > width - 1 ? width - 1 : x + 1;
+      num ly = y - 1 < 0 ? 0 : y - 1;
+      num uy = y + 1 > height - 1 ? height - 1 : y + 1;
+      num lx = x - 1 < 0 ? 0 : x - 1;
+      num ux = x + 1 > width - 1 ? width - 1 : x + 1;
 
-			var points = [];
-			var origin = [ 0, 0, data[ ( y * width + x ) * 4 ] / 255 * depth ];
-			points.add( [ - 1, 0, data[ ( y * width + lx ) * 4 ] / 255 * depth ] );
-			points.add( [ - 1, - 1, data[ ( ly * width + lx ) * 4 ] / 255 * depth ] );
-			points.add( [ 0, - 1, data[ ( ly * width + x ) * 4 ] / 255 * depth ] );
-			points.add( [  1, - 1, data[ ( ly * width + ux ) * 4 ] / 255 * depth ] );
-			points.add( [ 1, 0, data[ ( y * width + ux ) * 4 ] / 255 * depth ] );
-			points.add( [ 1, 1, data[ ( uy * width + ux ) * 4 ] / 255 * depth ] );
-			points.add( [ 0, 1, data[ ( uy * width + x ) * 4 ] / 255 * depth ] );
-			points.add( [ - 1, 1, data[ ( uy * width + lx ) * 4 ] / 255 * depth ] );
+      var points = [];
+      var origin = [ 0, 0, data[ ( y * width + x ) * 4 ] / 255 * depth ];
+      points.add( [ - 1, 0, data[ ( y * width + lx ) * 4 ] / 255 * depth ] );
+      points.add( [ - 1, - 1, data[ ( ly * width + lx ) * 4 ] / 255 * depth ] );
+      points.add( [ 0, - 1, data[ ( ly * width + x ) * 4 ] / 255 * depth ] );
+      points.add( [  1, - 1, data[ ( ly * width + ux ) * 4 ] / 255 * depth ] );
+      points.add( [ 1, 0, data[ ( y * width + ux ) * 4 ] / 255 * depth ] );
+      points.add( [ 1, 1, data[ ( uy * width + ux ) * 4 ] / 255 * depth ] );
+      points.add( [ 0, 1, data[ ( uy * width + x ) * 4 ] / 255 * depth ] );
+      points.add( [ - 1, 1, data[ ( uy * width + lx ) * 4 ] / 255 * depth ] );
 
-			List<List> normals = [];
-			var num_points = points.length;
+      List<List> normals = [];
+      var num_points = points.length;
 
-			for ( var i = 0; i < num_points; i ++ ) {
+      for ( var i = 0; i < num_points; i ++ ) {
 
-				var v1 = points[ i ];
-				var v2 = points[ ( i + 1 ) % num_points ];
-				v1 = subtract( v1, origin );
-				v2 = subtract( v2, origin );
-				normals.add( normalize( cross( v1, v2 ) ) );
+        var v1 = points[ i ];
+        var v2 = points[ ( i + 1 ) % num_points ];
+        v1 = subtract( v1, origin );
+        v2 = subtract( v2, origin );
+        normals.add( normalize( cross( v1, v2 ) ) );
 
-			}
+      }
 
-			List<num> normal = [ 0, 0, 0 ];
+      List<num> normal = [ 0, 0, 0 ];
 
-			for ( var i = 0; i < normals.length; i ++ ) {
+      for ( var i = 0; i < normals.length; i ++ ) {
 
-				normal[ 0 ] += normals[ i ][ 0 ];
-				normal[ 1 ] += normals[ i ][ 1 ];
-				normal[ 2 ] += normals[ i ][ 2 ];
+        normal[ 0 ] += normals[ i ][ 0 ];
+        normal[ 1 ] += normals[ i ][ 1 ];
+        normal[ 2 ] += normals[ i ][ 2 ];
 
-			}
+      }
 
-			normal[ 0 ] /= normals.length;
-			normal[ 1 ] /= normals.length;
-			normal[ 2 ] /= normals.length;
+      normal[ 0 ] /= normals.length;
+      normal[ 1 ] /= normals.length;
+      normal[ 2 ] /= normals.length;
 
-			var idx = ( y * width + x ) * 4;
+      var idx = ( y * width + x ) * 4;
 
-			output[ idx ] = ( ( normal[ 0 ] + 1.0 ) / 2.0 * 255 ).toInt() | 0;
-			output[ idx + 1 ] = ( ( normal[ 1 ] + 1.0 ) / 2.0 * 255 ).toInt() | 0;
-			output[ idx + 2 ] = ( normal[ 2 ] * 255 ).toInt() | 0;
-			output[ idx + 3 ] = 255;
+      output[ idx ] = ( ( normal[ 0 ] + 1.0 ) / 2.0 * 255 ).toInt() | 0;
+      output[ idx + 1 ] = ( ( normal[ 1 ] + 1.0 ) / 2.0 * 255 ).toInt() | 0;
+      output[ idx + 2 ] = ( normal[ 2 ] * 255 ).toInt() | 0;
+      output[ idx + 3 ] = 255;
 
-		}
+    }
 
-	}
+  }
 
-	context.putImageData( imageData, 0, 0 );
+  context.putImageData( imageData, 0, 0 );
 
-	return canvas;
+  return canvas;
 
 }
 
 DataTexture generateDataTexture( num width, num height, Color color ) {
 
-	var size = width * height;
-	var data = new Uint8List( 3 * size );
+  var size = width * height;
+  var data = new Uint8List( 3 * size );
 
-	var r = ( color.r * 255 ).floor();
-	var g = ( color.g * 255 ).floor();
-	var b = ( color.b * 255 ).floor();
+  var r = ( color.r * 255 ).floor();
+  var g = ( color.g * 255 ).floor();
+  var b = ( color.b * 255 ).floor();
 
-	for ( var i = 0; i < size; i ++ ) {
+  for ( var i = 0; i < size; i ++ ) {
 
-		data[ i * 3 ] 	  = r;
-		data[ i * 3 + 1 ] = g;
-		data[ i * 3 + 2 ] = b;
+    data[ i * 3 ]     = r;
+    data[ i * 3 + 1 ] = g;
+    data[ i * 3 + 2 ] = b;
 
-	}
+  }
 
-	var texture = new DataTexture( data, width, height, RGBFormat );
-	texture.needsUpdate = true;
+  var texture = new DataTexture( data, width, height, RGBFormat );
+  texture.needsUpdate = true;
 
-	return texture;
+  return texture;
 
 }

--- a/lib/extras/objects/immediate_render_object.dart
+++ b/lib/extras/objects/immediate_render_object.dart
@@ -1,5 +1,5 @@
 part of three;
 
 class ImmediateRenderObject extends Object3D {
-	render(renderCallback) {}
+  render(renderCallback) {}
 }

--- a/lib/extras/objects/lens_flare.dart
+++ b/lib/extras/objects/lens_flare.dart
@@ -1,23 +1,23 @@
 part of three;
 
 class LensFlare extends Object3D {
-	List lensFlares;
-	var customUpdateCallback;
+  List lensFlares;
+  var customUpdateCallback;
 
-	Vector3 positionScreen;
+  Vector3 positionScreen;
 
-	LensFlare(texture, size, distance, blending, color )
-		: 	lensFlares = [],
-			customUpdateCallback = null,
-			super() {
+  LensFlare(texture, size, distance, blending, color )
+    :   lensFlares = [],
+      customUpdateCallback = null,
+      super() {
 
-		positionScreen = new Vector3.zero();
+    positionScreen = new Vector3.zero();
 
-		// TODO
-		//if( texture != undefined ) {
-		//	add( texture, size, distance, blending, color );
-		//}
+    // TODO
+    //if( texture != undefined ) {
+    //  add( texture, size, distance, blending, color );
+    //}
 
-	}
+  }
 
 }

--- a/lib/extras/shaders/basic_shader.dart
+++ b/lib/extras/shaders/basic_shader.dart
@@ -11,26 +11,26 @@ part of three_shaders;
 
 var BasicShader = {
 
-	'uniforms': {},
+  'uniforms': {},
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"void main() {",
+    "void main() {",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"void main() {",
+    "void main() {",
 
-			"gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );",
+      "gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/bleach_bypass_shader.dart
+++ b/lib/extras/shaders/bleach_bypass_shader.dart
@@ -13,57 +13,57 @@ part of three_shaders;
 
 var BleachBypassShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"opacity":  { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "opacity":  { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float opacity;",
+    "uniform float opacity;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 base = texture2D( tDiffuse, vUv );",
+      "vec4 base = texture2D( tDiffuse, vUv );",
 
-			"vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );",
-			"float lum = dot( lumCoeff, base.rgb );",
-			"vec3 blend = vec3( lum );",
+      "vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );",
+      "float lum = dot( lumCoeff, base.rgb );",
+      "vec3 blend = vec3( lum );",
 
-			"float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );",
+      "float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );",
 
-			"vec3 result1 = 2.0 * base.rgb * blend;",
-			"vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );",
+      "vec3 result1 = 2.0 * base.rgb * blend;",
+      "vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );",
 
-			"vec3 newColor = mix( result1, result2, L );",
+      "vec3 newColor = mix( result1, result2, L );",
 
-			"float A2 = opacity * base.a;",
-			"vec3 mixRGB = A2 * newColor.rgb;",
-			"mixRGB += ( ( 1.0 - A2 ) * base.rgb );",
+      "float A2 = opacity * base.a;",
+      "vec3 mixRGB = A2 * newColor.rgb;",
+      "mixRGB += ( ( 1.0 - A2 ) * base.rgb );",
 
-			"gl_FragColor = vec4( mixRGB, base.a );",
+      "gl_FragColor = vec4( mixRGB, base.a );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/blend_shader.dart
+++ b/lib/extras/shaders/blend_shader.dart
@@ -11,46 +11,46 @@ part of three_shaders;
 
 var BlendShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse1": { 'type': "t", 'value': null },
-		"tDiffuse2": { 'type': "t", 'value': null },
-		"mixRatio":  { 'type': "f", 'value': 0.5 },
-		"opacity":   { 'type': "f", 'value': 1.0 }
+    "tDiffuse1": { 'type': "t", 'value': null },
+    "tDiffuse2": { 'type': "t", 'value': null },
+    "mixRatio":  { 'type': "f", 'value': 0.5 },
+    "opacity":   { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float opacity;",
-		"uniform float mixRatio;",
+    "uniform float opacity;",
+    "uniform float mixRatio;",
 
-		"uniform sampler2D tDiffuse1;",
-		"uniform sampler2D tDiffuse2;",
+    "uniform sampler2D tDiffuse1;",
+    "uniform sampler2D tDiffuse2;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 texel1 = texture2D( tDiffuse1, vUv );",
-			"vec4 texel2 = texture2D( tDiffuse2, vUv );",
-			"gl_FragColor = opacity * mix( texel1, texel2, mixRatio );",
+      "vec4 texel1 = texture2D( tDiffuse1, vUv );",
+      "vec4 texel2 = texture2D( tDiffuse2, vUv );",
+      "gl_FragColor = opacity * mix( texel1, texel2, mixRatio );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/bokeh_shader.dart
+++ b/lib/extras/shaders/bokeh_shader.dart
@@ -13,109 +13,109 @@ part of three_shaders;
 
 var BokehShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tColor":   { 'type': "t", 'value': null },
-		"tDepth":   { 'type': "t", 'value': null },
-		"focus":    { 'type': "f", 'value': 1.0 },
-		"aspect":   { 'type': "f", 'value': 1.0 },
-		"aperture": { 'type': "f", 'value': 0.025 },
-		"maxblur":  { 'type': "f", 'value': 1.0 }
+    "tColor":   { 'type': "t", 'value': null },
+    "tDepth":   { 'type': "t", 'value': null },
+    "focus":    { 'type': "f", 'value': 1.0 },
+    "aspect":   { 'type': "f", 'value': 1.0 },
+    "aperture": { 'type': "f", 'value': 0.025 },
+    "maxblur":  { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
+    "uniform sampler2D tColor;",
+    "uniform sampler2D tDepth;",
 
-		"uniform float maxblur;",  // max blur amount
-		"uniform float aperture;", // aperture - bigger 'value's for shallower depth of field
+    "uniform float maxblur;",  // max blur amount
+    "uniform float aperture;", // aperture - bigger 'value's for shallower depth of field
 
-		"uniform float focus;",
-		"uniform float aspect;",
+    "uniform float focus;",
+    "uniform float aspect;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 aspectcorrect = vec2( 1.0, aspect );",
+      "vec2 aspectcorrect = vec2( 1.0, aspect );",
 
-			"vec4 depth1 = texture2D( tDepth, vUv );",
+      "vec4 depth1 = texture2D( tDepth, vUv );",
 
-			"float factor = depth1.x - focus;",
+      "float factor = depth1.x - focus;",
 
-			"vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );",
+      "vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );",
 
-			"vec2 dofblur9 = dofblur * 0.9;",
-			"vec2 dofblur7 = dofblur * 0.7;",
-			"vec2 dofblur4 = dofblur * 0.4;",
+      "vec2 dofblur9 = dofblur * 0.9;",
+      "vec2 dofblur7 = dofblur * 0.7;",
+      "vec2 dofblur4 = dofblur * 0.4;",
 
-			"vec4 col = vec4( 0.0 );",
+      "vec4 col = vec4( 0.0 );",
 
-			"col += texture2D( tColor, vUv.xy );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );",
 
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
 
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );",
 
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
-			"col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
+      "col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );",
 
-			"gl_FragColor = col / 41.0;",
-			"gl_FragColor.a = 1.0;",
+      "gl_FragColor = col / 41.0;",
+      "gl_FragColor.a = 1.0;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/bokeh_shader2.dart
+++ b/lib/extras/shaders/bokeh_shader2.dart
@@ -17,367 +17,367 @@ part of three_shaders;
 
 var BokehShader2 = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"textureWidth":  { 'type': "f", 'value': 1.0 },
-		"textureHeight":  { 'type': "f", 'value': 1.0 },
+    "textureWidth":  { 'type': "f", 'value': 1.0 },
+    "textureHeight":  { 'type': "f", 'value': 1.0 },
 
-		"focalDepth":   { 'type': "f", 'value': 1.0 },
-		"focalLength":   { 'type': "f", 'value': 24.0 },
-		"fstop": { 'type': "f", 'value': 0.9 },
+    "focalDepth":   { 'type': "f", 'value': 1.0 },
+    "focalLength":   { 'type': "f", 'value': 24.0 },
+    "fstop": { 'type': "f", 'value': 0.9 },
 
-		"tColor":   { 'type': "t", 'value': null },
-		"tDepth":   { 'type': "t", 'value': null },
+    "tColor":   { 'type': "t", 'value': null },
+    "tDepth":   { 'type': "t", 'value': null },
 
-		"maxblur":  { 'type': "f", 'value': 1.0 },
+    "maxblur":  { 'type': "f", 'value': 1.0 },
 
-		"showFocus":   { 'type': "i", 'value': 0 },
-		"manualdof":   { 'type': "i", 'value': 0 },
-		"vignetting":   { 'type': "i", 'value': 0 },
-		"depthblur":   { 'type': "i", 'value': 0 },
+    "showFocus":   { 'type': "i", 'value': 0 },
+    "manualdof":   { 'type': "i", 'value': 0 },
+    "vignetting":   { 'type': "i", 'value': 0 },
+    "depthblur":   { 'type': "i", 'value': 0 },
 
-		"threshold":  { 'type': "f", 'value': 0.5 },
-		"gain":  { 'type': "f", 'value': 2.0 },
-		"bias":  { 'type': "f", 'value': 0.5 },
-		"fringe":  { 'type': "f", 'value': 0.7 },
+    "threshold":  { 'type': "f", 'value': 0.5 },
+    "gain":  { 'type': "f", 'value': 2.0 },
+    "bias":  { 'type': "f", 'value': 0.5 },
+    "fringe":  { 'type': "f", 'value': 0.7 },
 
-		"znear":  { 'type': "f", 'value': 0.1 },
-		"zfar":  { 'type': "f", 'value': 100 },
+    "znear":  { 'type': "f", 'value': 0.1 },
+    "zfar":  { 'type': "f", 'value': 100 },
 
-		"noise":  { 'type': "i", 'value': 1 },
-		"dithering":  { 'type': "f", 'value': 0.0001 },
-		"pentagon": { 'type': "i", 'value': 0 },
+    "noise":  { 'type': "i", 'value': 1 },
+    "dithering":  { 'type': "f", 'value': 0.0001 },
+    "pentagon": { 'type': "i", 'value': 0 },
 
-		"shaderFocus":  { 'type': "i", 'value': 1 },
-		"focusCoords":  { 'type': "v2", 'value': new Vector2.zero()},
+    "shaderFocus":  { 'type': "i", 'value': 1 },
+    "focusCoords":  { 'type': "v2", 'value': new Vector2.zero()},
 
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
-		"uniform float textureWidth;",
-		"uniform float textureHeight;",
+    "uniform sampler2D tColor;",
+    "uniform sampler2D tDepth;",
+    "uniform float textureWidth;",
+    "uniform float textureHeight;",
 
-		"const float PI = 3.14159265;",
+    "const float PI = 3.14159265;",
 
-		"float width = textureWidth; //texture width",
-		"float height = textureHeight; //texture height",
+    "float width = textureWidth; //texture width",
+    "float height = textureHeight; //texture height",
 
-		"vec2 texel = vec2(1.0/width,1.0/height);",
+    "vec2 texel = vec2(1.0/width,1.0/height);",
 
-		"uniform float focalDepth;  //focal distance 'value' in meters, but you may use autofocus option below",
-		"uniform float focalLength; //focal length in mm",
-		"uniform float fstop; //f-stop 'value'",
-		"uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)",
+    "uniform float focalDepth;  //focal distance 'value' in meters, but you may use autofocus option below",
+    "uniform float focalLength; //focal length in mm",
+    "uniform float fstop; //f-stop 'value'",
+    "uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)",
 
-		"/*",
-		"make sure that these two 'value's are the same for your camera, otherwise distances will be wrong.",
-		"*/",
+    "/*",
+    "make sure that these two 'value's are the same for your camera, otherwise distances will be wrong.",
+    "*/",
 
-		"uniform float znear; // camera clipping start",
-		"uniform float zfar; // camera clipping end",
+    "uniform float znear; // camera clipping start",
+    "uniform float zfar; // camera clipping end",
 
-		"//------------------------------------------",
-		"//user variables",
+    "//------------------------------------------",
+    "//user variables",
 
-		"const int samples = SAMPLES; //samples on the first ring",
-		"const int rings = RINGS; //ring count",
+    "const int samples = SAMPLES; //samples on the first ring",
+    "const int rings = RINGS; //ring count",
 
-		"const int maxringsamples = rings * samples;",
+    "const int maxringsamples = rings * samples;",
 
-		"uniform bool manualdof; // manual dof calculation",
-		"float ndofstart = 1.0; // near dof blur start",
-		"float ndofdist = 2.0; // near dof blur falloff distance",
-		"float fdofstart = 1.0; // far dof blur start",
-		"float fdofdist = 3.0; // far dof blur falloff distance",
+    "uniform bool manualdof; // manual dof calculation",
+    "float ndofstart = 1.0; // near dof blur start",
+    "float ndofdist = 2.0; // near dof blur falloff distance",
+    "float fdofstart = 1.0; // far dof blur start",
+    "float fdofdist = 3.0; // far dof blur falloff distance",
 
-		"float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)",
+    "float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)",
 
-		"uniform bool vignetting; // use optical lens vignetting",
+    "uniform bool vignetting; // use optical lens vignetting",
 
-		"float vignout = 1.3; // vignetting outer border",
-		"float vignin = 0.0; // vignetting inner border",
-		"float vignfade = 22.0; // f-stops till vignete fades",
+    "float vignout = 1.3; // vignetting outer border",
+    "float vignin = 0.0; // vignetting inner border",
+    "float vignfade = 22.0; // f-stops till vignete fades",
 
-		"uniform bool shaderFocus;",
+    "uniform bool shaderFocus;",
 
-		"bool autofocus = shaderFocus;",
-		"//use autofocus in shader - use with focusCoords",
-		"// disable if you use external focalDepth 'value'",
+    "bool autofocus = shaderFocus;",
+    "//use autofocus in shader - use with focusCoords",
+    "// disable if you use external focalDepth 'value'",
 
-		"uniform vec2 focusCoords;",
-		"// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)",
-		"// if center of screen use vec2(0.5, 0.5);",
+    "uniform vec2 focusCoords;",
+    "// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)",
+    "// if center of screen use vec2(0.5, 0.5);",
 
-		"uniform float maxblur;",
-		"//clamp 'value' of max blur (0.0 = no blur, 1.0 default)",
+    "uniform float maxblur;",
+    "//clamp 'value' of max blur (0.0 = no blur, 1.0 default)",
 
-		"uniform float threshold; // highlight threshold;",
-		"uniform float gain; // highlight gain;",
+    "uniform float threshold; // highlight threshold;",
+    "uniform float gain; // highlight gain;",
 
-		"uniform float bias; // bokeh edge bias",
-		"uniform float fringe; // bokeh chromatic aberration / fringing",
+    "uniform float bias; // bokeh edge bias",
+    "uniform float fringe; // bokeh chromatic aberration / fringing",
 
-		"uniform bool noise; //use noise instead of pattern for sample dithering",
+    "uniform bool noise; //use noise instead of pattern for sample dithering",
 
-		"uniform float dithering;",
-		"float namount = dithering; //dither amount",
+    "uniform float dithering;",
+    "float namount = dithering; //dither amount",
 
-		"uniform bool depthblur; // blur the depth buffer",
-		"float dbsize = 1.25; // depth blur size",
+    "uniform bool depthblur; // blur the depth buffer",
+    "float dbsize = 1.25; // depth blur size",
 
-		"/*",
-		"next part is experimental",
-		"not looking good with small sample and ring count",
-		"looks okay starting from samples = 4, rings = 4",
-		"*/",
+    "/*",
+    "next part is experimental",
+    "not looking good with small sample and ring count",
+    "looks okay starting from samples = 4, rings = 4",
+    "*/",
 
-		"uniform bool pentagon; //use pentagon as bokeh shape?",
-		"float feather = 0.4; //pentagon shape feather",
+    "uniform bool pentagon; //use pentagon as bokeh shape?",
+    "float feather = 0.4; //pentagon shape feather",
 
-		"//------------------------------------------",
+    "//------------------------------------------",
 
-		"float penta(vec2 coords) {",
-			"//pentagonal shape",
-			"float scale = float(rings) - 1.3;",
-			"vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);",
-			"vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);",
-			"vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);",
-			"vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);",
-			"vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);",
-			"vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);",
+    "float penta(vec2 coords) {",
+      "//pentagonal shape",
+      "float scale = float(rings) - 1.3;",
+      "vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);",
+      "vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);",
+      "vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);",
+      "vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);",
+      "vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);",
+      "vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);",
 
-			"vec4  one = vec4( 1.0 );",
+      "vec4  one = vec4( 1.0 );",
 
-			"vec4 P = vec4((coords),vec2(scale, scale));",
+      "vec4 P = vec4((coords),vec2(scale, scale));",
 
-			"vec4 dist = vec4(0.0);",
-			"float inorout = -4.0;",
+      "vec4 dist = vec4(0.0);",
+      "float inorout = -4.0;",
 
-			"dist.x = dot( P, HS0 );",
-			"dist.y = dot( P, HS1 );",
-			"dist.z = dot( P, HS2 );",
-			"dist.w = dot( P, HS3 );",
+      "dist.x = dot( P, HS0 );",
+      "dist.y = dot( P, HS1 );",
+      "dist.z = dot( P, HS2 );",
+      "dist.w = dot( P, HS3 );",
 
-			"dist = smoothstep( -feather, feather, dist );",
+      "dist = smoothstep( -feather, feather, dist );",
 
-			"inorout += dot( dist, one );",
+      "inorout += dot( dist, one );",
 
-			"dist.x = dot( P, HS4 );",
-			"dist.y = HS5.w - abs( P.z );",
+      "dist.x = dot( P, HS4 );",
+      "dist.y = HS5.w - abs( P.z );",
 
-			"dist = smoothstep( -feather, feather, dist );",
-			"inorout += dist.x;",
+      "dist = smoothstep( -feather, feather, dist );",
+      "inorout += dist.x;",
 
-			"return clamp( inorout, 0.0, 1.0 );",
-		"}",
+      "return clamp( inorout, 0.0, 1.0 );",
+    "}",
 
-		"float bdepth(vec2 coords) {",
-			"// Depth buffer blur",
-			"float d = 0.0;",
-			"float kernel[9];",
-			"vec2 offset[9];",
+    "float bdepth(vec2 coords) {",
+      "// Depth buffer blur",
+      "float d = 0.0;",
+      "float kernel[9];",
+      "vec2 offset[9];",
 
-			"vec2 wh = vec2(texel.x, texel.y) * dbsize;",
+      "vec2 wh = vec2(texel.x, texel.y) * dbsize;",
 
-			"offset[0] = vec2(-wh.x,-wh.y);",
-			"offset[1] = vec2( 0.0, -wh.y);",
-			"offset[2] = vec2( wh.x -wh.y);",
+      "offset[0] = vec2(-wh.x,-wh.y);",
+      "offset[1] = vec2( 0.0, -wh.y);",
+      "offset[2] = vec2( wh.x -wh.y);",
 
-			"offset[3] = vec2(-wh.x,  0.0);",
-			"offset[4] = vec2( 0.0,   0.0);",
-			"offset[5] = vec2( wh.x,  0.0);",
+      "offset[3] = vec2(-wh.x,  0.0);",
+      "offset[4] = vec2( 0.0,   0.0);",
+      "offset[5] = vec2( wh.x,  0.0);",
 
-			"offset[6] = vec2(-wh.x, wh.y);",
-			"offset[7] = vec2( 0.0,  wh.y);",
-			"offset[8] = vec2( wh.x, wh.y);",
+      "offset[6] = vec2(-wh.x, wh.y);",
+      "offset[7] = vec2( 0.0,  wh.y);",
+      "offset[8] = vec2( wh.x, wh.y);",
 
-			"kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;",
-			"kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;",
-			"kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;",
+      "kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;",
+      "kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;",
+      "kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;",
 
 
-			"for( int i=0; i<9; i++ ) {",
-				"float tmp = texture2D(tDepth, coords + offset[i]).r;",
-				"d += tmp * kernel[i];",
-			"}",
+      "for( int i=0; i<9; i++ ) {",
+        "float tmp = texture2D(tDepth, coords + offset[i]).r;",
+        "d += tmp * kernel[i];",
+      "}",
 
-			"return d;",
-		"}",
+      "return d;",
+    "}",
 
 
-		"vec3 color(vec2 coords,float blur) {",
-			"//processing the sample",
+    "vec3 color(vec2 coords,float blur) {",
+      "//processing the sample",
 
-			"vec3 col = vec3(0.0);",
+      "vec3 col = vec3(0.0);",
 
-			"col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;",
-			"col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;",
-			"col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;",
+      "col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;",
+      "col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;",
+      "col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;",
 
-			"vec3 lumcoeff = vec3(0.299,0.587,0.114);",
-			"float lum = dot(col.rgb, lumcoeff);",
-			"float thresh = max((lum-threshold)*gain, 0.0);",
-			"return col+mix(vec3(0.0),col,thresh*blur);",
-		"}",
+      "vec3 lumcoeff = vec3(0.299,0.587,0.114);",
+      "float lum = dot(col.rgb, lumcoeff);",
+      "float thresh = max((lum-threshold)*gain, 0.0);",
+      "return col+mix(vec3(0.0),col,thresh*blur);",
+    "}",
 
-		"vec2 rand(vec2 coord) {",
-			"// generating noise / pattern texture for dithering",
+    "vec2 rand(vec2 coord) {",
+      "// generating noise / pattern texture for dithering",
 
-			"float noiseX = ((fract(1.0-coord.s*(width/2.0))*0.25)+(fract(coord.t*(height/2.0))*0.75))*2.0-1.0;",
-			"float noiseY = ((fract(1.0-coord.s*(width/2.0))*0.75)+(fract(coord.t*(height/2.0))*0.25))*2.0-1.0;",
+      "float noiseX = ((fract(1.0-coord.s*(width/2.0))*0.25)+(fract(coord.t*(height/2.0))*0.75))*2.0-1.0;",
+      "float noiseY = ((fract(1.0-coord.s*(width/2.0))*0.75)+(fract(coord.t*(height/2.0))*0.25))*2.0-1.0;",
 
-			"if (noise) {",
-				"noiseX = clamp(fract(sin(dot(coord ,vec2(12.9898,78.233))) * 43758.5453),0.0,1.0)*2.0-1.0;",
-				"noiseY = clamp(fract(sin(dot(coord ,vec2(12.9898,78.233)*2.0)) * 43758.5453),0.0,1.0)*2.0-1.0;",
-			"}",
+      "if (noise) {",
+        "noiseX = clamp(fract(sin(dot(coord ,vec2(12.9898,78.233))) * 43758.5453),0.0,1.0)*2.0-1.0;",
+        "noiseY = clamp(fract(sin(dot(coord ,vec2(12.9898,78.233)*2.0)) * 43758.5453),0.0,1.0)*2.0-1.0;",
+      "}",
 
-			"return vec2(noiseX,noiseY);",
-		"}",
+      "return vec2(noiseX,noiseY);",
+    "}",
 
-		"vec3 debugFocus(vec3 col, float blur, float depth) {",
-			"float edge = 0.002*depth; //distance based edge smoothing",
-			"float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);",
-			"float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);",
+    "vec3 debugFocus(vec3 col, float blur, float depth) {",
+      "float edge = 0.002*depth; //distance based edge smoothing",
+      "float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);",
+      "float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);",
 
-			"col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);",
-			"col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);",
+      "col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);",
+      "col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);",
 
-			"return col;",
-		"}",
+      "return col;",
+    "}",
 
-		"float linearize(float depth) {",
-			"return -zfar * znear / (depth * (zfar - znear) - zfar);",
-		"}",
+    "float linearize(float depth) {",
+      "return -zfar * znear / (depth * (zfar - znear) - zfar);",
+    "}",
 
 
-		"float vignette() {",
-			"float dist = distance(vUv.xy, vec2(0.5,0.5));",
-			"dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);",
-			"return clamp(dist,0.0,1.0);",
-		"}",
+    "float vignette() {",
+      "float dist = distance(vUv.xy, vec2(0.5,0.5));",
+      "dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);",
+      "return clamp(dist,0.0,1.0);",
+    "}",
 
-		"float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {",
-			"float rings2 = float(rings);",
-			"float step = PI*2.0 / float(ringsamples);",
-			"float pw = cos(j*step)*i;",
-			"float ph = sin(j*step)*i;",
-			"float p = 1.0;",
-			"if (pentagon) {",
-				"p = penta(vec2(pw,ph));",
-			"}",
-			"col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;",
-			"return 1.0 * mix(1.0, i /rings2, bias) * p;",
-		"}",
+    "float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {",
+      "float rings2 = float(rings);",
+      "float step = PI*2.0 / float(ringsamples);",
+      "float pw = cos(j*step)*i;",
+      "float ph = sin(j*step)*i;",
+      "float p = 1.0;",
+      "if (pentagon) {",
+        "p = penta(vec2(pw,ph));",
+      "}",
+      "col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;",
+      "return 1.0 * mix(1.0, i /rings2, bias) * p;",
+    "}",
 
-		"void main() {",
-			"//scene depth calculation",
+    "void main() {",
+      "//scene depth calculation",
 
-			"float depth = linearize(texture2D(tDepth,vUv.xy).x);",
+      "float depth = linearize(texture2D(tDepth,vUv.xy).x);",
 
-			"// Blur depth?",
-			"if (depthblur) {",
-				"depth = linearize(bdepth(vUv.xy));",
-			"}",
+      "// Blur depth?",
+      "if (depthblur) {",
+        "depth = linearize(bdepth(vUv.xy));",
+      "}",
 
-			"//focal plane calculation",
+      "//focal plane calculation",
 
-			"float fDepth = focalDepth;",
+      "float fDepth = focalDepth;",
 
-			"if (autofocus) {",
+      "if (autofocus) {",
 
-				"fDepth = linearize(texture2D(tDepth,focusCoords).x);",
+        "fDepth = linearize(texture2D(tDepth,focusCoords).x);",
 
-			"}",
+      "}",
 
-			"// dof blur factor calculation",
+      "// dof blur factor calculation",
 
-			"float blur = 0.0;",
+      "float blur = 0.0;",
 
-			"if (manualdof) {",
-				"float a = depth-fDepth; // Focal plane",
-				"float b = (a-fdofstart)/fdofdist; // Far DoF",
-				"float c = (-a-ndofstart)/ndofdist; // Near Dof",
-				"blur = (a>0.0) ? b : c;",
-			"} else {",
-				"float f = focalLength; // focal length in mm",
-				"float d = fDepth*1000.0; // focal plane in mm",
-				"float o = depth*1000.0; // depth in mm",
+      "if (manualdof) {",
+        "float a = depth-fDepth; // Focal plane",
+        "float b = (a-fdofstart)/fdofdist; // Far DoF",
+        "float c = (-a-ndofstart)/ndofdist; // Near Dof",
+        "blur = (a>0.0) ? b : c;",
+      "} else {",
+        "float f = focalLength; // focal length in mm",
+        "float d = fDepth*1000.0; // focal plane in mm",
+        "float o = depth*1000.0; // depth in mm",
 
-				"float a = (o*f)/(o-f);",
-				"float b = (d*f)/(d-f);",
-				"float c = (d-f)/(d*fstop*CoC);",
+        "float a = (o*f)/(o-f);",
+        "float b = (d*f)/(d-f);",
+        "float c = (d-f)/(d*fstop*CoC);",
 
-				"blur = abs(a-b)*c;",
-			"}",
+        "blur = abs(a-b)*c;",
+      "}",
 
-			"blur = clamp(blur,0.0,1.0);",
+      "blur = clamp(blur,0.0,1.0);",
 
-			"// calculation of pattern for dithering",
+      "// calculation of pattern for dithering",
 
-			"vec2 noise = rand(vUv.xy)*namount*blur;",
+      "vec2 noise = rand(vUv.xy)*namount*blur;",
 
-			"// getting blur x and y step factor",
+      "// getting blur x and y step factor",
 
-			"float w = (1.0/width)*blur*maxblur+noise.x;",
-			"float h = (1.0/height)*blur*maxblur+noise.y;",
+      "float w = (1.0/width)*blur*maxblur+noise.x;",
+      "float h = (1.0/height)*blur*maxblur+noise.y;",
 
-			"// calculation of final color",
+      "// calculation of final color",
 
-			"vec3 col = vec3(0.0);",
+      "vec3 col = vec3(0.0);",
 
-			"if(blur < 0.05) {",
-				"//some optimization thingy",
-				"col = texture2D(tColor, vUv.xy).rgb;",
-			"} else {",
-				"col = texture2D(tColor, vUv.xy).rgb;",
-				"float s = 1.0;",
-				"int ringsamples;",
+      "if(blur < 0.05) {",
+        "//some optimization thingy",
+        "col = texture2D(tColor, vUv.xy).rgb;",
+      "} else {",
+        "col = texture2D(tColor, vUv.xy).rgb;",
+        "float s = 1.0;",
+        "int ringsamples;",
 
-				"for (int i = 1; i <= rings; i++) {",
-					"/*unboxstart*/",
-					"ringsamples = i * samples;",
+        "for (int i = 1; i <= rings; i++) {",
+          "/*unboxstart*/",
+          "ringsamples = i * samples;",
 
-					"for (int j = 0 ; j < maxringsamples ; j++) {",
-						"if (j >= ringsamples) break;",
-						"s += gather(float(i), float(j), ringsamples, col, w, h, blur);",
-					"}",
-					"/*unboxend*/",
-				"}",
+          "for (int j = 0 ; j < maxringsamples ; j++) {",
+            "if (j >= ringsamples) break;",
+            "s += gather(float(i), float(j), ringsamples, col, w, h, blur);",
+          "}",
+          "/*unboxend*/",
+        "}",
 
-				"col /= s; //divide by sample count",
-			"}",
+        "col /= s; //divide by sample count",
+      "}",
 
-			"if (showFocus) {",
-				"col = debugFocus(col, blur, depth);",
-			"}",
+      "if (showFocus) {",
+        "col = debugFocus(col, blur, depth);",
+      "}",
 
-			"if (vignetting) {",
-				"col *= vignette();",
-			"}",
+      "if (vignetting) {",
+        "col *= vignette();",
+      "}",
 
-			"gl_FragColor.rgb = col;",
-			"gl_FragColor.a = 1.0;",
-		"} "
+      "gl_FragColor.rgb = col;",
+      "gl_FragColor.a = 1.0;",
+    "} "
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/brightness_contrast_shader.dart
+++ b/lib/extras/shaders/brightness_contrast_shader.dart
@@ -14,50 +14,50 @@ part of three_shaders;
 
 var BrightnessContrastShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":   { 'type': "t", 'value': null },
-		"brightness": { 'type': "f", 'value': 0 },
-		"contrast":   { 'type': "f", 'value': 0 }
+    "tDiffuse":   { 'type': "t", 'value': null },
+    "brightness": { 'type': "f", 'value': 0 },
+    "contrast":   { 'type': "f", 'value': 0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
+      "vUv = uv;",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float brightness;",
-		"uniform float contrast;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float brightness;",
+    "uniform float contrast;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"gl_FragColor = texture2D( tDiffuse, vUv );",
+      "gl_FragColor = texture2D( tDiffuse, vUv );",
 
-			"gl_FragColor.rgb += brightness;",
+      "gl_FragColor.rgb += brightness;",
 
-			"if (contrast > 0.0) {",
-				"gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;",
-			"} else {",
-				"gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;",
-			"}",
+      "if (contrast > 0.0) {",
+        "gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;",
+      "} else {",
+        "gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;",
+      "}",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/color_correction_shader.dart
+++ b/lib/extras/shaders/color_correction_shader.dart
@@ -11,43 +11,43 @@ part of three_shaders;
 
 var ColorCorrectionShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"powRGB":   { 'type': "v3", 'value': new Vector3( 2.0, 2.0, 2.0 ) },
-		"mulRGB":   { 'type': "v3", 'value': new Vector3( 1.0, 1.0, 1.0 ) }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "powRGB":   { 'type': "v3", 'value': new Vector3( 2.0, 2.0, 2.0 ) },
+    "mulRGB":   { 'type': "v3", 'value': new Vector3( 1.0, 1.0, 1.0 ) }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
+      "vUv = uv;",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec3 powRGB;",
-		"uniform vec3 mulRGB;",
+    "uniform sampler2D tDiffuse;",
+    "uniform vec3 powRGB;",
+    "uniform vec3 mulRGB;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"gl_FragColor = texture2D( tDiffuse, vUv );",
-			"gl_FragColor.rgb = mulRGB * pow( gl_FragColor.rgb, powRGB );",
+      "gl_FragColor = texture2D( tDiffuse, vUv );",
+      "gl_FragColor.rgb = mulRGB * pow( gl_FragColor.rgb, powRGB );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/colorify_shader.dart
+++ b/lib/extras/shaders/colorify_shader.dart
@@ -11,44 +11,44 @@ part of three_shaders;
 
 var ColorifyShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"color":    { 'type': "c", 'value': new Color( 0xffffff ) }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "color":    { 'type': "c", 'value': new Color( 0xffffff ) }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform vec3 color;",
-		"uniform sampler2D tDiffuse;",
+    "uniform vec3 color;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 texel = texture2D( tDiffuse, vUv );",
+      "vec4 texel = texture2D( tDiffuse, vUv );",
 
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
-			"float v = dot( texel.xyz, luma );",
+      "vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+      "float v = dot( texel.xyz, luma );",
 
-			"gl_FragColor = vec4( v * color, texel.w );",
+      "gl_FragColor = vec4( v * color, texel.w );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/convolution_shader.dart
+++ b/lib/extras/shaders/convolution_shader.dart
@@ -13,99 +13,99 @@ part of three_shaders;
 
 var ConvolutionShader = {
 
-	'defines': {
+  'defines': {
 
-		"KERNEL_SIZE_FLOAT": "25.0",
-		"KERNEL_SIZE_INT": "25",
+    "KERNEL_SIZE_FLOAT": "25.0",
+    "KERNEL_SIZE_INT": "25",
 
-	},
+  },
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":        { 'type': "t", 'value': null },
-		"uImageIncrement": { 'type': "v2", 'value': new Vector2.array([0.001953125, 0.0]) },
-		"cKernel":         { 'type': "fv1", 'value': [] }
+    "tDiffuse":        { 'type': "t", 'value': null },
+    "uImageIncrement": { 'type': "v2", 'value': new Vector2.array([0.001953125, 0.0]) },
+    "cKernel":         { 'type': "fv1", 'value': [] }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"uniform vec2 uImageIncrement;",
+    "uniform vec2 uImageIncrement;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float cKernel[ KERNEL_SIZE_INT ];",
+    "uniform float cKernel[ KERNEL_SIZE_INT ];",
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec2 uImageIncrement;",
+    "uniform sampler2D tDiffuse;",
+    "uniform vec2 uImageIncrement;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 imageCoord = vUv;",
-			"vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );",
+      "vec2 imageCoord = vUv;",
+      "vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );",
 
-			"for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {",
+      "for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {",
 
-				"sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];",
-				"imageCoord += uImageIncrement;",
+        "sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];",
+        "imageCoord += uImageIncrement;",
 
-			"}",
+      "}",
 
-			"gl_FragColor = sum;",
+      "gl_FragColor = sum;",
 
-		"}"
+    "}"
 
 
-	].join("\n"),
+  ].join("\n"),
 
-	'buildKernel': ( double sigma ) {
+  'buildKernel': ( double sigma ) {
 
-		// We lop off the sqrt(2 * pi) * sigma term, since we're going to normalize anyway.
+    // We lop off the sqrt(2 * pi) * sigma term, since we're going to normalize anyway.
 
-		double gauss( x, sigma ) {
+    double gauss( x, sigma ) {
 
-			return exp( - ( x * x ) / ( 2.0 * sigma * sigma ) );
+      return exp( - ( x * x ) / ( 2.0 * sigma * sigma ) );
 
-		}
+    }
 
-		var i;
-		var values;
-		var sum;
-		var halfWidth;
-		var kMaxKernelSize = 25;
-		int kernelSize = 2 * (sigma * 3.0).ceil() + 1;
+    var i;
+    var values;
+    var sum;
+    var halfWidth;
+    var kMaxKernelSize = 25;
+    int kernelSize = 2 * (sigma * 3.0).ceil() + 1;
 
-		if ( kernelSize > kMaxKernelSize ) kernelSize = kMaxKernelSize;
-		halfWidth = ( kernelSize - 1 ) * 0.5;
+    if ( kernelSize > kMaxKernelSize ) kernelSize = kMaxKernelSize;
+    halfWidth = ( kernelSize - 1 ) * 0.5;
 
-		values = new List( kernelSize );
-		sum = 0.0;
-		for ( i = 0; i < kernelSize; ++i ) {
+    values = new List( kernelSize );
+    sum = 0.0;
+    for ( i = 0; i < kernelSize; ++i ) {
 
-			values[ i ] = gauss( i - halfWidth, sigma );
-			sum += values[ i ];
+      values[ i ] = gauss( i - halfWidth, sigma );
+      sum += values[ i ];
 
-		}
+    }
 
-		// normalize the kernel
+    // normalize the kernel
 
-		for ( i = 0; i < kernelSize; ++i ) values[ i ] /= sum;
+    for ( i = 0; i < kernelSize; ++i ) values[ i ] /= sum;
 
-		return values;
+    return values;
 
-	}
+  }
 
 };

--- a/lib/extras/shaders/copy_shader.dart
+++ b/lib/extras/shaders/copy_shader.dart
@@ -11,41 +11,41 @@ part of three_shaders;
 
 var CopyShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"opacity":  { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "opacity":  { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float opacity;",
+    "uniform float opacity;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 texel = texture2D( tDiffuse, vUv );",
-			"gl_FragColor = opacity * texel;",
+      "vec4 texel = texture2D( tDiffuse, vUv );",
+      "gl_FragColor = opacity * texel;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/digital_glitch.dart
+++ b/lib/extras/shaders/digital_glitch.dart
@@ -17,92 +17,92 @@ part of three_shaders;
 
 var DigitalGlitch = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":		{ 'type': "t", 'value': null },//diffuse texture
-		"tDisp":		{ 'type': "t", 'value': null },//displacement texture for digital glitch squares
-		"byp":			{ 'type': "i", 'value': 0 },//apply the glitch ?
-		"amount":		{ 'type': "f", 'value': 0.08 },
-		"angle":		{ 'type': "f", 'value': 0.02 },
-		"seed":			{ 'type': "f", 'value': 0.02 },
-		"seed_x":		{ 'type': "f", 'value': 0.02 },//-1,1
-		"seed_y":		{ 'type': "f", 'value': 0.02 },//-1,1
-		"distortion_x":	{ 'type': "f", 'value': 0.5 },
-		"distortion_y":	{ 'type': "f", 'value': 0.6 },
-		"col_s":		{ 'type': "f", 'value': 0.05 }
-	},
+    "tDiffuse":    { 'type': "t", 'value': null },//diffuse texture
+    "tDisp":    { 'type': "t", 'value': null },//displacement texture for digital glitch squares
+    "byp":      { 'type': "i", 'value': 0 },//apply the glitch ?
+    "amount":    { 'type': "f", 'value': 0.08 },
+    "angle":    { 'type': "f", 'value': 0.02 },
+    "seed":      { 'type': "f", 'value': 0.02 },
+    "seed_x":    { 'type': "f", 'value': 0.02 },//-1,1
+    "seed_y":    { 'type': "f", 'value': 0.02 },//-1,1
+    "distortion_x":  { 'type': "f", 'value': 0.5 },
+    "distortion_y":  { 'type': "f", 'value': 0.6 },
+    "col_s":    { 'type': "f", 'value': 0.05 }
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
-		"void main() {",
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"}"
-	].join("\n"),
+    "varying vec2 vUv;",
+    "void main() {",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+    "}"
+  ].join("\n"),
 
-	'fragmentShader': [
-		"uniform int byp;",//should we apply the glitch ?
-		
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tDisp;",
-		
-		"uniform float amount;",
-		"uniform float angle;",
-		"uniform float seed;",
-		"uniform float seed_x;",
-		"uniform float seed_y;",
-		"uniform float distortion_x;",
-		"uniform float distortion_y;",
-		"uniform float col_s;",
-			
-		"varying vec2 vUv;",
-		
-		
-		"float rand(vec2 co){",
-			"return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);",
-		"}",
-				
-		"void main() {",
-			"if(byp<1) {",
-				"vec2 p = vUv;",
-				"float xs = floor(gl_FragCoord.x / 0.5);",
-				"float ys = floor(gl_FragCoord.y / 0.5);",
-				//based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
-				"vec4 normal = texture2D (tDisp, p*seed*seed);",
-				"if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {",
-					"if(seed_x>0.){",
-						"p.y = 1. - (p.y + distortion_y);",
-					"}",
-					"else {",
-						"p.y = distortion_y;",
-					"}",
-				"}",
-				"if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {",
-					"if(seed_y>0.){",
-						"p.x=distortion_x;",
-					"}",
-					"else {",
-						"p.x = 1. - (p.x + distortion_x);",
-					"}",
-				"}",
-				"p.x+=normal.x*seed_x*(seed/5.);",
-				"p.y+=normal.y*seed_y*(seed/5.);",
-				//base from RGB shift shader
-				"vec2 offset = amount * vec2( cos(angle), sin(angle));",
-				"vec4 cr = texture2D(tDiffuse, p + offset);",
-				"vec4 cga = texture2D(tDiffuse, p);",
-				"vec4 cb = texture2D(tDiffuse, p - offset);",
-				"gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
-				//add noise
-				"vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);",
-				"gl_FragColor = gl_FragColor+ snow;",
-			"}",
-			"else {",
-				"gl_FragColor=texture2D (tDiffuse, vUv);",
-			"}",
-		"}"
+  'fragmentShader': [
+    "uniform int byp;",//should we apply the glitch ?
+    
+    "uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDisp;",
+    
+    "uniform float amount;",
+    "uniform float angle;",
+    "uniform float seed;",
+    "uniform float seed_x;",
+    "uniform float seed_y;",
+    "uniform float distortion_x;",
+    "uniform float distortion_y;",
+    "uniform float col_s;",
+      
+    "varying vec2 vUv;",
+    
+    
+    "float rand(vec2 co){",
+      "return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);",
+    "}",
+        
+    "void main() {",
+      "if(byp<1) {",
+        "vec2 p = vUv;",
+        "float xs = floor(gl_FragCoord.x / 0.5);",
+        "float ys = floor(gl_FragCoord.y / 0.5);",
+        //based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
+        "vec4 normal = texture2D (tDisp, p*seed*seed);",
+        "if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {",
+          "if(seed_x>0.){",
+            "p.y = 1. - (p.y + distortion_y);",
+          "}",
+          "else {",
+            "p.y = distortion_y;",
+          "}",
+        "}",
+        "if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {",
+          "if(seed_y>0.){",
+            "p.x=distortion_x;",
+          "}",
+          "else {",
+            "p.x = 1. - (p.x + distortion_x);",
+          "}",
+        "}",
+        "p.x+=normal.x*seed_x*(seed/5.);",
+        "p.y+=normal.y*seed_y*(seed/5.);",
+        //base from RGB shift shader
+        "vec2 offset = amount * vec2( cos(angle), sin(angle));",
+        "vec4 cr = texture2D(tDiffuse, p + offset);",
+        "vec4 cga = texture2D(tDiffuse, p);",
+        "vec4 cb = texture2D(tDiffuse, p - offset);",
+        "gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
+        //add noise
+        "vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);",
+        "gl_FragColor = gl_FragColor+ snow;",
+      "}",
+      "else {",
+        "gl_FragColor=texture2D (tDiffuse, vUv);",
+      "}",
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/dof_mipmap_shader.dart
+++ b/lib/extras/shaders/dof_mipmap_shader.dart
@@ -13,51 +13,51 @@ part of three_shaders;
 
 var DOFMipMapShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tColor":   { 'type': "t", 'value': null },
-		"tDepth":   { 'type': "t", 'value': null },
-		"focus":    { 'type': "f", 'value': 1.0 },
-		"maxblur":  { 'type': "f", 'value': 1.0 }
+    "tColor":   { 'type': "t", 'value': null },
+    "tDepth":   { 'type': "t", 'value': null },
+    "focus":    { 'type': "f", 'value': 1.0 },
+    "maxblur":  { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float focus;",
-		"uniform float maxblur;",
+    "uniform float focus;",
+    "uniform float maxblur;",
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
+    "uniform sampler2D tColor;",
+    "uniform sampler2D tDepth;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 depth = texture2D( tDepth, vUv );",
+      "vec4 depth = texture2D( tDepth, vUv );",
 
-			"float factor = depth.x - focus;",
+      "float factor = depth.x - focus;",
 
-			"vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );",
+      "vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );",
 
-			"gl_FragColor = col;",
-			"gl_FragColor.a = 1.0;",
+      "gl_FragColor = col;",
+      "gl_FragColor.a = 1.0;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/dot_screen_shader.dart
+++ b/lib/extras/shaders/dot_screen_shader.dart
@@ -13,61 +13,61 @@ part of three_shaders;
 
 var DotScreenShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"tSize":    { 'type': "v2", 'value': new Vector2( 256.0, 256.0 ) },
-		"center":   { 'type': "v2", 'value': new Vector2( 0.5, 0.5 ) },
-		"angle":    { 'type': "f", 'value': 1.57 },
-		"scale":    { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "tSize":    { 'type': "v2", 'value': new Vector2( 256.0, 256.0 ) },
+    "center":   { 'type': "v2", 'value': new Vector2( 0.5, 0.5 ) },
+    "angle":    { 'type': "f", 'value': 1.57 },
+    "scale":    { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform vec2 center;",
-		"uniform float angle;",
-		"uniform float scale;",
-		"uniform vec2 tSize;",
+    "uniform vec2 center;",
+    "uniform float angle;",
+    "uniform float scale;",
+    "uniform vec2 tSize;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"float pattern() {",
+    "float pattern() {",
 
-			"float s = sin( angle ), c = cos( angle );",
+      "float s = sin( angle ), c = cos( angle );",
 
-			"vec2 tex = vUv * tSize - center;",
-			"vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;",
+      "vec2 tex = vUv * tSize - center;",
+      "vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;",
 
-			"return ( sin( point.x ) * sin( point.y ) ) * 4.0;",
+      "return ( sin( point.x ) * sin( point.y ) ) * 4.0;",
 
-		"}",
+    "}",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 color = texture2D( tDiffuse, vUv );",
+      "vec4 color = texture2D( tDiffuse, vUv );",
 
-			"float average = ( color.r + color.g + color.b ) / 3.0;",
+      "float average = ( color.r + color.g + color.b ) / 3.0;",
 
-			"gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );",
+      "gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/edge_shader2.dart
+++ b/lib/extras/shaders/edge_shader2.dart
@@ -14,69 +14,69 @@ part of three_shaders;
 
 var EdgeShader2 = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"aspect":    { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
-	},
+    "tDiffuse": { 'type': "t", 'value': null },
+    "aspect":    { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"varying vec2 vUv;",
-		"uniform vec2 aspect;",
-
-
-		"vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);",
-
-		"mat3 G[2];",
-
-		"const mat3 g0 = mat3( 1.0, 2.0, 1.0, 0.0, 0.0, 0.0, -1.0, -2.0, -1.0 );",
-		"const mat3 g1 = mat3( 1.0, 0.0, -1.0, 2.0, 0.0, -2.0, 1.0, 0.0, -1.0 );",
+    "uniform sampler2D tDiffuse;",
+    "varying vec2 vUv;",
+    "uniform vec2 aspect;",
 
 
-		"void main(void)",
-		"{",
-			"mat3 I;",
-			"float cnv[2];",
-			"vec3 sample;",
+    "vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);",
 
-			"G[0] = g0;",
-			"G[1] = g1;",
+    "mat3 G[2];",
 
-			/*
-			 * fetch the 3x3 neighbourhood and use the RGB vector's length as intensity 'value'
+    "const mat3 g0 = mat3( 1.0, 2.0, 1.0, 0.0, 0.0, 0.0, -1.0, -2.0, -1.0 );",
+    "const mat3 g1 = mat3( 1.0, 0.0, -1.0, 2.0, 0.0, -2.0, 1.0, 0.0, -1.0 );",
+
+
+    "void main(void)",
+    "{",
+      "mat3 I;",
+      "float cnv[2];",
+      "vec3 sample;",
+
+      "G[0] = g0;",
+      "G[1] = g1;",
+
+      /*
+       * fetch the 3x3 neighbourhood and use the RGB vector's length as intensity 'value'
        */
-			"for (float i=0.0; i<3.0; i++)",
-			"for (float j=0.0; j<3.0; j++) {",
-				"sample = texture2D( tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;",
-				"I[int(i)][int(j)] = length(sample);",
-			"}",
+      "for (float i=0.0; i<3.0; i++)",
+      "for (float j=0.0; j<3.0; j++) {",
+        "sample = texture2D( tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;",
+        "I[int(i)][int(j)] = length(sample);",
+      "}",
 
-			/*
-			 * calculate the convolution 'value's for all the masks
+      /*
+       * calculate the convolution 'value's for all the masks
        */
-			"for (int i=0; i<2; i++) {",
-				"float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);",
-				"cnv[i] = dp3 * dp3; ",
-			"}",
+      "for (int i=0; i<2; i++) {",
+        "float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);",
+        "cnv[i] = dp3 * dp3; ",
+      "}",
 
-			"gl_FragColor = vec4(0.5 * sqrt(cnv[0]*cnv[0]+cnv[1]*cnv[1]));",
-		"} ",
+      "gl_FragColor = vec4(0.5 * sqrt(cnv[0]*cnv[0]+cnv[1]*cnv[1]));",
+    "} ",
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/film_shader.dart
+++ b/lib/extras/shaders/film_shader.dart
@@ -27,83 +27,83 @@ part of three_shaders;
 
 var FilmShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":   { 'type': "t", 'value': null },
-		"time":       { 'type': "f", 'value': 0.0 },
-		"nIntensity": { 'type': "f", 'value': 0.5 },
-		"sIntensity": { 'type': "f", 'value': 0.05 },
-		"sCount":     { 'type': "f", 'value': 4096 },
-		"grayscale":  { 'type': "i", 'value': 1 }
+    "tDiffuse":   { 'type': "t", 'value': null },
+    "time":       { 'type': "f", 'value': 0.0 },
+    "nIntensity": { 'type': "f", 'value': 0.5 },
+    "sIntensity": { 'type': "f", 'value': 0.05 },
+    "sCount":     { 'type': "f", 'value': 4096 },
+    "grayscale":  { 'type': "i", 'value': 1 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		// control parameter
-		"uniform float time;",
+    // control parameter
+    "uniform float time;",
 
-		"uniform bool grayscale;",
+    "uniform bool grayscale;",
 
-		// noise effect intensity 'value' (0 = no effect, 1 = full effect)
-		"uniform float nIntensity;",
+    // noise effect intensity 'value' (0 = no effect, 1 = full effect)
+    "uniform float nIntensity;",
 
-		// scanlines effect intensity 'value' (0 = no effect, 1 = full effect)
-		"uniform float sIntensity;",
+    // scanlines effect intensity 'value' (0 = no effect, 1 = full effect)
+    "uniform float sIntensity;",
 
-		// scanlines effect count 'value' (0 = no effect, 4096 = full effect)
-		"uniform float sCount;",
+    // scanlines effect count 'value' (0 = no effect, 4096 = full effect)
+    "uniform float sCount;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			// sample the source
-			"vec4 cTextureScreen = texture2D( tDiffuse, vUv );",
+      // sample the source
+      "vec4 cTextureScreen = texture2D( tDiffuse, vUv );",
 
-			// make some noise
-			"float x = vUv.x * vUv.y * time *  1000.0;",
-			"x = mod( x, 13.0 ) * mod( x, 123.0 );",
-			"float dx = mod( x, 0.01 );",
+      // make some noise
+      "float x = vUv.x * vUv.y * time *  1000.0;",
+      "x = mod( x, 13.0 ) * mod( x, 123.0 );",
+      "float dx = mod( x, 0.01 );",
 
-			// add noise
-			"vec3 cResult = cTextureScreen.rgb + cTextureScreen.rgb * clamp( 0.1 + dx * 100.0, 0.0, 1.0 );",
+      // add noise
+      "vec3 cResult = cTextureScreen.rgb + cTextureScreen.rgb * clamp( 0.1 + dx * 100.0, 0.0, 1.0 );",
 
-			// get us a sine and cosine
-			"vec2 sc = vec2( sin( vUv.y * sCount ), cos( vUv.y * sCount ) );",
+      // get us a sine and cosine
+      "vec2 sc = vec2( sin( vUv.y * sCount ), cos( vUv.y * sCount ) );",
 
-			// add scanlines
-			"cResult += cTextureScreen.rgb * vec3( sc.x, sc.y, sc.x ) * sIntensity;",
+      // add scanlines
+      "cResult += cTextureScreen.rgb * vec3( sc.x, sc.y, sc.x ) * sIntensity;",
 
-			// interpolate between source and result by intensity
-			"cResult = cTextureScreen.rgb + clamp( nIntensity, 0.0,1.0 ) * ( cResult - cTextureScreen.rgb );",
+      // interpolate between source and result by intensity
+      "cResult = cTextureScreen.rgb + clamp( nIntensity, 0.0,1.0 ) * ( cResult - cTextureScreen.rgb );",
 
-			// convert to grayscale if desired
-			"if( grayscale ) {",
+      // convert to grayscale if desired
+      "if( grayscale ) {",
 
-				"cResult = vec3( cResult.r * 0.3 + cResult.g * 0.59 + cResult.b * 0.11 );",
+        "cResult = vec3( cResult.r * 0.3 + cResult.g * 0.59 + cResult.b * 0.11 );",
 
-			"}",
+      "}",
 
-			"gl_FragColor =  vec4( cResult, cTextureScreen.a );",
+      "gl_FragColor =  vec4( cResult, cTextureScreen.a );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/focus_shader.dart
+++ b/lib/extras/shaders/focus_shader.dart
@@ -13,84 +13,84 @@ part of three_shaders;
 
 var FocusShader = {
 
-	'uniforms' : {
+  'uniforms' : {
 
-		"tDiffuse":       { 'type': "t", 'value': null },
-		"screenWidth":    { 'type': "f", 'value': 1024 },
-		"screenHeight":   { 'type': "f", 'value': 1024 },
-		"sampleDistance": { 'type': "f", 'value': 0.94 },
-		"waveFactor":     { 'type': "f", 'value': 0.00125 }
+    "tDiffuse":       { 'type': "t", 'value': null },
+    "screenWidth":    { 'type': "f", 'value': 1024 },
+    "screenHeight":   { 'type': "f", 'value': 1024 },
+    "sampleDistance": { 'type': "f", 'value': 0.94 },
+    "waveFactor":     { 'type': "f", 'value': 0.00125 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float screenWidth;",
-		"uniform float screenHeight;",
-		"uniform float sampleDistance;",
-		"uniform float waveFactor;",
+    "uniform float screenWidth;",
+    "uniform float screenHeight;",
+    "uniform float sampleDistance;",
+    "uniform float waveFactor;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 color, org, tmp, add;",
-			"float sample_dist, f;",
-			"vec2 vin;",
-			"vec2 uv = vUv;",
+      "vec4 color, org, tmp, add;",
+      "float sample_dist, f;",
+      "vec2 vin;",
+      "vec2 uv = vUv;",
 
-			"add = color = org = texture2D( tDiffuse, uv );",
+      "add = color = org = texture2D( tDiffuse, uv );",
 
-			"vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );",
-			"sample_dist = dot( vin, vin ) * 2.0;",
+      "vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );",
+      "sample_dist = dot( vin, vin ) * 2.0;",
 
-			"f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;",
+      "f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;",
 
-			"vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );",
+      "vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );",
-			"if( tmp.b < color.b ) color = tmp;",
+      "add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );",
+      "if( tmp.b < color.b ) color = tmp;",
 
-			"color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );",
-			"color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );",
+      "color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );",
+      "color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );",
 
-			"gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );",
+      "gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );",
 
-		"}"
+    "}"
 
 
-	].join("\n")
+  ].join("\n")
 };

--- a/lib/extras/shaders/fresnel_shader.dart
+++ b/lib/extras/shaders/fresnel_shader.dart
@@ -11,69 +11,69 @@ part of three_shaders;
 
 var FresnelShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"mRefractionRatio": { 'type': "f", 'value': 1.02 },
-		"mFresnelBias": { 'type': "f", 'value': 0.1 },
-		"mFresnelPower": { 'type': "f", 'value': 2.0 },
-		"mFresnelScale": { 'type': "f", 'value': 1.0 },
-		"tCube": { 'type': "t", 'value': null }
+    "mRefractionRatio": { 'type': "f", 'value': 1.02 },
+    "mFresnelBias": { 'type': "f", 'value': 0.1 },
+    "mFresnelPower": { 'type': "f", 'value': 2.0 },
+    "mFresnelScale": { 'type': "f", 'value': 1.0 },
+    "tCube": { 'type': "t", 'value': null }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"uniform float mRefractionRatio;",
-		"uniform float mFresnelBias;",
-		"uniform float mFresnelScale;",
-		"uniform float mFresnelPower;",
+    "uniform float mRefractionRatio;",
+    "uniform float mFresnelBias;",
+    "uniform float mFresnelScale;",
+    "uniform float mFresnelPower;",
 
-		"varying vec3 vReflect;",
-		"varying vec3 vRefract[3];",
-		"varying float vReflectionFactor;",
+    "varying vec3 vReflect;",
+    "varying vec3 vRefract[3];",
+    "varying float vReflectionFactor;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-			"vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
+      "vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
+      "vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
 
-			"vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );",
+      "vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );",
 
-			"vec3 I = worldPosition.xyz - cameraPosition;",
+      "vec3 I = worldPosition.xyz - cameraPosition;",
 
-			"vReflect = reflect( I, worldNormal );",
-			"vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );",
-			"vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );",
-			"vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );",
-			"vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );",
+      "vReflect = reflect( I, worldNormal );",
+      "vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );",
+      "vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );",
+      "vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );",
+      "vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );",
 
-			"gl_Position = projectionMatrix * mvPosition;",
+      "gl_Position = projectionMatrix * mvPosition;",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform samplerCube tCube;",
+    "uniform samplerCube tCube;",
 
-		"varying vec3 vReflect;",
-		"varying vec3 vRefract[3];",
-		"varying float vReflectionFactor;",
+    "varying vec3 vReflect;",
+    "varying vec3 vRefract[3];",
+    "varying float vReflectionFactor;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );",
-			"vec4 refractedColor = vec4( 1.0 );",
+      "vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );",
+      "vec4 refractedColor = vec4( 1.0 );",
 
-			"refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;",
-			"refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;",
-			"refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;",
+      "refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;",
+      "refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;",
+      "refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;",
 
-			"gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );",
+      "gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/fxaa_shader.dart
+++ b/lib/extras/shaders/fxaa_shader.dart
@@ -15,79 +15,79 @@ part of three_shaders;
 
 var FXAAShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":   { 'type': "t", 'value': null },
-		"resolution": { 'type': "v2", 'value': new Vector2( 1 / 1024, 1 / 512 )  }
+    "tDiffuse":   { 'type': "t", 'value': null },
+    "resolution": { 'type': "v2", 'value': new Vector2( 1 / 1024, 1 / 512 )  }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"void main() {",
+    "void main() {",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec2 resolution;",
+    "uniform sampler2D tDiffuse;",
+    "uniform vec2 resolution;",
 
-		"#define FXAA_REDUCE_MIN   (1.0/128.0)",
-		"#define FXAA_REDUCE_MUL   (1.0/8.0)",
-		"#define FXAA_SPAN_MAX     8.0",
+    "#define FXAA_REDUCE_MIN   (1.0/128.0)",
+    "#define FXAA_REDUCE_MUL   (1.0/8.0)",
+    "#define FXAA_SPAN_MAX     8.0",
 
-		"void main() {",
+    "void main() {",
 
-			"vec3 rgbNW = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( -1.0, -1.0 ) ) * resolution ).xyz;",
-			"vec3 rgbNE = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( 1.0, -1.0 ) ) * resolution ).xyz;",
-			"vec3 rgbSW = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( -1.0, 1.0 ) ) * resolution ).xyz;",
-			"vec3 rgbSE = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( 1.0, 1.0 ) ) * resolution ).xyz;",
-			"vec4 rgbaM  = texture2D( tDiffuse,  gl_FragCoord.xy  * resolution );",
-			"vec3 rgbM  = rgbaM.xyz;",
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+      "vec3 rgbNW = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( -1.0, -1.0 ) ) * resolution ).xyz;",
+      "vec3 rgbNE = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( 1.0, -1.0 ) ) * resolution ).xyz;",
+      "vec3 rgbSW = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( -1.0, 1.0 ) ) * resolution ).xyz;",
+      "vec3 rgbSE = texture2D( tDiffuse, ( gl_FragCoord.xy + vec2( 1.0, 1.0 ) ) * resolution ).xyz;",
+      "vec4 rgbaM  = texture2D( tDiffuse,  gl_FragCoord.xy  * resolution );",
+      "vec3 rgbM  = rgbaM.xyz;",
+      "vec3 luma = vec3( 0.299, 0.587, 0.114 );",
 
-			"float lumaNW = dot( rgbNW, luma );",
-			"float lumaNE = dot( rgbNE, luma );",
-			"float lumaSW = dot( rgbSW, luma );",
-			"float lumaSE = dot( rgbSE, luma );",
-			"float lumaM  = dot( rgbM,  luma );",
-			"float lumaMin = min( lumaM, min( min( lumaNW, lumaNE ), min( lumaSW, lumaSE ) ) );",
-			"float lumaMax = max( lumaM, max( max( lumaNW, lumaNE) , max( lumaSW, lumaSE ) ) );",
+      "float lumaNW = dot( rgbNW, luma );",
+      "float lumaNE = dot( rgbNE, luma );",
+      "float lumaSW = dot( rgbSW, luma );",
+      "float lumaSE = dot( rgbSE, luma );",
+      "float lumaM  = dot( rgbM,  luma );",
+      "float lumaMin = min( lumaM, min( min( lumaNW, lumaNE ), min( lumaSW, lumaSE ) ) );",
+      "float lumaMax = max( lumaM, max( max( lumaNW, lumaNE) , max( lumaSW, lumaSE ) ) );",
 
-			"vec2 dir;",
-			"dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));",
-			"dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));",
+      "vec2 dir;",
+      "dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));",
+      "dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));",
 
-			"float dirReduce = max( ( lumaNW + lumaNE + lumaSW + lumaSE ) * ( 0.25 * FXAA_REDUCE_MUL ), FXAA_REDUCE_MIN );",
+      "float dirReduce = max( ( lumaNW + lumaNE + lumaSW + lumaSE ) * ( 0.25 * FXAA_REDUCE_MUL ), FXAA_REDUCE_MIN );",
 
-			"float rcpDirMin = 1.0 / ( min( abs( dir.x ), abs( dir.y ) ) + dirReduce );",
-			"dir = min( vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),",
-				  "max( vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),",
-						"dir * rcpDirMin)) * resolution;",
-			"vec4 rgbA = (1.0/2.0) * (",
-        	"texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (1.0/3.0 - 0.5)) +",
-			"texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (2.0/3.0 - 0.5)));",
-    		"vec4 rgbB = rgbA * (1.0/2.0) + (1.0/4.0) * (",
-			"texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (0.0/3.0 - 0.5)) +",
-      		"texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (3.0/3.0 - 0.5)));",
-    		"float lumaB = dot(rgbB, vec4(luma, 0.0));",
+      "float rcpDirMin = 1.0 / ( min( abs( dir.x ), abs( dir.y ) ) + dirReduce );",
+      "dir = min( vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),",
+          "max( vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),",
+            "dir * rcpDirMin)) * resolution;",
+      "vec4 rgbA = (1.0/2.0) * (",
+          "texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (1.0/3.0 - 0.5)) +",
+      "texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (2.0/3.0 - 0.5)));",
+        "vec4 rgbB = rgbA * (1.0/2.0) + (1.0/4.0) * (",
+      "texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (0.0/3.0 - 0.5)) +",
+          "texture2D(tDiffuse,  gl_FragCoord.xy  * resolution + dir * (3.0/3.0 - 0.5)));",
+        "float lumaB = dot(rgbB, vec4(luma, 0.0));",
 
-			"if ( ( lumaB < lumaMin ) || ( lumaB > lumaMax ) ) {",
+      "if ( ( lumaB < lumaMin ) || ( lumaB > lumaMax ) ) {",
 
-				"gl_FragColor = rgbA;",
+        "gl_FragColor = rgbA;",
 
-			"} else {",
-				"gl_FragColor = rgbB;",
+      "} else {",
+        "gl_FragColor = rgbB;",
 
-			"}",
+      "}",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/horizontal_blur_shader.dart
+++ b/lib/extras/shaders/horizontal_blur_shader.dart
@@ -17,51 +17,51 @@ part of three_shaders;
 
 var HorizontalBlurShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"h":        { 'type': "f", 'value': 1.0 / 512.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "h":        { 'type': "f", 'value': 1.0 / 512.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float h;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float h;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 sum = vec4( 0.0 );",
+      "vec4 sum = vec4( 0.0 );",
 
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;",
 
-			"gl_FragColor = sum;",
+      "gl_FragColor = sum;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/horizontal_tilt_shift_shader.dart
+++ b/lib/extras/shaders/horizontal_tilt_shift_shader.dart
@@ -16,55 +16,55 @@ part of three_shaders;
 
 var HorizontalTiltShiftShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"h":        { 'type': "f", 'value': 1.0 / 512.0 },
-		"r":        { 'type': "f", 'value': 0.35 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "h":        { 'type': "f", 'value': 1.0 / 512.0 },
+    "r":        { 'type': "f", 'value': 0.35 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float h;",
-		"uniform float r;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float h;",
+    "uniform float r;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 sum = vec4( 0.0 );",
+      "vec4 sum = vec4( 0.0 );",
 
-			"float hh = h * abs( r - vUv.y );",
+      "float hh = h * abs( r - vUv.y );",
 
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;",
 
-			"gl_FragColor = sum;",
+      "gl_FragColor = sum;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/hue_saturation_shader.dart
+++ b/lib/extras/shaders/hue_saturation_shader.dart
@@ -14,61 +14,61 @@ part of three_shaders;
 
 var HueSaturationShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":   { 'type': "t", 'value': null },
-		"hue":        { 'type': "f", 'value': 0 },
-		"saturation": { 'type': "f", 'value': 0 }
+    "tDiffuse":   { 'type': "t", 'value': null },
+    "hue":        { 'type': "f", 'value': 0 },
+    "saturation": { 'type': "f", 'value': 0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
+      "vUv = uv;",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float hue;",
-		"uniform float saturation;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float hue;",
+    "uniform float saturation;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"gl_FragColor = texture2D( tDiffuse, vUv );",
+      "gl_FragColor = texture2D( tDiffuse, vUv );",
 
-			// hue
-			"float angle = hue * 3.14159265;",
-			"float s = sin(angle), c = cos(angle);",
-			"vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;",
-			"float len = length(gl_FragColor.rgb);",
-			"gl_FragColor.rgb = vec3(",
-				"dot(gl_FragColor.rgb, weights.xyz),",
-				"dot(gl_FragColor.rgb, weights.zxy),",
-				"dot(gl_FragColor.rgb, weights.yzx)",
-			");",
+      // hue
+      "float angle = hue * 3.14159265;",
+      "float s = sin(angle), c = cos(angle);",
+      "vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;",
+      "float len = length(gl_FragColor.rgb);",
+      "gl_FragColor.rgb = vec3(",
+        "dot(gl_FragColor.rgb, weights.xyz),",
+        "dot(gl_FragColor.rgb, weights.zxy),",
+        "dot(gl_FragColor.rgb, weights.yzx)",
+      ");",
 
-			// saturation
-			"float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;",
-			"if (saturation > 0.0) {",
-				"gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));",
-			"} else {",
-				"gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);",
-			"}",
+      // saturation
+      "float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;",
+      "if (saturation > 0.0) {",
+        "gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));",
+      "} else {",
+        "gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);",
+      "}",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/kaleido_shader.dart
+++ b/lib/extras/shaders/kaleido_shader.dart
@@ -17,49 +17,49 @@ part of three_shaders;
 
 var KaleidoShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"sides":    { 'type': "f", 'value': 6.0 },
-		"angle":    { 'type': "f", 'value': 0.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "sides":    { 'type': "f", 'value': 6.0 },
+    "angle":    { 'type': "f", 'value': 0.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float sides;",
-		"uniform float angle;",
-		
-		"varying vec2 vUv;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float sides;",
+    "uniform float angle;",
+    
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 p = vUv - 0.5;",
-			"float r = length(p);",
-			"float a = atan(p.y, p.x) + angle;",
-			"float tau = 2. * 3.1416 ;",
-			"a = mod(a, tau/sides);",
-			"a = abs(a - tau/sides/2.) ;",
-			"p = r * vec2(cos(a), sin(a));",
-			"vec4 color = texture2D(tDiffuse, p + 0.5);",
-			"gl_FragColor = color;",
+      "vec2 p = vUv - 0.5;",
+      "float r = length(p);",
+      "float a = atan(p.y, p.x) + angle;",
+      "float tau = 2. * 3.1416 ;",
+      "a = mod(a, tau/sides);",
+      "a = abs(a - tau/sides/2.) ;",
+      "p = r * vec2(cos(a), sin(a));",
+      "vec4 color = texture2D(tDiffuse, p + 0.5);",
+      "gl_FragColor = color;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/luminosity_shader.dart
+++ b/lib/extras/shaders/luminosity_shader.dart
@@ -12,44 +12,44 @@ part of three_shaders;
 
 var LuminosityShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null }
+    "tDiffuse": { 'type': "t", 'value': null }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
+      "vUv = uv;",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 texel = texture2D( tDiffuse, vUv );",
+      "vec4 texel = texture2D( tDiffuse, vUv );",
 
-			"vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+      "vec3 luma = vec3( 0.299, 0.587, 0.114 );",
 
-			"float v = dot( texel.xyz, luma );",
+      "float v = dot( texel.xyz, luma );",
 
-			"gl_FragColor = vec4( v, v, v, texel.w );",
+      "gl_FragColor = vec4( v, v, v, texel.w );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/mirror_shader.dart
+++ b/lib/extras/shaders/mirror_shader.dart
@@ -14,50 +14,50 @@ part of three_shaders;
 
 var MirrorShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"side":     { 'type': "i", 'value': 1 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "side":     { 'type': "i", 'value': 1 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform int side;",
-		
-		"varying vec2 vUv;",
+    "uniform sampler2D tDiffuse;",
+    "uniform int side;",
+    
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 p = vUv;",
-			"if (side == 0){",
-				"if (p.x > 0.5) p.x = 1.0 - p.x;",
-			"}else if (side == 1){",
-				"if (p.x < 0.5) p.x = 1.0 - p.x;",
-			"}else if (side == 2){",
-				"if (p.y < 0.5) p.y = 1.0 - p.y;",
-			"}else if (side == 3){",
-				"if (p.y > 0.5) p.y = 1.0 - p.y;",
-			"} ",
-			"vec4 color = texture2D(tDiffuse, p);",
-			"gl_FragColor = color;",
+      "vec2 p = vUv;",
+      "if (side == 0){",
+        "if (p.x > 0.5) p.x = 1.0 - p.x;",
+      "}else if (side == 1){",
+        "if (p.x < 0.5) p.x = 1.0 - p.x;",
+      "}else if (side == 2){",
+        "if (p.y < 0.5) p.y = 1.0 - p.y;",
+      "}else if (side == 3){",
+        "if (p.y > 0.5) p.y = 1.0 - p.y;",
+      "} ",
+      "vec4 color = texture2D(tDiffuse, p);",
+      "gl_FragColor = color;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/normal_map_shader.dart
+++ b/lib/extras/shaders/normal_map_shader.dart
@@ -12,47 +12,47 @@ part of three_shaders;
 
 var NormalMapShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"heightMap":  { 'type': "t", 'value': null },
-		"resolution": { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
-		"scale":      { 'type': "v2", 'value': new Vector2( 1.0, 1.0 ) },
-		"height":     { 'type': "f", 'value': 0.05 }
+    "heightMap":  { 'type': "t", 'value': null },
+    "resolution": { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
+    "scale":      { 'type': "v2", 'value': new Vector2( 1.0, 1.0 ) },
+    "height":     { 'type': "f", 'value': 0.05 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float height;",
-		"uniform vec2 resolution;",
-		"uniform sampler2D heightMap;",
+    "uniform float height;",
+    "uniform vec2 resolution;",
+    "uniform sampler2D heightMap;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"float val = texture2D( heightMap, vUv ).x;",
+      "float val = texture2D( heightMap, vUv ).x;",
 
-			"float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;",
-			"float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;",
+      "float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;",
+      "float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;",
 
-			"gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );",
+      "gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/parallax_shader.dart
+++ b/lib/extras/shaders/parallax_shader.dart
@@ -6,178 +6,178 @@ part of three_shaders;
 //   http://mmikkelsen3d.blogspot.sk/2012/02/parallaxpoc-mapping-and-no-tangent.html
 
 var ParallaxShader = {
-	// Ordered from fastest to best quality.
-	'modes': {
-		'none':  'NO_PARALLAX',
-		'basic': 'USE_BASIC_PARALLAX',
-		'steep': 'USE_STEEP_PARALLAX',
-		'occlusion': 'USE_OCLUSION_PARALLAX', // a.k.a. POM
-		'relief': 'USE_RELIEF_PARALLAX',
-	},
+  // Ordered from fastest to best quality.
+  'modes': {
+    'none':  'NO_PARALLAX',
+    'basic': 'USE_BASIC_PARALLAX',
+    'steep': 'USE_STEEP_PARALLAX',
+    'occlusion': 'USE_OCLUSION_PARALLAX', // a.k.a. POM
+    'relief': 'USE_RELIEF_PARALLAX',
+  },
 
-	'uniforms': {
-		"bumpMap": { 'type': "t", 'value': null },
-		"map": { 'type': "t", 'value': null },
-		"parallaxScale": { 'type': "f", 'value': null },
-		"parallaxMinLayers": { 'type': "f", 'value': null },
-		"parallaxMaxLayers": { 'type': "f", 'value': null }
-	},
+  'uniforms': {
+    "bumpMap": { 'type': "t", 'value': null },
+    "map": { 'type': "t", 'value': null },
+    "parallaxScale": { 'type': "f", 'value': null },
+    "parallaxMinLayers": { 'type': "f", 'value': null },
+    "parallaxMaxLayers": { 'type': "f", 'value': null }
+  },
 
-	'vertexShader': [
-		"varying vec2 vUv;",
-		"varying vec3 vViewPosition;",
-		"varying vec3 vNormal;",
+  'vertexShader': [
+    "varying vec2 vUv;",
+    "varying vec3 vViewPosition;",
+    "varying vec3 vNormal;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-			"vViewPosition = -mvPosition.xyz;",
-			"vNormal = normalize( normalMatrix * normal );",
-			"gl_Position = projectionMatrix * mvPosition;",
+      "vUv = uv;",
+      "vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
+      "vViewPosition = -mvPosition.xyz;",
+      "vNormal = normalize( normalMatrix * normal );",
+      "gl_Position = projectionMatrix * mvPosition;",
 
-		"}"
+    "}"
 
   ].join( "\n" ),
 
-	'fragmentShader': [
-		"uniform sampler2D bumpMap;",
-		"uniform sampler2D map;",
+  'fragmentShader': [
+    "uniform sampler2D bumpMap;",
+    "uniform sampler2D map;",
 
-		"uniform float parallaxScale;",
-		"uniform float parallaxMinLayers;",
-		"uniform float parallaxMaxLayers;",
+    "uniform float parallaxScale;",
+    "uniform float parallaxMinLayers;",
+    "uniform float parallaxMaxLayers;",
 
-		"varying vec2 vUv;",
-		"varying vec3 vViewPosition;",
-		"varying vec3 vNormal;",
+    "varying vec2 vUv;",
+    "varying vec3 vViewPosition;",
+    "varying vec3 vNormal;",
 
-		"#ifdef USE_BASIC_PARALLAX",
+    "#ifdef USE_BASIC_PARALLAX",
 
-			"vec2 parallaxMap( in vec3 V ) {",
+      "vec2 parallaxMap( in vec3 V ) {",
 
-				"float initialHeight = texture2D( bumpMap, vUv ).r;",
+        "float initialHeight = texture2D( bumpMap, vUv ).r;",
 
-				// No Offset Limitting: messy, floating output at grazing angles.
-				//"vec2 texCoordOffset = parallaxScale * V.xy / V.z * initialHeight;",
+        // No Offset Limitting: messy, floating output at grazing angles.
+        //"vec2 texCoordOffset = parallaxScale * V.xy / V.z * initialHeight;",
 
-				// Offset Limiting
-				"vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;",
-				"return vUv - texCoordOffset;",
+        // Offset Limiting
+        "vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;",
+        "return vUv - texCoordOffset;",
 
-			"}",
+      "}",
 
-		"#else",
+    "#else",
 
-			"vec2 parallaxMap( in vec3 V ) {",
+      "vec2 parallaxMap( in vec3 V ) {",
 
-				// Determine number of layers from angle between V and N
-				"float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );",
+        // Determine number of layers from angle between V and N
+        "float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );",
 
-				"float layerHeight = 1.0 / numLayers;",
-				"float currentLayerHeight = 0.0;",
-				// Shift of texture coordinates for each iteration
-				"vec2 dtex = parallaxScale * V.xy / V.z / numLayers;",
+        "float layerHeight = 1.0 / numLayers;",
+        "float currentLayerHeight = 0.0;",
+        // Shift of texture coordinates for each iteration
+        "vec2 dtex = parallaxScale * V.xy / V.z / numLayers;",
 
-				"vec2 currentTextureCoords = vUv;",
+        "vec2 currentTextureCoords = vUv;",
 
-				"float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
+        "float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
 
-				// while ( heightFromTexture > currentLayerHeight )
-				"for ( int i = 0; i == 0; i += 0 ) {",
-					"if ( heightFromTexture <= currentLayerHeight ) {",
-						"break;",
-					"}",
-					"currentLayerHeight += layerHeight;",
-					// Shift texture coordinates along vector V
-					"currentTextureCoords -= dtex;",
-					"heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
-				"}",
+        // while ( heightFromTexture > currentLayerHeight )
+        "for ( int i = 0; i == 0; i += 0 ) {",
+          "if ( heightFromTexture <= currentLayerHeight ) {",
+            "break;",
+          "}",
+          "currentLayerHeight += layerHeight;",
+          // Shift texture coordinates along vector V
+          "currentTextureCoords -= dtex;",
+          "heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
+        "}",
 
-				"#ifdef USE_STEEP_PARALLAX",
+        "#ifdef USE_STEEP_PARALLAX",
 
-					"return currentTextureCoords;",
+          "return currentTextureCoords;",
 
-				"#elif defined( USE_RELIEF_PARALLAX )",
+        "#elif defined( USE_RELIEF_PARALLAX )",
 
-					"vec2 deltaTexCoord = dtex / 2.0;",
-					"float deltaHeight = layerHeight / 2.0;",
+          "vec2 deltaTexCoord = dtex / 2.0;",
+          "float deltaHeight = layerHeight / 2.0;",
 
-					// Return to the mid point of previous layer
-					"currentTextureCoords += deltaTexCoord;",
-					"currentLayerHeight -= deltaHeight;",
+          // Return to the mid point of previous layer
+          "currentTextureCoords += deltaTexCoord;",
+          "currentLayerHeight -= deltaHeight;",
 
-					// Binary search to increase precision of Steep Parallax Mapping
-					"const int numSearches = 5;",
-					"for ( int i = 0; i < numSearches; i += 1 ) {",
+          // Binary search to increase precision of Steep Parallax Mapping
+          "const int numSearches = 5;",
+          "for ( int i = 0; i < numSearches; i += 1 ) {",
 
-						"deltaTexCoord /= 2.0;",
-						"deltaHeight /= 2.0;",
-						"heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
-						// Shift along or against vector V
-						"if( heightFromTexture > currentLayerHeight ) {", // Below the surface
+            "deltaTexCoord /= 2.0;",
+            "deltaHeight /= 2.0;",
+            "heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
+            // Shift along or against vector V
+            "if( heightFromTexture > currentLayerHeight ) {", // Below the surface
 
-							"currentTextureCoords -= deltaTexCoord;",
-							"currentLayerHeight += deltaHeight;",
+              "currentTextureCoords -= deltaTexCoord;",
+              "currentLayerHeight += deltaHeight;",
 
-						"} else {", // above the surface
+            "} else {", // above the surface
 
-							"currentTextureCoords += deltaTexCoord;",
-							"currentLayerHeight -= deltaHeight;",
+              "currentTextureCoords += deltaTexCoord;",
+              "currentLayerHeight -= deltaHeight;",
 
-						"}",
+            "}",
 
-					"}",
-					"return currentTextureCoords;",
+          "}",
+          "return currentTextureCoords;",
 
-				"#elif defined( USE_OCLUSION_PARALLAX )",
+        "#elif defined( USE_OCLUSION_PARALLAX )",
 
-					"vec2 prevTCoords = currentTextureCoords + dtex;",
+          "vec2 prevTCoords = currentTextureCoords + dtex;",
 
-					// Heights for linear interpolation
-					"float nextH = heightFromTexture - currentLayerHeight;",
-					"float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;",
+          // Heights for linear interpolation
+          "float nextH = heightFromTexture - currentLayerHeight;",
+          "float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;",
 
-					// Proportions for linear interpolation
-					"float weight = nextH / ( nextH - prevH );",
+          // Proportions for linear interpolation
+          "float weight = nextH / ( nextH - prevH );",
 
-					// Interpolation of texture coordinates
-					"return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );",
+          // Interpolation of texture coordinates
+          "return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );",
 
-				"#else", // NO_PARALLAX
+        "#else", // NO_PARALLAX
 
-					"return vUv;",
+          "return vUv;",
 
-				"#endif",
+        "#endif",
 
-			"}",
-		"#endif",
+      "}",
+    "#endif",
 
-		"vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {",
+    "vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {",
 
- 			"vec2 texDx = dFdx( vUv );",
-			"vec2 texDy = dFdy( vUv );",
+       "vec2 texDx = dFdx( vUv );",
+      "vec2 texDy = dFdy( vUv );",
 
-			"vec3 vSigmaX = dFdx( surfPosition );",
-			"vec3 vSigmaY = dFdy( surfPosition );",
-			"vec3 vR1 = cross( vSigmaY, surfNormal );",
-			"vec3 vR2 = cross( surfNormal, vSigmaX );",
-			"float fDet = dot( vSigmaX, vR1 );",
+      "vec3 vSigmaX = dFdx( surfPosition );",
+      "vec3 vSigmaY = dFdy( surfPosition );",
+      "vec3 vR1 = cross( vSigmaY, surfNormal );",
+      "vec3 vR2 = cross( surfNormal, vSigmaX );",
+      "float fDet = dot( vSigmaX, vR1 );",
 
-			"vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );",
-			"vec3 vProjVtex;",
-			"vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;",
-			"vProjVtex.z = dot( surfNormal, viewPosition );",
+      "vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );",
+      "vec3 vProjVtex;",
+      "vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;",
+      "vProjVtex.z = dot( surfNormal, viewPosition );",
 
-			"return parallaxMap( vProjVtex );",
-		"}",
+      "return parallaxMap( vProjVtex );",
+    "}",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );",
-			"gl_FragColor = texture2D( map, mapUv );",
+      "vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );",
+      "gl_FragColor = texture2D( map, mapUv );",
 
-		"}",
+    "}",
 
   ].join( "\n" )
 

--- a/lib/extras/shaders/rgb_shift_shader.dart
+++ b/lib/extras/shaders/rgb_shift_shader.dart
@@ -17,45 +17,45 @@ part of three_shaders;
 
 var RGBShiftShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"amount":   { 'type': "f", 'value': 0.005 },
-		"angle":    { 'type': "f", 'value': 0.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "amount":   { 'type': "f", 'value': 0.005 },
+    "angle":    { 'type': "f", 'value': 0.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float amount;",
-		"uniform float angle;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float amount;",
+    "uniform float angle;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 offset = amount * vec2( cos(angle), sin(angle));",
-			"vec4 cr = texture2D(tDiffuse, vUv + offset);",
-			"vec4 cga = texture2D(tDiffuse, vUv);",
-			"vec4 cb = texture2D(tDiffuse, vUv - offset);",
-			"gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
+      "vec2 offset = amount * vec2( cos(angle), sin(angle));",
+      "vec4 cr = texture2D(tDiffuse, vUv + offset);",
+      "vec4 cga = texture2D(tDiffuse, vUv);",
+      "vec4 cb = texture2D(tDiffuse, vUv - offset);",
+      "gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/sepia_shader.dart
+++ b/lib/extras/shaders/sepia_shader.dart
@@ -13,47 +13,47 @@ part of three_shaders;
 
 var SepiaShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"amount":   { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "amount":   { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float amount;",
+    "uniform float amount;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 color = texture2D( tDiffuse, vUv );",
-			"vec3 c = color.rgb;",
+      "vec4 color = texture2D( tDiffuse, vUv );",
+      "vec3 c = color.rgb;",
 
-			"color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );",
-			"color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );",
-			"color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );",
+      "color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );",
+      "color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );",
+      "color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );",
 
-			"gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );",
+      "gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/ssao_shader.dart
+++ b/lib/extras/shaders/ssao_shader.dart
@@ -18,218 +18,218 @@ part of three_shaders;
 
 var SSAOShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse":     { 'type': "t", 'value': null },
-		"tDepth":       { 'type': "t", 'value': null },
-		"size":         { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
-		"cameraNear":   { 'type': "f", 'value': 1 },
-		"cameraFar":    { 'type': "f", 'value': 100 },
-		"onlyAO":       { 'type': "i", 'value': 0 },
-		"aoClamp":      { 'type': "f", 'value': 0.5 },
-		"lumInfluence": { 'type': "f", 'value': 0.5 }
+    "tDiffuse":     { 'type': "t", 'value': null },
+    "tDepth":       { 'type': "t", 'value': null },
+    "size":         { 'type': "v2", 'value': new Vector2( 512.0, 512.0 ) },
+    "cameraNear":   { 'type': "f", 'value': 1 },
+    "cameraFar":    { 'type': "f", 'value': 100 },
+    "onlyAO":       { 'type': "i", 'value': 0 },
+    "aoClamp":      { 'type': "f", 'value': 0.5 },
+    "lumInfluence": { 'type': "f", 'value': 0.5 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
+      "vUv = uv;",
 
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float cameraNear;",
-		"uniform float cameraFar;",
+    "uniform float cameraNear;",
+    "uniform float cameraFar;",
 
-		"uniform bool onlyAO;",      // use only ambient occlusion pass?
+    "uniform bool onlyAO;",      // use only ambient occlusion pass?
 
-		"uniform vec2 size;",        // texture width, height
-		"uniform float aoClamp;",    // depth clamp - reduces haloing at screen edges
+    "uniform vec2 size;",        // texture width, height
+    "uniform float aoClamp;",    // depth clamp - reduces haloing at screen edges
 
-		"uniform float lumInfluence;",  // how much luminance affects occlusion
+    "uniform float lumInfluence;",  // how much luminance affects occlusion
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tDepth;",
+    "uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDepth;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		// "#define PI 3.14159265",
-		"#define DL 2.399963229728653",  // PI * ( 3.0 - sqrt( 5.0 ) )
-		"#define EULER 2.718281828459045",
+    // "#define PI 3.14159265",
+    "#define DL 2.399963229728653",  // PI * ( 3.0 - sqrt( 5.0 ) )
+    "#define EULER 2.718281828459045",
 
-		// helpers
+    // helpers
 
-		"float width = size.x;",   // texture width
-		"float height = size.y;",  // texture height
+    "float width = size.x;",   // texture width
+    "float height = size.y;",  // texture height
 
-		"float cameraFarPlusNear = cameraFar + cameraNear;",
-		"float cameraFarMinusNear = cameraFar - cameraNear;",
-		"float cameraCoef = 2.0 * cameraNear;",
+    "float cameraFarPlusNear = cameraFar + cameraNear;",
+    "float cameraFarMinusNear = cameraFar - cameraNear;",
+    "float cameraCoef = 2.0 * cameraNear;",
 
-		// user variables
+    // user variables
 
-		"const int samples = 8;",     // ao sample count
-		"const float radius = 5.0;",  // ao radius
+    "const int samples = 8;",     // ao sample count
+    "const float radius = 5.0;",  // ao radius
 
-		"const bool useNoise = false;",      // use noise instead of pattern for sample dithering
-		"const float noiseAmount = 0.0003;", // dithering amount
+    "const bool useNoise = false;",      // use noise instead of pattern for sample dithering
+    "const float noiseAmount = 0.0003;", // dithering amount
 
-		"const float diffArea = 0.4;",   // self-shadowing reduction
-		"const float gDisplace = 0.4;",  // gauss bell center
+    "const float diffArea = 0.4;",   // self-shadowing reduction
+    "const float gDisplace = 0.4;",  // gauss bell center
 
 
-		// RGBA depth
+    // RGBA depth
 
-		"float unpackDepth( const in vec4 rgba_depth ) {",
+    "float unpackDepth( const in vec4 rgba_depth ) {",
 
-			"const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
-			"float depth = dot( rgba_depth, bit_shift );",
-			"return depth;",
+      "const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
+      "float depth = dot( rgba_depth, bit_shift );",
+      "return depth;",
 
-		"}",
+    "}",
 
-		// generating noise / pattern texture for dithering
+    // generating noise / pattern texture for dithering
 
-		"vec2 rand( const vec2 coord ) {",
+    "vec2 rand( const vec2 coord ) {",
 
-			"vec2 noise;",
+      "vec2 noise;",
 
-			"if ( useNoise ) {",
+      "if ( useNoise ) {",
 
-				"float nx = dot ( coord, vec2( 12.9898, 78.233 ) );",
-				"float ny = dot ( coord, vec2( 12.9898, 78.233 ) * 2.0 );",
+        "float nx = dot ( coord, vec2( 12.9898, 78.233 ) );",
+        "float ny = dot ( coord, vec2( 12.9898, 78.233 ) * 2.0 );",
 
-				"noise = clamp( fract ( 43758.5453 * sin( vec2( nx, ny ) ) ), 0.0, 1.0 );",
+        "noise = clamp( fract ( 43758.5453 * sin( vec2( nx, ny ) ) ), 0.0, 1.0 );",
 
-			"} else {",
+      "} else {",
 
-				"float ff = fract( 1.0 - coord.s * ( width / 2.0 ) );",
-				"float gg = fract( coord.t * ( height / 2.0 ) );",
+        "float ff = fract( 1.0 - coord.s * ( width / 2.0 ) );",
+        "float gg = fract( coord.t * ( height / 2.0 ) );",
 
-				"noise = vec2( 0.25, 0.75 ) * vec2( ff ) + vec2( 0.75, 0.25 ) * gg;",
+        "noise = vec2( 0.25, 0.75 ) * vec2( ff ) + vec2( 0.75, 0.25 ) * gg;",
 
-			"}",
+      "}",
 
-			"return ( noise * 2.0  - 1.0 ) * noiseAmount;",
+      "return ( noise * 2.0  - 1.0 ) * noiseAmount;",
 
-		"}",
+    "}",
 
-		"float readDepth( const in vec2 coord ) {",
+    "float readDepth( const in vec2 coord ) {",
 
-			// "return ( 2.0 * cameraNear ) / ( cameraFar + cameraNear - unpackDepth( texture2D( tDepth, coord ) ) * ( cameraFar - cameraNear ) );",
-			"return cameraCoef / ( cameraFarPlusNear - unpackDepth( texture2D( tDepth, coord ) ) * cameraFarMinusNear );",
+      // "return ( 2.0 * cameraNear ) / ( cameraFar + cameraNear - unpackDepth( texture2D( tDepth, coord ) ) * ( cameraFar - cameraNear ) );",
+      "return cameraCoef / ( cameraFarPlusNear - unpackDepth( texture2D( tDepth, coord ) ) * cameraFarMinusNear );",
 
 
-		"}",
+    "}",
 
-		"float compareDepths( const in float depth1, const in float depth2, inout int far ) {",
+    "float compareDepths( const in float depth1, const in float depth2, inout int far ) {",
 
-			"float garea = 2.0;",                         // gauss bell width
-			"float diff = ( depth1 - depth2 ) * 100.0;",  // depth difference (0-100)
+      "float garea = 2.0;",                         // gauss bell width
+      "float diff = ( depth1 - depth2 ) * 100.0;",  // depth difference (0-100)
 
-			// reduce left bell width to avoid self-shadowing
+      // reduce left bell width to avoid self-shadowing
 
-			"if ( diff < gDisplace ) {",
+      "if ( diff < gDisplace ) {",
 
-				"garea = diffArea;",
+        "garea = diffArea;",
 
-			"} else {",
+      "} else {",
 
-				"far = 1;",
+        "far = 1;",
 
-			"}",
+      "}",
 
-			"float dd = diff - gDisplace;",
-			"float gauss = pow( EULER, -2.0 * dd * dd / ( garea * garea ) );",
-			"return gauss;",
+      "float dd = diff - gDisplace;",
+      "float gauss = pow( EULER, -2.0 * dd * dd / ( garea * garea ) );",
+      "return gauss;",
 
-		"}",
+    "}",
 
-		"float calcAO( float depth, float dw, float dh ) {",
+    "float calcAO( float depth, float dw, float dh ) {",
 
-			"float dd = radius - depth * radius;",
-			"vec2 vv = vec2( dw, dh );",
+      "float dd = radius - depth * radius;",
+      "vec2 vv = vec2( dw, dh );",
 
-			"vec2 coord1 = vUv + dd * vv;",
-			"vec2 coord2 = vUv - dd * vv;",
+      "vec2 coord1 = vUv + dd * vv;",
+      "vec2 coord2 = vUv - dd * vv;",
 
-			"float temp1 = 0.0;",
-			"float temp2 = 0.0;",
+      "float temp1 = 0.0;",
+      "float temp2 = 0.0;",
 
-			"int far = 0;",
-			"temp1 = compareDepths( depth, readDepth( coord1 ), far );",
+      "int far = 0;",
+      "temp1 = compareDepths( depth, readDepth( coord1 ), far );",
 
-			// DEPTH EXTRAPOLATION
+      // DEPTH EXTRAPOLATION
 
-			"if ( far > 0 ) {",
+      "if ( far > 0 ) {",
 
-				"temp2 = compareDepths( readDepth( coord2 ), depth, far );",
-				"temp1 += ( 1.0 - temp1 ) * temp2;",
+        "temp2 = compareDepths( readDepth( coord2 ), depth, far );",
+        "temp1 += ( 1.0 - temp1 ) * temp2;",
 
-			"}",
+      "}",
 
-			"return temp1;",
+      "return temp1;",
 
-		"}",
+    "}",
 
-		"void main() {",
+    "void main() {",
 
-			"vec2 noise = rand( vUv );",
-			"float depth = readDepth( vUv );",
+      "vec2 noise = rand( vUv );",
+      "float depth = readDepth( vUv );",
 
-			"float tt = clamp( depth, aoClamp, 1.0 );",
+      "float tt = clamp( depth, aoClamp, 1.0 );",
 
-			"float w = ( 1.0 / width )  / tt + ( noise.x * ( 1.0 - noise.x ) );",
-			"float h = ( 1.0 / height ) / tt + ( noise.y * ( 1.0 - noise.y ) );",
+      "float w = ( 1.0 / width )  / tt + ( noise.x * ( 1.0 - noise.x ) );",
+      "float h = ( 1.0 / height ) / tt + ( noise.y * ( 1.0 - noise.y ) );",
 
-			"float ao = 0.0;",
+      "float ao = 0.0;",
 
-			"float dz = 1.0 / float( samples );",
-			"float z = 1.0 - dz / 2.0;",
-			"float l = 0.0;",
+      "float dz = 1.0 / float( samples );",
+      "float z = 1.0 - dz / 2.0;",
+      "float l = 0.0;",
 
-			"for ( int i = 0; i <= samples; i ++ ) {",
+      "for ( int i = 0; i <= samples; i ++ ) {",
 
-				"float r = sqrt( 1.0 - z );",
+        "float r = sqrt( 1.0 - z );",
 
-				"float pw = cos( l ) * r;",
-				"float ph = sin( l ) * r;",
-				"ao += calcAO( depth, pw * w, ph * h );",
-				"z = z - dz;",
-				"l = l + DL;",
+        "float pw = cos( l ) * r;",
+        "float ph = sin( l ) * r;",
+        "ao += calcAO( depth, pw * w, ph * h );",
+        "z = z - dz;",
+        "l = l + DL;",
 
-			"}",
+      "}",
 
-			"ao /= float( samples );",
-			"ao = 1.0 - ao;",
+      "ao /= float( samples );",
+      "ao = 1.0 - ao;",
 
-			"vec3 color = texture2D( tDiffuse, vUv ).rgb;",
+      "vec3 color = texture2D( tDiffuse, vUv ).rgb;",
 
-			"vec3 lumcoeff = vec3( 0.299, 0.587, 0.114 );",
-			"float lum = dot( color.rgb, lumcoeff );",
-			"vec3 luminance = vec3( lum );",
+      "vec3 lumcoeff = vec3( 0.299, 0.587, 0.114 );",
+      "float lum = dot( color.rgb, lumcoeff );",
+      "vec3 luminance = vec3( lum );",
 
-			"vec3 final = vec3( color * mix( vec3( ao ), vec3( 1.0 ), luminance * lumInfluence ) );",  // mix( color * ao, white, luminance )
+      "vec3 final = vec3( color * mix( vec3( ao ), vec3( 1.0 ), luminance * lumInfluence ) );",  // mix( color * ao, white, luminance )
 
-			"if ( onlyAO ) {",
+      "if ( onlyAO ) {",
 
-				"final = vec3( mix( vec3( ao ), vec3( 1.0 ), luminance * lumInfluence ) );",  // ambient occlusion only
+        "final = vec3( mix( vec3( ao ), vec3( 1.0 ), luminance * lumInfluence ) );",  // ambient occlusion only
 
-			"}",
+      "}",
 
-			"gl_FragColor = vec4( final, 1.0 );",
+      "gl_FragColor = vec4( final, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/technicolor_shader.dart
+++ b/lib/extras/shaders/technicolor_shader.dart
@@ -14,39 +14,39 @@ part of three_shaders;
 
 var TechnicolorShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
+    "tDiffuse": { 'type': "t", 'value': null },
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"varying vec2 vUv;",
+    "uniform sampler2D tDiffuse;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
-			"vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);",
+      "vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
+      "vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);",
 
-			"gl_FragColor = newTex;",
+      "gl_FragColor = newTex;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/triangle_blur_shader.dart
+++ b/lib/extras/shaders/triangle_blur_shader.dart
@@ -17,67 +17,67 @@ part of three_shaders;
 
 var TriangleBlurShader = {
 
-	'uniforms' : {
+  'uniforms' : {
 
-		"texture": { 'type': "t", 'value': null },
-		"delta":   { 'type': "v2", 'value':new Vector2( 1.0, 1.0 )  }
+    "texture": { 'type': "t", 'value': null },
+    "delta":   { 'type': "v2", 'value':new Vector2( 1.0, 1.0 )  }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"#define ITERATIONS 10.0",
+    "#define ITERATIONS 10.0",
 
-		"uniform sampler2D texture;",
-		"uniform vec2 delta;",
+    "uniform sampler2D texture;",
+    "uniform vec2 delta;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"float random( vec3 scale, float seed ) {",
+    "float random( vec3 scale, float seed ) {",
 
-			// use the fragment position for a different seed per-pixel
+      // use the fragment position for a different seed per-pixel
 
-			"return fract( sin( dot( gl_FragCoord.xyz + seed, scale ) ) * 43758.5453 + seed );",
+      "return fract( sin( dot( gl_FragCoord.xyz + seed, scale ) ) * 43758.5453 + seed );",
 
-		"}",
+    "}",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 color = vec4( 0.0 );",
+      "vec4 color = vec4( 0.0 );",
 
-			"float total = 0.0;",
+      "float total = 0.0;",
 
-			// randomize the lookup 'value's to hide the fixed number of samples
+      // randomize the lookup 'value's to hide the fixed number of samples
 
-			"float offset = random( vec3( 12.9898, 78.233, 151.7182 ), 0.0 );",
+      "float offset = random( vec3( 12.9898, 78.233, 151.7182 ), 0.0 );",
 
-			"for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {",
+      "for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {",
 
-				"float percent = ( t + offset - 0.5 ) / ITERATIONS;",
-				"float weight = 1.0 - abs( percent );",
+        "float percent = ( t + offset - 0.5 ) / ITERATIONS;",
+        "float weight = 1.0 - abs( percent );",
 
-				"color += texture2D( texture, vUv + delta * percent ) * weight;",
-				"total += weight;",
+        "color += texture2D( texture, vUv + delta * percent ) * weight;",
+        "total += weight;",
 
-			"}",
+      "}",
 
-			"gl_FragColor = color / total;",
+      "gl_FragColor = color / total;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/unpack_depth_rgba_shader.dart
+++ b/lib/extras/shaders/unpack_depth_rgba_shader.dart
@@ -12,51 +12,51 @@ part of three_shaders;
 
 var UnpackDepthRGBAShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"opacity":  { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "opacity":  { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float opacity;",
+    "uniform float opacity;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		// RGBA depth
+    // RGBA depth
 
-		"float unpackDepth( const in vec4 rgba_depth ) {",
+    "float unpackDepth( const in vec4 rgba_depth ) {",
 
-			"const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
-			"float depth = dot( rgba_depth, bit_shift );",
-			"return depth;",
+      "const vec4 bit_shift = vec4( 1.0 / ( 256.0 * 256.0 * 256.0 ), 1.0 / ( 256.0 * 256.0 ), 1.0 / 256.0, 1.0 );",
+      "float depth = dot( rgba_depth, bit_shift );",
+      "return depth;",
 
-		"}",
+    "}",
 
-		"void main() {",
+    "void main() {",
 
-			"float depth = 1.0 - unpackDepth( texture2D( tDiffuse, vUv ) );",
-			"gl_FragColor = opacity * vec4( vec3( depth ), 1.0 );",
+      "float depth = 1.0 - unpackDepth( texture2D( tDiffuse, vUv ) );",
+      "gl_FragColor = opacity * vec4( vec3( depth ), 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/vertical_blur_shader.dart
+++ b/lib/extras/shaders/vertical_blur_shader.dart
@@ -17,51 +17,51 @@ part of three_shaders;
 
 var VerticalBlurShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"v":        { 'type': "f", 'value': 1.0 / 512.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "v":        { 'type': "f", 'value': 1.0 / 512.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float v;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float v;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 sum = vec4( 0.0 );",
+      "vec4 sum = vec4( 0.0 );",
 
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;",
 
-			"gl_FragColor = sum;",
+      "gl_FragColor = sum;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/vertical_tilt_shift_shader.dart
+++ b/lib/extras/shaders/vertical_tilt_shift_shader.dart
@@ -16,55 +16,55 @@ part of three_shaders;
 
 var VerticalTiltShiftShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"v":        { 'type': "f", 'value': 1.0 / 512.0 },
-		"r":        { 'type': "f", 'value': 0.35 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "v":        { 'type': "f", 'value': 1.0 / 512.0 },
+    "r":        { 'type': "f", 'value': 0.35 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float v;",
-		"uniform float r;",
+    "uniform sampler2D tDiffuse;",
+    "uniform float v;",
+    "uniform float r;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vec4 sum = vec4( 0.0 );",
+      "vec4 sum = vec4( 0.0 );",
 
-			"float vv = v * abs( r - vUv.y );",
+      "float vv = v * abs( r - vUv.y );",
 
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;",
-			"sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;",
+      "sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;",
 
-			"gl_FragColor = sum;",
+      "gl_FragColor = sum;",
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/extras/shaders/vignette_shader.dart
+++ b/lib/extras/shaders/vignette_shader.dart
@@ -13,56 +13,56 @@ part of three_shaders;
 
 var VignetteShader = {
 
-	'uniforms': {
+  'uniforms': {
 
-		"tDiffuse": { 'type': "t", 'value': null },
-		"offset":   { 'type': "f", 'value': 1.0 },
-		"darkness": { 'type': "f", 'value': 1.0 }
+    "tDiffuse": { 'type': "t", 'value': null },
+    "offset":   { 'type': "f", 'value': 1.0 },
+    "darkness": { 'type': "f", 'value': 1.0 }
 
-	},
+  },
 
-	'vertexShader': [
+  'vertexShader': [
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			"vUv = uv;",
-			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
 
-		"}"
+    "}"
 
-	].join("\n"),
+  ].join("\n"),
 
-	'fragmentShader': [
+  'fragmentShader': [
 
-		"uniform float offset;",
-		"uniform float darkness;",
+    "uniform float offset;",
+    "uniform float darkness;",
 
-		"uniform sampler2D tDiffuse;",
+    "uniform sampler2D tDiffuse;",
 
-		"varying vec2 vUv;",
+    "varying vec2 vUv;",
 
-		"void main() {",
+    "void main() {",
 
-			// Eskil's vignette
+      // Eskil's vignette
 
-			"vec4 texel = texture2D( tDiffuse, vUv );",
-			"vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );",
-			"gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );",
+      "vec4 texel = texture2D( tDiffuse, vUv );",
+      "vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );",
+      "gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );",
 
-			/*
-			// alternative version from glfx.js
-			// this one makes more "dusty" look (as opposed to "burned")
+      /*
+      // alternative version from glfx.js
+      // this one makes more "dusty" look (as opposed to "burned")
 
-			"vec4 color = texture2D( tDiffuse, vUv );",
-			"float dist = distance( vUv, vec2( 0.5 ) );",
-			"color.rgb *= smoothstep( 0.8, offset * 0.799, dist *( darkness + offset ) );",
-			"gl_FragColor = color;",
-			*/
+      "vec4 color = texture2D( tDiffuse, vUv );",
+      "float dist = distance( vUv, vec2( 0.5 ) );",
+      "color.rgb *= smoothstep( 0.8, offset * 0.799, dist *( darkness + offset ) );",
+      "gl_FragColor = color;",
+      */
 
-		"}"
+    "}"
 
-	].join("\n")
+  ].join("\n")
 
 };

--- a/lib/src/core/buffer_geometry.dart
+++ b/lib/src/core/buffer_geometry.dart
@@ -44,26 +44,26 @@ class Chunk {
 /// TODO: there are several unported methods from three.js.
 class BufferGeometry implements Geometry {
 
-	int id = GeometryCount ++;
+  int id = GeometryCount ++;
 
-	// attributes
-	Map<String, GeometryAttribute> attributes = {};
+  // attributes
+  Map<String, GeometryAttribute> attributes = {};
 
   // offsets for chunks when using indexed elements
-	List<Chunk> offsets = [];
+  List<Chunk> offsets = [];
 
-	// attributes typed arrays are kept only if dynamic flag is set
-	bool _dynamic = false;
+  // attributes typed arrays are kept only if dynamic flag is set
+  bool _dynamic = false;
 
-	// boundings
-	var boundingBox = null;
-	var boundingSphere = null;
+  // boundings
+  var boundingBox = null;
+  var boundingSphere = null;
 
-	bool hasTangents;
+  bool hasTangents;
 
-	// for compatibility
-	List morphTargets = [];
-	List morphNormals = [];
+  // for compatibility
+  List morphTargets = [];
+  List morphNormals = [];
 
   // WebGL
   bool  verticesNeedUpdate = true,
@@ -75,448 +75,448 @@ class BufferGeometry implements Geometry {
        buffersNeedUpdate = true,
        morphTargetsNeedUpdate = true,
        lineDistancesNeedUpdate = true;
-	bool __webglInit = false;
+  bool __webglInit = false;
   var __webglVertexBuffer;
 
-	applyMatrix ( Matrix4 matrix ) {
+  applyMatrix ( Matrix4 matrix ) {
 
-		var positionArray;
-		var normalArray;
+    var positionArray;
+    var normalArray;
 
-		if ( aPosition != null ) positionArray = aPosition.array;
-		if ( aNormal != null ) normalArray = aNormal.array;
+    if ( aPosition != null ) positionArray = aPosition.array;
+    if ( aNormal != null ) normalArray = aNormal.array;
 
-		if ( positionArray != null) {
+    if ( positionArray != null) {
 
-			multiplyVector3Array(matrix, positionArray);
-			this["verticesNeedUpdate"] = true;
+      multiplyVector3Array(matrix, positionArray);
+      this["verticesNeedUpdate"] = true;
 
-		}
+    }
 
-		if ( normalArray != null ) {
+    if ( normalArray != null ) {
 
-			var matrixRotation = new Matrix4.identity();
-			extractRotation( matrixRotation, matrix );
+      var matrixRotation = new Matrix4.identity();
+      extractRotation( matrixRotation, matrix );
 
-			multiplyVector3Array(matrixRotation, normalArray );
-			this["normalsNeedUpdate"] = true;
+      multiplyVector3Array(matrixRotation, normalArray );
+      this["normalsNeedUpdate"] = true;
 
-		}
+    }
 
-	}
+  }
 
-	/// Computes bounding box of the geometry, updating Geometry.boundingBox.
-	computeBoundingBox () {
+  /// Computes bounding box of the geometry, updating Geometry.boundingBox.
+  computeBoundingBox () {
 
-		if ( boundingBox == null ) {
+    if ( boundingBox == null ) {
 
-			boundingBox = new BoundingBox(
-				min: new Vector3( double.INFINITY, double.INFINITY, double.INFINITY ),
-				max: new Vector3( -double.INFINITY, -double.INFINITY, -double.INFINITY )
-			);
+      boundingBox = new BoundingBox(
+        min: new Vector3( double.INFINITY, double.INFINITY, double.INFINITY ),
+        max: new Vector3( -double.INFINITY, -double.INFINITY, -double.INFINITY )
+      );
 
-		}
+    }
 
-		var positions = aPosition.array;
+    var positions = aPosition.array;
 
-		if ( positions ) {
+    if ( positions ) {
 
-			var bb = boundingBox;
-			var x, y, z;
+      var bb = boundingBox;
+      var x, y, z;
 
-			for ( var i = 0, il = positions.length; i < il; i += 3 ) {
+      for ( var i = 0, il = positions.length; i < il; i += 3 ) {
 
-				x = positions[ i ];
-				y = positions[ i + 1 ];
-				z = positions[ i + 2 ];
+        x = positions[ i ];
+        y = positions[ i + 1 ];
+        z = positions[ i + 2 ];
 
-				// bounding box
+        // bounding box
 
-				if ( x < bb.min.x ) {
+        if ( x < bb.min.x ) {
 
-					bb.min.x = x;
+          bb.min.x = x;
 
-				} else if ( x > bb.max.x ) {
+        } else if ( x > bb.max.x ) {
 
-					bb.max.x = x;
+          bb.max.x = x;
 
-				}
+        }
 
-				if ( y < bb.min.y ) {
+        if ( y < bb.min.y ) {
 
-					bb.min.y = y;
+          bb.min.y = y;
 
-				} else if ( y > bb.max.y ) {
+        } else if ( y > bb.max.y ) {
 
-					bb.max.y = y;
+          bb.max.y = y;
 
-				}
+        }
 
-				if ( z < bb.min.z ) {
+        if ( z < bb.min.z ) {
 
-					bb.min.z = z;
+          bb.min.z = z;
 
-				} else if ( z > bb.max.z ) {
+        } else if ( z > bb.max.z ) {
 
-					bb.max.z = z;
+          bb.max.z = z;
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		if ( positions == null || positions.length == 0 ) {
+    if ( positions == null || positions.length == 0 ) {
 
-			boundingBox.min.setValues( 0, 0, 0 );
-			boundingBox.max.setValues( 0, 0, 0 );
+      boundingBox.min.setValues( 0, 0, 0 );
+      boundingBox.max.setValues( 0, 0, 0 );
 
-		}
+    }
 
-	}
+  }
 
-	/// Computes bounding sphere of the geometry, updating Geometry.boundingSphere.
-	///
-	/// Neither bounding boxes or bounding spheres are computed by default.
-	/// They need to be explicitly computed, otherwise they are null.
-	computeBoundingSphere() {
+  /// Computes bounding sphere of the geometry, updating Geometry.boundingSphere.
+  ///
+  /// Neither bounding boxes or bounding spheres are computed by default.
+  /// They need to be explicitly computed, otherwise they are null.
+  computeBoundingSphere() {
 
-		if ( boundingSphere == null ) boundingSphere = new BoundingSphere( radius: 0 );
+    if ( boundingSphere == null ) boundingSphere = new BoundingSphere( radius: 0 );
 
-		var positions = aPosition.array;
+    var positions = aPosition.array;
 
-		if ( positions != null ) {
+    if ( positions != null ) {
 
-			var radiusSq, maxRadiusSq = 0;
-			var x, y, z;
+      var radiusSq, maxRadiusSq = 0;
+      var x, y, z;
 
-			for ( var i = 0, il = positions.length; i < il; i += 3 ) {
+      for ( var i = 0, il = positions.length; i < il; i += 3 ) {
 
-				x = positions[ i ];
-				y = positions[ i + 1 ];
-				z = positions[ i + 2 ];
+        x = positions[ i ];
+        y = positions[ i + 1 ];
+        z = positions[ i + 2 ];
 
-				radiusSq =  x * x + y * y + z * z;
-				if ( radiusSq > maxRadiusSq ) maxRadiusSq = radiusSq;
+        radiusSq =  x * x + y * y + z * z;
+        if ( radiusSq > maxRadiusSq ) maxRadiusSq = radiusSq;
 
-			}
+      }
 
-			boundingSphere.radius = Math.sqrt( maxRadiusSq );
+      boundingSphere.radius = Math.sqrt( maxRadiusSq );
 
-		}
+    }
 
-	}
+  }
 
-	/// Computes vertex normals by averaging face normals.
-	/// Face normals must be existing / computed beforehand.
-	computeVertexNormals() {
+  /// Computes vertex normals by averaging face normals.
+  /// Face normals must be existing / computed beforehand.
+  computeVertexNormals() {
 
-		if ( aPosition != null && aIndex != null ) {
+    if ( aPosition != null && aIndex != null ) {
 
-			var i, il;
-			var j, jl;
+      var i, il;
+      var j, jl;
 
-			if ( aNormal == null ) {
+      if ( aNormal == null ) {
 
-				attributes[ GeometryAttribute.NORMAL ] = new GeometryAttribute.float32(aPosition.numItems, 3);
+        attributes[ GeometryAttribute.NORMAL ] = new GeometryAttribute.float32(aPosition.numItems, 3);
 
-			} else {
+      } else {
 
-				// reset existing normals to zero
-			  il = aNormal.array.length;
+        // reset existing normals to zero
+        il = aNormal.array.length;
 
-				for ( i = 0; i < il; i ++ ) {
+        for ( i = 0; i < il; i ++ ) {
 
-					attributes[ "normal" ].array[ i ] = 0.0;
+          attributes[ "normal" ].array[ i ] = 0.0;
 
-				}
+        }
 
-			}
+      }
 
-			var indices = aIndex.array;
-			var positions = aPosition.array;
-			var normals = aNormal.array;
+      var indices = aIndex.array;
+      var positions = aPosition.array;
+      var normals = aNormal.array;
 
-			var vA, vB, vC, x, y, z,
+      var vA, vB, vC, x, y, z,
 
-			pA = new Vector3.zero(),
-			pB = new Vector3.zero(),
-			pC = new Vector3.zero(),
+      pA = new Vector3.zero(),
+      pB = new Vector3.zero(),
+      pC = new Vector3.zero(),
 
-			cb = new Vector3.zero(),
-			ab = new Vector3.zero();
+      cb = new Vector3.zero(),
+      ab = new Vector3.zero();
 
-			jl = offsets.length;
-			for ( j = 0; j < jl; ++ j ) {
+      jl = offsets.length;
+      for ( j = 0; j < jl; ++ j ) {
 
-				var start = offsets[ j ].start;
-				var count = offsets[ j ].count;
-				var index = offsets[ j ].index;
+        var start = offsets[ j ].start;
+        var count = offsets[ j ].count;
+        var index = offsets[ j ].index;
 
-				il = start + count;
-				for ( i = start; i < il; i += 3 ) {
+        il = start + count;
+        for ( i = start; i < il; i += 3 ) {
 
-					vA = index + indices[ i ];
-					vB = index + indices[ i + 1 ];
-					vC = index + indices[ i + 2 ];
+          vA = index + indices[ i ];
+          vB = index + indices[ i + 1 ];
+          vC = index + indices[ i + 2 ];
 
-					x = positions[ vA * 3 ];
-					y = positions[ vA * 3 + 1 ];
-					z = positions[ vA * 3 + 2 ];
-					pA.setValues( x, y, z );
+          x = positions[ vA * 3 ];
+          y = positions[ vA * 3 + 1 ];
+          z = positions[ vA * 3 + 2 ];
+          pA.setValues( x, y, z );
 
-					x = positions[ vB * 3 ];
-					y = positions[ vB * 3 + 1 ];
-					z = positions[ vB * 3 + 2 ];
-					pB.setValues( x, y, z );
+          x = positions[ vB * 3 ];
+          y = positions[ vB * 3 + 1 ];
+          z = positions[ vB * 3 + 2 ];
+          pB.setValues( x, y, z );
 
-					x = positions[ vC * 3 ];
-					y = positions[ vC * 3 + 1 ];
-					z = positions[ vC * 3 + 2 ];
-					pC.setValues( x, y, z );
+          x = positions[ vC * 3 ];
+          y = positions[ vC * 3 + 1 ];
+          z = positions[ vC * 3 + 2 ];
+          pC.setValues( x, y, z );
 
-					cb = pC - pB;
-					ab = pA - pB;
-					cb = cb.cross( ab );
+          cb = pC - pB;
+          ab = pA - pB;
+          cb = cb.cross( ab );
 
-					normals[ vA * 3 ] += cb.x;
-					normals[ vA * 3 + 1 ] += cb.y;
-					normals[ vA * 3 + 2 ] += cb.z;
+          normals[ vA * 3 ] += cb.x;
+          normals[ vA * 3 + 1 ] += cb.y;
+          normals[ vA * 3 + 2 ] += cb.z;
 
-					normals[ vB * 3 ] += cb.x;
-					normals[ vB * 3 + 1 ] += cb.y;
-					normals[ vB * 3 + 2 ] += cb.z;
+          normals[ vB * 3 ] += cb.x;
+          normals[ vB * 3 + 1 ] += cb.y;
+          normals[ vB * 3 + 2 ] += cb.z;
 
-					normals[ vC * 3 ] += cb.x;
-					normals[ vC * 3 + 1 ] += cb.y;
-					normals[ vC * 3 + 2 ] += cb.z;
+          normals[ vC * 3 ] += cb.x;
+          normals[ vC * 3 + 1 ] += cb.y;
+          normals[ vC * 3 + 2 ] += cb.z;
 
-				}
+        }
 
-			}
+      }
 
-			// normalize normals
-			il = normals.length;
-			for ( i = 0; i < il; i += 3 ) {
+      // normalize normals
+      il = normals.length;
+      for ( i = 0; i < il; i += 3 ) {
 
-				x = normals[ i ];
-				y = normals[ i + 1 ];
-				z = normals[ i + 2 ];
+        x = normals[ i ];
+        y = normals[ i + 1 ];
+        z = normals[ i + 2 ];
 
-				var n = 1.0 / Math.sqrt( x * x + y * y + z * z );
+        var n = 1.0 / Math.sqrt( x * x + y * y + z * z );
 
-				normals[ i ] *= n;
-				normals[ i + 1 ] *= n;
-				normals[ i + 2 ] *= n;
+        normals[ i ] *= n;
+        normals[ i + 1 ] *= n;
+        normals[ i + 2 ] *= n;
 
-			}
+      }
 
-			this["normalsNeedUpdate"] = true;
+      this["normalsNeedUpdate"] = true;
 
-		}
+    }
 
-	}
+  }
 
-	/// Computes vertex tangents.
-	/// Based on http://www.terathon.com/code/tangent.html
-	/// Geometry must have vertex UVs (layer 0 will be used).
-	computeTangents() {
+  /// Computes vertex tangents.
+  /// Based on http://www.terathon.com/code/tangent.html
+  /// Geometry must have vertex UVs (layer 0 will be used).
+  computeTangents() {
 
-		// based on http://www.terathon.com/code/tangent.html
-		// (per vertex tangents)
+    // based on http://www.terathon.com/code/tangent.html
+    // (per vertex tangents)
 
-		if ( aIndex == null || aPosition == null || aNormal == null || aUV == null ) {
+    if ( aIndex == null || aPosition == null || aNormal == null || aUV == null ) {
 
-			print( "Missing required attributes (index, position, normal or uv) in BufferGeometry.computeTangents()" );
-			return;
+      print( "Missing required attributes (index, position, normal or uv) in BufferGeometry.computeTangents()" );
+      return;
 
-		}
+    }
 
-		var indices = aIndex.array;
-		var positions = aPosition.array;
-		var normals = aNormal.array;
-		var uvs = aUV.array;
+    var indices = aIndex.array;
+    var positions = aPosition.array;
+    var normals = aNormal.array;
+    var uvs = aUV.array;
 
-		var nVertices = aPosition.numItems ~/ 3;
+    var nVertices = aPosition.numItems ~/ 3;
 
-		if ( aTangent == null ) {
+    if ( aTangent == null ) {
 
-			attributes[ "tangent" ] = new GeometryAttribute.float32(nVertices, 4);
+      attributes[ "tangent" ] = new GeometryAttribute.float32(nVertices, 4);
 
-		}
+    }
 
-		var tangents = aTangent.array;
+    var tangents = aTangent.array;
 
-		List<Vector3> tan1 = [], tan2 = [];
+    List<Vector3> tan1 = [], tan2 = [];
 
-		for ( var k = 0; k < nVertices; k ++ ) {
+    for ( var k = 0; k < nVertices; k ++ ) {
 
-			tan1[ k ] = new Vector3.zero();
-			tan2[ k ] = new Vector3.zero();
+      tan1[ k ] = new Vector3.zero();
+      tan2[ k ] = new Vector3.zero();
 
-		}
+    }
 
-		var xA, yA, zA,
-			xB, yB, zB,
-			xC, yC, zC,
+    var xA, yA, zA,
+      xB, yB, zB,
+      xC, yC, zC,
 
-			uA, vA,
-			uB, vB,
-			uC, vC,
+      uA, vA,
+      uB, vB,
+      uC, vC,
 
-			x1, x2, y1, y2, z1, z2,
-			s1, s2, t1, t2, r;
+      x1, x2, y1, y2, z1, z2,
+      s1, s2, t1, t2, r;
 
-		var sdir = new Vector3.zero(),
-		    tdir = new Vector3.zero();
+    var sdir = new Vector3.zero(),
+        tdir = new Vector3.zero();
 
-		var handleTriangle = ( a, b, c ) {
+    var handleTriangle = ( a, b, c ) {
 
-			xA = positions[ a * 3 ];
-			yA = positions[ a * 3 + 1 ];
-			zA = positions[ a * 3 + 2 ];
+      xA = positions[ a * 3 ];
+      yA = positions[ a * 3 + 1 ];
+      zA = positions[ a * 3 + 2 ];
 
-			xB = positions[ b * 3 ];
-			yB = positions[ b * 3 + 1 ];
-			zB = positions[ b * 3 + 2 ];
+      xB = positions[ b * 3 ];
+      yB = positions[ b * 3 + 1 ];
+      zB = positions[ b * 3 + 2 ];
 
-			xC = positions[ c * 3 ];
-			yC = positions[ c * 3 + 1 ];
-			zC = positions[ c * 3 + 2 ];
+      xC = positions[ c * 3 ];
+      yC = positions[ c * 3 + 1 ];
+      zC = positions[ c * 3 + 2 ];
 
-			uA = uvs[ a * 2 ];
-			vA = uvs[ a * 2 + 1 ];
+      uA = uvs[ a * 2 ];
+      vA = uvs[ a * 2 + 1 ];
 
-			uB = uvs[ b * 2 ];
-			vB = uvs[ b * 2 + 1 ];
+      uB = uvs[ b * 2 ];
+      vB = uvs[ b * 2 + 1 ];
 
-			uC = uvs[ c * 2 ];
-			vC = uvs[ c * 2 + 1 ];
+      uC = uvs[ c * 2 ];
+      vC = uvs[ c * 2 + 1 ];
 
-			x1 = xB - xA;
-			x2 = xC - xA;
+      x1 = xB - xA;
+      x2 = xC - xA;
 
-			y1 = yB - yA;
-			y2 = yC - yA;
+      y1 = yB - yA;
+      y2 = yC - yA;
 
-			z1 = zB - zA;
-			z2 = zC - zA;
+      z1 = zB - zA;
+      z2 = zC - zA;
 
-			s1 = uB - uA;
-			s2 = uC - uA;
+      s1 = uB - uA;
+      s2 = uC - uA;
 
-			t1 = vB - vA;
-			t2 = vC - vA;
+      t1 = vB - vA;
+      t2 = vC - vA;
 
-			r = 1.0 / ( s1 * t2 - s2 * t1 );
+      r = 1.0 / ( s1 * t2 - s2 * t1 );
 
-			sdir.setValues(
-				( t2 * x1 - t1 * x2 ) * r,
-				( t2 * y1 - t1 * y2 ) * r,
-				( t2 * z1 - t1 * z2 ) * r
-			);
+      sdir.setValues(
+        ( t2 * x1 - t1 * x2 ) * r,
+        ( t2 * y1 - t1 * y2 ) * r,
+        ( t2 * z1 - t1 * z2 ) * r
+      );
 
-			tdir.setValues(
-				( s1 * x2 - s2 * x1 ) * r,
-				( s1 * y2 - s2 * y1 ) * r,
-				( s1 * z2 - s2 * z1 ) * r
-			);
+      tdir.setValues(
+        ( s1 * x2 - s2 * x1 ) * r,
+        ( s1 * y2 - s2 * y1 ) * r,
+        ( s1 * z2 - s2 * z1 ) * r
+      );
 
-			tan1[ a ].add( sdir );
-			tan1[ b ].add( sdir );
-			tan1[ c ].add( sdir );
+      tan1[ a ].add( sdir );
+      tan1[ b ].add( sdir );
+      tan1[ c ].add( sdir );
 
-			tan2[ a ].add( tdir );
-			tan2[ b ].add( tdir );
-			tan2[ c ].add( tdir );
+      tan2[ a ].add( tdir );
+      tan2[ b ].add( tdir );
+      tan2[ c ].add( tdir );
 
-		};
+    };
 
-		var i, il;
-		var j, jl;
-		var iA, iB, iC;
+    var i, il;
+    var j, jl;
+    var iA, iB, iC;
 
-		jl = offsets.length;
-		for ( j = 0; j < jl; ++ j ) {
+    jl = offsets.length;
+    for ( j = 0; j < jl; ++ j ) {
 
-			var start = offsets[ j ].start;
-			var count = offsets[ j ].count;
-			var index = offsets[ j ].index;
+      var start = offsets[ j ].start;
+      var count = offsets[ j ].count;
+      var index = offsets[ j ].index;
 
-			il = start + count;
-			for ( i = start; i < il; i += 3 ) {
+      il = start + count;
+      for ( i = start; i < il; i += 3 ) {
 
-				iA = index + indices[ i ];
-				iB = index + indices[ i + 1 ];
-				iC = index + indices[ i + 2 ];
+        iA = index + indices[ i ];
+        iB = index + indices[ i + 1 ];
+        iC = index + indices[ i + 2 ];
 
-				handleTriangle( iA, iB, iC );
+        handleTriangle( iA, iB, iC );
 
-			}
+      }
 
-		}
+    }
 
-		var tmp = new Vector3.zero(),
-		    tmp2 = new Vector3.zero();
-		var n = new Vector3.zero(),
-		    n2 = new Vector3.zero();
-		var w, t, test;
-		var nx, ny, nz;
+    var tmp = new Vector3.zero(),
+        tmp2 = new Vector3.zero();
+    var n = new Vector3.zero(),
+        n2 = new Vector3.zero();
+    var w, t, test;
+    var nx, ny, nz;
 
-		var handleVertex = ( v ) {
+    var handleVertex = ( v ) {
 
-			n.x = normals[ v * 3 ];
-			n.y = normals[ v * 3 + 1 ];
-			n.z = normals[ v * 3 + 2 ];
+      n.x = normals[ v * 3 ];
+      n.y = normals[ v * 3 + 1 ];
+      n.z = normals[ v * 3 + 2 ];
 
-			n2.setFrom( n );
+      n2.setFrom( n );
 
-			t = tan1[ v ];
+      t = tan1[ v ];
 
-			// Gram-Schmidt orthogonalize
+      // Gram-Schmidt orthogonalize
 
-			tmp.setFrom( t );
-			tmp.sub( n.scale( n.dot( t ) ) ).normalize();
+      tmp.setFrom( t );
+      tmp.sub( n.scale( n.dot( t ) ) ).normalize();
 
-			// Calculate handedness
+      // Calculate handedness
 
-			tmp2 = n2.cross( t );
-			test = tmp2.dot( tan2[ v ] );
-			w = ( test < 0.0 ) ? -1.0 : 1.0;
+      tmp2 = n2.cross( t );
+      test = tmp2.dot( tan2[ v ] );
+      w = ( test < 0.0 ) ? -1.0 : 1.0;
 
-			tangents[ v * 4 ]     = tmp.x;
-			tangents[ v * 4 + 1 ] = tmp.y;
-			tangents[ v * 4 + 2 ] = tmp.z;
-			tangents[ v * 4 + 3 ] = w;
+      tangents[ v * 4 ]     = tmp.x;
+      tangents[ v * 4 + 1 ] = tmp.y;
+      tangents[ v * 4 + 2 ] = tmp.z;
+      tangents[ v * 4 + 3 ] = w;
 
-		};
+    };
 
-		jl = offsets.length;
-		for ( j = 0; j < jl; ++ j ) {
+    jl = offsets.length;
+    for ( j = 0; j < jl; ++ j ) {
 
-			var start = offsets[ j ].start;
-			var count = offsets[ j ].count;
-			var index = offsets[ j ].index;
+      var start = offsets[ j ].start;
+      var count = offsets[ j ].count;
+      var index = offsets[ j ].index;
 
-			il = start + count;
-			for ( i = start; i < il; i += 3 ) {
+      il = start + count;
+      for ( i = start; i < il; i += 3 ) {
 
-				iA = index + indices[ i ];
-				iB = index + indices[ i + 1 ];
-				iC = index + indices[ i + 2 ];
+        iA = index + indices[ i ];
+        iB = index + indices[ i + 1 ];
+        iC = index + indices[ i + 2 ];
 
-				handleVertex( iA );
-				handleVertex( iB );
-				handleVertex( iC );
+        handleVertex( iA );
+        handleVertex( iB );
+        handleVertex( iC );
 
-			}
+      }
 
-		}
+    }
 
-		hasTangents = true;
-		this["tangentsNeedUpdate"] = true;
+    hasTangents = true;
+    this["tangentsNeedUpdate"] = true;
 
-	}
+  }
 
   // dynamic is a reserved word in Dart
   bool get isDynamic => _dynamic;

--- a/lib/src/core/event_emitter.dart
+++ b/lib/src/core/event_emitter.dart
@@ -9,36 +9,36 @@ class EventEmitterEvent {
 
 class EventEmitter {
 
-	var listeners;
+  var listeners;
 
-	EventEmitter() : listeners = {};
+  EventEmitter() : listeners = {};
 
-	addEventListener( type, listener ) {
+  addEventListener( type, listener ) {
 
-		if ( listeners[ type ] == null ) {
-			listeners[ type ] = [];
-		}
+    if ( listeners[ type ] == null ) {
+      listeners[ type ] = [];
+    }
 
-		if ( listeners[ type ].indexOf( listener ) == - 1 ) {
-			listeners[ type ].add( listener );
-		}
+    if ( listeners[ type ].indexOf( listener ) == - 1 ) {
+      listeners[ type ].add( listener );
+    }
 
-	}
+  }
 
-	dispatchEvent( event ) {
-		if ( listeners[ event.type ] != null ) {
-			listeners[ event.type ].forEach((listener) => listener( event ));
-		}
-	}
+  dispatchEvent( event ) {
+    if ( listeners[ event.type ] != null ) {
+      listeners[ event.type ].forEach((listener) => listener( event ));
+    }
+  }
 
-	removeEventListener ( type, listener ) {
+  removeEventListener ( type, listener ) {
 
-		var index = listeners[ type ].indexOf( listener );
+    var index = listeners[ type ].indexOf( listener );
 
-		if ( index != - 1 ) {
-			listeners[ type ].removeAt( index );
-		}
+    if ( index != - 1 ) {
+      listeners[ type ].removeAt( index );
+    }
 
-	}
+  }
 
 }

--- a/lib/src/core/projector.dart
+++ b/lib/src/core/projector.dart
@@ -323,8 +323,8 @@ class Projector {
 
           _face.normalWorld.setFrom( face.normal );
 
-		      if ( visible == false && ( side == BackSide || side == DoubleSide ) ) _face.normalWorld.negate();
-		      _face.normalWorld.applyProjection(rotationMatrix);
+          if ( visible == false && ( side == BackSide || side == DoubleSide ) ) _face.normalWorld.negate();
+          _face.normalWorld.applyProjection(rotationMatrix);
 
           _face.centroidWorld.setFrom( face.centroid );
           _face.centroidWorld.applyProjection(modelMatrix);

--- a/lib/src/loaders/image_loader.dart
+++ b/lib/src/loaders/image_loader.dart
@@ -2,26 +2,26 @@ part of three;
 
 class ImageLoader extends EventEmitter {
 
-	String crossOrigin;
+  String crossOrigin;
 
-	ImageLoader() : crossOrigin = null, super();
+  ImageLoader() : crossOrigin = null, super();
 
-	load( String url, [ImageElement image = null] ) {
+  load( String url, [ImageElement image = null] ) {
 
-		if ( image == null ) image = new ImageElement();
+    if ( image == null ) image = new ImageElement();
 
-		image.onLoad.listen((_) {
-			dispatchEvent( new EventEmitterEvent(type: 'load', content: image) );
-		});
+    image.onLoad.listen((_) {
+      dispatchEvent( new EventEmitterEvent(type: 'load', content: image) );
+    });
 
-		image.onError.listen( (_) {
-			dispatchEvent( new EventEmitterEvent(type: 'error', message: "Couldn\'t load URL [$url]" ) );
-		});
+    image.onError.listen( (_) {
+      dispatchEvent( new EventEmitterEvent(type: 'error', message: "Couldn\'t load URL [$url]" ) );
+    });
 
-		if ( crossOrigin != null ) image.crossOrigin = crossOrigin;
+    if ( crossOrigin != null ) image.crossOrigin = crossOrigin;
 
-		image.src = url;
+    image.src = url;
 
-	}
+  }
 
 }

--- a/lib/src/objects/particle_system.dart
+++ b/lib/src/objects/particle_system.dart
@@ -5,21 +5,21 @@ class ParticleSystem extends Object3D {
   bool sortParticles;
 
   ParticleSystem(Geometry geometry, [Material material = null]) : sortParticles = false, super() {
-  	if (material == null) {
-  		material = new ParticleBasicMaterial( color: new Math.Random().nextDouble() * 0xffffff );
-  	}
+    if (material == null) {
+      material = new ParticleBasicMaterial( color: new Math.Random().nextDouble() * 0xffffff );
+    }
     this.material= material;
 
-  	if ( geometry != null) {
-  		// calc bound radius
-  		if( geometry.boundingSphere == null) {
-  			geometry.computeBoundingSphere();
-  		}
-  		boundRadius = geometry.boundingSphere.radius;
-  		this.geometry = geometry;
-  	}
+    if ( geometry != null) {
+      // calc bound radius
+      if( geometry.boundingSphere == null) {
+        geometry.computeBoundingSphere();
+      }
+      boundRadius = geometry.boundingSphere.radius;
+      this.geometry = geometry;
+    }
 
-  	frustumCulled = false;
+    frustumCulled = false;
   }
 
 }

--- a/lib/src/objects/skinned_mesh.dart
+++ b/lib/src/objects/skinned_mesh.dart
@@ -2,16 +2,16 @@ part of three;
 
 /// An 3d object that has bones data. These Bones can then be used to animate the vertices of the object.
 class SkinnedMesh extends Mesh {
-	/// Whether a vertex texture is used to calculate the bones. This shouldn't be changed after constructor.
-	bool useVertexTexture;
-	num boneTextureWidth, boneTextureHeight;
-	List bones;
-	List boneMatrices;
-	/// This is an identityMatrix to calculate the bones matrices from.
-	Matrix4 identityMatrix;
-	DataTexture boneTexture;
+  /// Whether a vertex texture is used to calculate the bones. This shouldn't be changed after constructor.
+  bool useVertexTexture;
+  num boneTextureWidth, boneTextureHeight;
+  List bones;
+  List boneMatrices;
+  /// This is an identityMatrix to calculate the bones matrices from.
+  Matrix4 identityMatrix;
+  DataTexture boneTexture;
 
-	SkinnedMesh( geometry, material, {this.useVertexTexture: true} )
+  SkinnedMesh( geometry, material, {this.useVertexTexture: true} )
       : identityMatrix = new Matrix4.identity(),
         bones = [],
         boneMatrices = [],
@@ -107,135 +107,135 @@ class SkinnedMesh extends Mesh {
       pose();
 
     }
-	}
+  }
 
-	/// This method adds the bone to the skinnedmesh when it is provided.
-	///
-	/// It creates a new bone and adds that when no bone is given.
-	Bone addBone( {Bone bone} ) {
+  /// This method adds the bone to the skinnedmesh when it is provided.
+  ///
+  /// It creates a new bone and adds that when no bone is given.
+  Bone addBone( {Bone bone} ) {
 
-	  if ( bone == null ) {
-	    bone = new Bone( this );
-	  }
+    if ( bone == null ) {
+      bone = new Bone( this );
+    }
 
-	  bones.add( bone );
+    bones.add( bone );
 
-	  return bone;
+    return bone;
 
-	}
+  }
 
-	void updateMatrixWorld({bool force: false}) {
+  void updateMatrixWorld({bool force: false}) {
 
-	  if(matrixAutoUpdate) updateMatrix();
+    if(matrixAutoUpdate) updateMatrix();
 
-	  // update matrixWorld
+    // update matrixWorld
 
-	  if ( matrixWorldNeedsUpdate || force ) {
+    if ( matrixWorldNeedsUpdate || force ) {
 
-	    if ( parent != null) {
+      if ( parent != null) {
 
-	      matrixWorld = parent.matrixWorld * matrix;
+        matrixWorld = parent.matrixWorld * matrix;
 
-	    } else {
+      } else {
 
-	      matrixWorld.setFrom( matrix );
+        matrixWorld.setFrom( matrix );
 
-	    }
+      }
 
-	    matrixWorldNeedsUpdate = false;
+      matrixWorldNeedsUpdate = false;
 
-	    force = true;
+      force = true;
 
-	  }
+    }
 
-	  // update children
-	  children.forEach((child) {
+    // update children
+    children.forEach((child) {
 
-	    if ( child is Bone ) {
-	      child.update( identityMatrix, false );
-	    } else {
-	      child.updateMatrixWorld( true );
-	    }
+      if ( child is Bone ) {
+        child.update( identityMatrix, false );
+      } else {
+        child.updateMatrixWorld( true );
+      }
 
-	  });
+    });
 
-	  // flatten bone matrices to array
+    // flatten bone matrices to array
 
-	  var b, bl = this.bones.length,
-	      ba = this.bones,
-	      bm = this.boneMatrices;
+    var b, bl = this.bones.length,
+        ba = this.bones,
+        bm = this.boneMatrices;
 
-	  for ( b = 0; b < bl; b ++ ) {
-	    ba[ b ].skinMatrix.flattenToArrayOffset( bm, b * 16 );
+    for ( b = 0; b < bl; b ++ ) {
+      ba[ b ].skinMatrix.flattenToArrayOffset( bm, b * 16 );
 
-	  }
+    }
 
-	  if ( useVertexTexture ) {
-	    boneTexture.needsUpdate = true;
-	  }
+    if ( useVertexTexture ) {
+      boneTexture.needsUpdate = true;
+    }
 
-	}
+  }
 
-	/// This method sets the skinnedmesh in the rest pose.
-	void pose() {
+  /// This method sets the skinnedmesh in the rest pose.
+  void pose() {
 
-	  updateMatrixWorld( force: true );
+    updateMatrixWorld( force: true );
 
-	  var bim, bone;
+    var bim, bone;
 
-	  List<Matrix4> boneInverses = [];
+    List<Matrix4> boneInverses = [];
 
-	  for ( var b = 0; b < bones.length; b ++ ) {
+    for ( var b = 0; b < bones.length; b ++ ) {
 
-	    bone = bones[ b ];
+      bone = bones[ b ];
 
-	    var inverseMatrix = bone.skinMatrix.clone();
-	    inverseMatrix.invert();
+      var inverseMatrix = bone.skinMatrix.clone();
+      inverseMatrix.invert();
 
-	    boneInverses.add( inverseMatrix );
+      boneInverses.add( inverseMatrix );
 
-	    bone.skinMatrix.flattenToArrayOffset( boneMatrices, b * 16 );
+      bone.skinMatrix.flattenToArrayOffset( boneMatrices, b * 16 );
 
-	  }
+    }
 
-	  // project vertices to local
+    // project vertices to local
 
-	  if ( geometry["skinVerticesA"] == null ) {
+    if ( geometry["skinVerticesA"] == null ) {
 
-	    geometry["skinVerticesA"] = [];
-	    geometry["skinVerticesA"] = [];
+      geometry["skinVerticesA"] = [];
+      geometry["skinVerticesA"] = [];
 
-	    var orgVertex, vertex;
+      var orgVertex, vertex;
 
-	    for ( var i = 0; i < geometry.skinIndices.length; i ++ ) {
+      for ( var i = 0; i < geometry.skinIndices.length; i ++ ) {
 
-	      orgVertex = geometry.vertices[ i ];
+        orgVertex = geometry.vertices[ i ];
 
-	      var indexA = geometry.skinIndices[ i ].x;
-	      var indexB = geometry.skinIndices[ i ].y;
+        var indexA = geometry.skinIndices[ i ].x;
+        var indexB = geometry.skinIndices[ i ].y;
 
-	      vertex = new Vector3( orgVertex.x, orgVertex.y, orgVertex.z );
-	      geometry["skinVerticesA"].add(vertex.applyProjection(boneInverses[indexA]));
+        vertex = new Vector3( orgVertex.x, orgVertex.y, orgVertex.z );
+        geometry["skinVerticesA"].add(vertex.applyProjection(boneInverses[indexA]));
 
-	      vertex = new Vector3( orgVertex.x, orgVertex.y, orgVertex.z );
-	      geometry["skinVerticesA"].add(vertex.applyProjection(boneInverses[indexB]));
+        vertex = new Vector3( orgVertex.x, orgVertex.y, orgVertex.z );
+        geometry["skinVerticesA"].add(vertex.applyProjection(boneInverses[indexB]));
 
-	      // todo: add more influences
+        // todo: add more influences
 
-	      // normalize weights
+        // normalize weights
 
-	      if ( geometry.skinWeights[ i ].x + geometry.skinWeights[ i ].y != 1 ) {
+        if ( geometry.skinWeights[ i ].x + geometry.skinWeights[ i ].y != 1 ) {
 
-	        var len = ( 1.0 - ( geometry.skinWeights[ i ].x + geometry.skinWeights[ i ].y ) ) * 0.5;
-	        geometry.skinWeights[ i ].x += len;
-	        geometry.skinWeights[ i ].y += len;
+          var len = ( 1.0 - ( geometry.skinWeights[ i ].x + geometry.skinWeights[ i ].y ) ) * 0.5;
+          geometry.skinWeights[ i ].x += len;
+          geometry.skinWeights[ i ].y += len;
 
-	      }
+        }
 
-	    }
+      }
 
-	  }
+    }
 
-	}
+  }
 
 }

--- a/lib/src/renderers/web_gl_render_target.dart
+++ b/lib/src/renderers/web_gl_render_target.dart
@@ -2,66 +2,66 @@ part of three;
 
 class WebGLRenderTarget extends Texture {
 
-	num width, height;
+  num width, height;
 
-	Vector2 offset;
-	Vector2 repeat;
+  Vector2 offset;
+  Vector2 repeat;
 
-	bool depthBuffer,
-		 stencilBuffer;
+  bool depthBuffer,
+     stencilBuffer;
 
-	bool generateMipmaps;
+  bool generateMipmaps;
 
-	var shareDepthFrom;
+  var shareDepthFrom;
 
-	var __webglFramebuffer; // List<WebGLFramebuffer> or WebGLFramebuffer
-	var __webglRenderbuffer; // List<WebGLRenderbuffer> or WebGLRenderbuffer
+  var __webglFramebuffer; // List<WebGLFramebuffer> or WebGLFramebuffer
+  var __webglRenderbuffer; // List<WebGLRenderbuffer> or WebGLRenderbuffer
 
-	WebGLRenderTarget ( this.width, this.height, {
-	  int wrapS: ClampToEdgeWrapping,
-	  int wrapT: ClampToEdgeWrapping,
-	  int magFilter: LinearFilter,
-	  int minFilter: LinearMipMapLinearFilter,
-	  int anisotropy: 1,
-	  int format: RGBAFormat,
-	  int type: UnsignedByteType,
-	  this.depthBuffer: true,
-	  this.stencilBuffer: true,
-	  this.offset: null, //new Vector2( 0, 0 ),
-	  this.repeat: null, //new Vector2( 1, 1 ),
-	  this.generateMipmaps: true,
-	  this.shareDepthFrom: null
-	} ) : super(null, null, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy){
+  WebGLRenderTarget ( this.width, this.height, {
+    int wrapS: ClampToEdgeWrapping,
+    int wrapT: ClampToEdgeWrapping,
+    int magFilter: LinearFilter,
+    int minFilter: LinearMipMapLinearFilter,
+    int anisotropy: 1,
+    int format: RGBAFormat,
+    int type: UnsignedByteType,
+    this.depthBuffer: true,
+    this.stencilBuffer: true,
+    this.offset: null, //new Vector2( 0, 0 ),
+    this.repeat: null, //new Vector2( 1, 1 ),
+    this.generateMipmaps: true,
+    this.shareDepthFrom: null
+  } ) : super(null, null, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy){
     if (offset == null) offset = new Vector2.zero();
     if (repeat == null) repeat = new Vector2( 1.0, 1.0 );
-	}
+  }
 
-	gl.Texture get __webglTexture => this["__webglTexture"];
+  gl.Texture get __webglTexture => this["__webglTexture"];
   set __webglTexture(gl.Texture tex) { this["__webglTexture"] = tex; }
 
   WebGLRenderTarget clone() => new WebGLRenderTarget(
-						width,
-						height ,
+            width,
+            height ,
 
-						wrapS: this.wrapS,
-						wrapT: this.wrapT,
+            wrapS: this.wrapS,
+            wrapT: this.wrapT,
 
-						magFilter: this.magFilter,
-						anisotropy: this.anisotropy,
+            magFilter: this.magFilter,
+            anisotropy: this.anisotropy,
 
-						minFilter: this.minFilter,
+            minFilter: this.minFilter,
 
-						offset: offset.clone(),
-						repeat: repeat.clone(),
+            offset: offset.clone(),
+            repeat: repeat.clone(),
 
-						format: this.format,
-						type: this.type,
+            format: this.format,
+            type: this.type,
 
-						depthBuffer: this.depthBuffer,
-						stencilBuffer: this.stencilBuffer,
+            depthBuffer: this.depthBuffer,
+            stencilBuffer: this.stencilBuffer,
 
-						generateMipmaps: this.generateMipmaps,
+            generateMipmaps: this.generateMipmaps,
 
-						shareDepthFrom: this.shareDepthFrom);
+            shareDepthFrom: this.shareDepthFrom);
 
 }

--- a/lib/src/renderers/web_gl_renderer.dart
+++ b/lib/src/renderers/web_gl_renderer.dart
@@ -22,128 +22,128 @@ class WebGLRenderer implements Renderer {
   num _clearAlpha;
   double devicePixelRatio;
 
-	bool alpha,
-		   premultipliedAlpha,
-		   antialias,
-		   stencil,
-		   preserveDrawingBuffer;
+  bool alpha,
+       premultipliedAlpha,
+       antialias,
+       stencil,
+       preserveDrawingBuffer;
 
-	/// Defines whether the renderer should automatically clear its output before rendering.
-	bool autoClear;
-	/// If autoClear is true, defines whether the renderer should clear the color buffer. Default is true.
-	bool autoClearColor;
-	/// If autoClear is true, defines whether the renderer should clear the depth buffer. Default is true.
-	bool autoClearDepth;
-	/// If autoClear is true, defines whether the renderer should clear the stencil buffer. Default is true.
-	bool autoClearStencil;
+  /// Defines whether the renderer should automatically clear its output before rendering.
+  bool autoClear;
+  /// If autoClear is true, defines whether the renderer should clear the color buffer. Default is true.
+  bool autoClearColor;
+  /// If autoClear is true, defines whether the renderer should clear the depth buffer. Default is true.
+  bool autoClearDepth;
+  /// If autoClear is true, defines whether the renderer should clear the stencil buffer. Default is true.
+  bool autoClearStencil;
 
-	// scene graph
+  // scene graph
 
-	/// Defines whether the renderer should sort objects. Default is true.
-	///
-	/// Note: Sorting is used to attempt to properly render objects that have some
-	/// degree of transparency. By definition, sorting objects may not work in all
-	/// cases. Depending on the needs of application, it may be necessary to turn
-	/// off sorting and use other methods to deal with transparency rendering
-	/// (e.g. manually determining the object rendering order).
-	bool sortObjects;
-	/// Defines whether the renderer should auto update objects. Default is true.
-	bool autoUpdateObjects;
-	bool autoUpdateScene;
+  /// Defines whether the renderer should sort objects. Default is true.
+  ///
+  /// Note: Sorting is used to attempt to properly render objects that have some
+  /// degree of transparency. By definition, sorting objects may not work in all
+  /// cases. Depending on the needs of application, it may be necessary to turn
+  /// off sorting and use other methods to deal with transparency rendering
+  /// (e.g. manually determining the object rendering order).
+  bool sortObjects;
+  /// Defines whether the renderer should auto update objects. Default is true.
+  bool autoUpdateObjects;
+  bool autoUpdateScene;
 
-	// physically based shading
+  // physically based shading
 
-	/// Default is false. If set, then it expects that all textures and colors are premultiplied gamma.
-	bool gammaInput;
-	/// Default is false. If set, then it expects that all textures and colors need to be outputted in premultiplied gamma.
-	bool gammaOutput;
-	bool physicallyBasedShading;
+  /// Default is false. If set, then it expects that all textures and colors are premultiplied gamma.
+  bool gammaInput;
+  /// Default is false. If set, then it expects that all textures and colors need to be outputted in premultiplied gamma.
+  bool gammaOutput;
+  bool physicallyBasedShading;
 
-	// shadow map
+  // shadow map
 
-	/// Default is false. If set, use shadow maps in the scene.
-	bool shadowMapEnabled;
-	bool shadowMapAutoUpdate;
-	bool shadowMapDebug;
-	bool shadowMapCascade;
-	/// Defines shadow map type (unfiltered, percentage close filtering,
-	/// percentage close filtering with bilinear filtering in shader)
-	///
-	/// Options are BasicShadowMap, PCFShadowMap, PCFSoftShadowMap. Default is PCFShadowMap.
-	int shadowMapType;
-	/// Default is CullFaceFront. The faces that needed to be culled.
-	///
-	/// Possible values: CullFaceFront and CullFaceBack
-	int shadowMapCullFrontFaces;
+  /// Default is false. If set, use shadow maps in the scene.
+  bool shadowMapEnabled;
+  bool shadowMapAutoUpdate;
+  bool shadowMapDebug;
+  bool shadowMapCascade;
+  /// Defines shadow map type (unfiltered, percentage close filtering,
+  /// percentage close filtering with bilinear filtering in shader)
+  ///
+  /// Options are BasicShadowMap, PCFShadowMap, PCFSoftShadowMap. Default is PCFShadowMap.
+  int shadowMapType;
+  /// Default is CullFaceFront. The faces that needed to be culled.
+  ///
+  /// Possible values: CullFaceFront and CullFaceBack
+  int shadowMapCullFrontFaces;
 
-	// morphs
+  // morphs
 
-	/// Default is 8. The maximum number of MorphTargets allowed in a shader.
-	///
-	/// Keep in mind that the standard materials only allow 8 MorphTargets.
-	int maxMorphTargets;
-	/// Default is 4. The maximum number of MorphNormals allowed in a shader.
-	///
-	/// Keep in mind that the standard materials only allow 4 MorphNormals.
-	int maxMorphNormals;
+  /// Default is 8. The maximum number of MorphTargets allowed in a shader.
+  ///
+  /// Keep in mind that the standard materials only allow 8 MorphTargets.
+  int maxMorphTargets;
+  /// Default is 4. The maximum number of MorphNormals allowed in a shader.
+  ///
+  /// Keep in mind that the standard materials only allow 4 MorphNormals.
+  int maxMorphNormals;
 
-	// flags
+  // flags
 
-	/// Default is true. If set, then Cubemaps are scaled, when they are bigger
-	/// than the maximum size, to make sure that they aren't bigger than the maximum size.
-	bool autoScaleCubemaps;
+  /// Default is true. If set, then Cubemaps are scaled, when they are bigger
+  /// than the maximum size, to make sure that they aren't bigger than the maximum size.
+  bool autoScaleCubemaps;
 
-	// custom render plugins
+  // custom render plugins
 
-	List renderPluginsPre,
-		renderPluginsPost;
+  List renderPluginsPre,
+    renderPluginsPost;
 
 
-	WebGLRendererInfo info;
+  WebGLRendererInfo info;
 
-	/** Internal properties **/
+  /** Internal properties **/
 
-	List<Program> _programs;
-	int _programs_counter;
+  List<Program> _programs;
+  int _programs_counter;
 
-	// internal state cache
-	var _currentProgram = null,
-		_currentFramebuffer = null,
-		_currentMaterialId = -1,
-		_currentGeometryGroupHash = null,
-		_currentCamera = null,
-		_geometryGroupCounter = 0,
-	  _usedTextureUnits = 0,
-	  _enabledAttributes = {};
+  // internal state cache
+  var _currentProgram = null,
+    _currentFramebuffer = null,
+    _currentMaterialId = -1,
+    _currentGeometryGroupHash = null,
+    _currentCamera = null,
+    _geometryGroupCounter = 0,
+    _usedTextureUnits = 0,
+    _enabledAttributes = {};
 
-	// GL state cache
-	var _oldDoubleSided = -1,
-	_oldFlipSided = -1,
+  // GL state cache
+  var _oldDoubleSided = -1,
+  _oldFlipSided = -1,
 
-	_oldBlending = -1,
+  _oldBlending = -1,
 
-	_oldBlendEquation = -1,
-	_oldBlendSrc = -1,
-	_oldBlendDst = -1,
+  _oldBlendEquation = -1,
+  _oldBlendSrc = -1,
+  _oldBlendDst = -1,
 
-	_oldDepthTest = -1,
-	_oldDepthWrite = -1,
+  _oldDepthTest = -1,
+  _oldDepthWrite = -1,
 
-	_oldPolygonOffset = null,
-	_oldPolygonOffsetFactor = null,
-	_oldPolygonOffsetUnits = null,
+  _oldPolygonOffset = null,
+  _oldPolygonOffsetFactor = null,
+  _oldPolygonOffsetUnits = null,
 
-	_oldLineWidth = null,
+  _oldLineWidth = null,
 
-	_viewportX = 0,
-	_viewportY = 0,
-	_viewportWidth = 0,
-	_viewportHeight = 0,
-	_currentWidth = 0,
-	_currentHeight = 0;
+  _viewportX = 0,
+  _viewportY = 0,
+  _viewportWidth = 0,
+  _viewportHeight = 0,
+  _currentWidth = 0,
+  _currentHeight = 0;
 
-	 // frustum
-	Frustum _frustum;
+   // frustum
+  Frustum _frustum;
 
    // camera matrices cache
   Matrix4 _projScreenMatrix,
@@ -166,108 +166,108 @@ class WebGLRenderer implements Renderer {
   var maxAnisotropy;
 
   bool supportsVertexTextures,
-  	   supportsBoneTextures;
+       supportsBoneTextures;
 
   var shadowMapPlugin;
 
   num maxTextures, maxVertexTextures, maxTextureSize, maxCubemapSize;
 
   WebGLRenderer( {  this.canvas,
-  					this.precision: PRECISION_HIGH,
-  					this.alpha: true,
-			      this.premultipliedAlpha: true,
-		        this.antialias: true,
-	          this.stencil: true,
-  					this.preserveDrawingBuffer: false,
-  					num clearColorHex: 0x000000,
-  					num clearAlpha: 0,
-  					num devicePixelRatio} )
-  		:
+            this.precision: PRECISION_HIGH,
+            this.alpha: true,
+            this.premultipliedAlpha: true,
+            this.antialias: true,
+            this.stencil: true,
+            this.preserveDrawingBuffer: false,
+            num clearColorHex: 0x000000,
+            num clearAlpha: 0,
+            num devicePixelRatio} )
+      :
 
-  		_clearColor = new Color(clearColorHex),
-  		_clearAlpha = clearAlpha,
+      _clearColor = new Color(clearColorHex),
+      _clearAlpha = clearAlpha,
 
-			// clearing
-			autoClear = true,
-			autoClearColor = true,
-			autoClearDepth = true,
-			autoClearStencil = true,
+      // clearing
+      autoClear = true,
+      autoClearColor = true,
+      autoClearDepth = true,
+      autoClearStencil = true,
 
-			// scene graph
-			sortObjects = true,
-			autoUpdateObjects = true,
-			autoUpdateScene = true,
+      // scene graph
+      sortObjects = true,
+      autoUpdateObjects = true,
+      autoUpdateScene = true,
 
-			// physically based shading
-			gammaInput = false,
-			gammaOutput = false,
-			physicallyBasedShading = false,
+      // physically based shading
+      gammaInput = false,
+      gammaOutput = false,
+      physicallyBasedShading = false,
 
-			// shadow map
-			shadowMapEnabled = false,
-			shadowMapAutoUpdate = true,
-			shadowMapType = PCFShadowMap,
-			shadowMapCullFrontFaces = CullFaceFront,
-			shadowMapDebug = false,
-			shadowMapCascade = false,
+      // shadow map
+      shadowMapEnabled = false,
+      shadowMapAutoUpdate = true,
+      shadowMapType = PCFShadowMap,
+      shadowMapCullFrontFaces = CullFaceFront,
+      shadowMapDebug = false,
+      shadowMapCascade = false,
 
-			// morphs
-			maxMorphTargets = 8,
-			maxMorphNormals = 4,
+      // morphs
+      maxMorphTargets = 8,
+      maxMorphNormals = 4,
 
-			// flags
-			autoScaleCubemaps = true,
+      // flags
+      autoScaleCubemaps = true,
 
-			// custom render plugins
-			renderPluginsPre = [],
-			renderPluginsPost = [],
+      // custom render plugins
+      renderPluginsPre = [],
+      renderPluginsPost = [],
 
-			info = new WebGLRendererInfo(),
+      info = new WebGLRendererInfo(),
 
-			// internal properties
+      // internal properties
 
-	_programs = [],
-	_programs_counter = 0,
+  _programs = [],
+  _programs_counter = 0,
 
-	// internal state cache
+  // internal state cache
 
-	_currentProgram = null,
-	_currentFramebuffer = null,
-	_currentMaterialId = -1,
-	_currentGeometryGroupHash = null,
-	_currentCamera = null,
-	_geometryGroupCounter = 0,
+  _currentProgram = null,
+  _currentFramebuffer = null,
+  _currentMaterialId = -1,
+  _currentGeometryGroupHash = null,
+  _currentCamera = null,
+  _geometryGroupCounter = 0,
 
-	// GL state cache
+  // GL state cache
 
-	_oldDoubleSided = -1,
-	_oldFlipSided = -1,
+  _oldDoubleSided = -1,
+  _oldFlipSided = -1,
 
-	_oldBlending = -1,
+  _oldBlending = -1,
 
-	_oldBlendEquation = -1,
-	_oldBlendSrc = -1,
-	_oldBlendDst = -1,
+  _oldBlendEquation = -1,
+  _oldBlendSrc = -1,
+  _oldBlendDst = -1,
 
-	_oldDepthTest = -1,
-	_oldDepthWrite = -1,
+  _oldDepthTest = -1,
+  _oldDepthWrite = -1,
 
-	_oldPolygonOffset = null,
-	_oldPolygonOffsetFactor = null,
-	_oldPolygonOffsetUnits = null,
+  _oldPolygonOffset = null,
+  _oldPolygonOffsetFactor = null,
+  _oldPolygonOffsetUnits = null,
 
-	_oldLineWidth = null,
+  _oldLineWidth = null,
 
-	_viewportX = 0,
-	_viewportY = 0,
-	_viewportWidth = 0,
-	_viewportHeight = 0,
-	_currentWidth = 0,
-	_currentHeight = 0 ,
+  _viewportX = 0,
+  _viewportY = 0,
+  _viewportWidth = 0,
+  _viewportHeight = 0,
+  _currentWidth = 0,
+  _currentHeight = 0 ,
 
   _enabledAttributes = {},
 
-	// frustum
+  // frustum
   _frustum = new Frustum(),
 
    // camera matrices cache
@@ -288,12 +288,12 @@ class WebGLRenderer implements Renderer {
 
     _lights = {
 
-	    "ambient": [ 0, 0, 0 ],
-	    "directional": { "length": 0, "colors": [], "positions": [] },
-	    "point": { "length": 0, "colors": [], "positions": [], "distances": [] },
-	    "spot": { "length": 0, "colors": [], "positions": [], "distances": [], "directions": [], "anglesCos": [], "exponents": [] },
-	    "hemi": { "length": 0, "skyColors": [], "groundColors": [], "positions": [] }
-	  };
+      "ambient": [ 0, 0, 0 ],
+      "directional": { "length": 0, "colors": [], "positions": [] },
+      "point": { "length": 0, "colors": [], "positions": [], "distances": [] },
+      "spot": { "length": 0, "colors": [], "positions": [], "distances": [], "directions": [], "anglesCos": [], "exponents": [] },
+      "hemi": { "length": 0, "skyColors": [], "groundColors": [], "positions": [] }
+    };
 
 
 
@@ -301,25 +301,25 @@ class WebGLRenderer implements Renderer {
         canvas = new CanvasElement();
     }
 
-  	// initialize
+    // initialize
 
-  	initGL();
+    initGL();
 
-  	setDefaultGLState();
+    setDefaultGLState();
 
 
-  	// GPU capabilities
-  	maxTextures = _gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
-  	maxVertexTextures = _gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );
-	maxTextureSize = _gl.getParameter( gl.MAX_TEXTURE_SIZE );
-	maxCubemapSize = _gl.getParameter( gl.MAX_CUBE_MAP_TEXTURE_SIZE );
+    // GPU capabilities
+    maxTextures = _gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
+    maxVertexTextures = _gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );
+  maxTextureSize = _gl.getParameter( gl.MAX_TEXTURE_SIZE );
+  maxCubemapSize = _gl.getParameter( gl.MAX_CUBE_MAP_TEXTURE_SIZE );
 
-  	maxAnisotropy = (_glExtensionTextureFilterAnisotropic != null) ? _gl.getParameter( gl.ExtTextureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT ) : 0;
+    maxAnisotropy = (_glExtensionTextureFilterAnisotropic != null) ? _gl.getParameter( gl.ExtTextureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT ) : 0;
 
-  	supportsVertexTextures = ( maxVertexTextures > 0 );
-  	supportsBoneTextures = supportsVertexTextures && (_glExtensionTextureFloat != null);
+    supportsVertexTextures = ( maxVertexTextures > 0 );
+    supportsBoneTextures = supportsVertexTextures && (_glExtensionTextureFloat != null);
 
-  	var _compressedTextureFormats = (_glExtensionCompressedTextureS3TC != null) ? _gl.getParameter( gl.COMPRESSED_TEXTURE_FORMATS ) : [];
+    var _compressedTextureFormats = (_glExtensionCompressedTextureS3TC != null) ? _gl.getParameter( gl.COMPRESSED_TEXTURE_FORMATS ) : [];
 
     //
 
@@ -367,4181 +367,4181 @@ class WebGLRenderer implements Renderer {
 
     }
 
-  	// default plugins (order is important)
+    // default plugins (order is important)
 
-  	shadowMapPlugin = new ShadowMapPlugin();
-  	addPrePlugin( shadowMapPlugin );
+    shadowMapPlugin = new ShadowMapPlugin();
+    addPrePlugin( shadowMapPlugin );
 
-  	//addPostPlugin( new SpritePlugin() );
-  	//addPostPlugin( new LensFlarePlugin() );
+    //addPostPlugin( new SpritePlugin() );
+    //addPostPlugin( new LensFlarePlugin() );
 
   }
 
   Element get domElement => canvas;
 
-	// API
+  // API
 
-	gl.RenderingContext get context => _gl;
+  gl.RenderingContext get context => _gl;
 
 
-	/// Resizes the output canvas to (width, height), and also sets the viewport
-	/// to fit that size, starting in (0, 0).
-	setSize( width, height ) {
-		canvas.width = (width * devicePixelRatio).toInt();
-		canvas.height = (height * devicePixelRatio).toInt();
+  /// Resizes the output canvas to (width, height), and also sets the viewport
+  /// to fit that size, starting in (0, 0).
+  setSize( width, height ) {
+    canvas.width = (width * devicePixelRatio).toInt();
+    canvas.height = (height * devicePixelRatio).toInt();
 
-		canvas.style.width = "${width}px";
-		canvas.style.height = "${height}px";
+    canvas.style.width = "${width}px";
+    canvas.style.height = "${height}px";
 
-		setViewport( 0, 0, canvas.width, canvas.height );
+    setViewport( 0, 0, canvas.width, canvas.height );
 
-	}
+  }
 
-	/// Sets the viewport to render from (x, y) to (x + width, y + height).
-	setViewport( [x = 0, y = 0, width = -1, height = -1] ) {
+  /// Sets the viewport to render from (x, y) to (x + width, y + height).
+  setViewport( [x = 0, y = 0, width = -1, height = -1] ) {
 
-		_viewportX = x;
-		_viewportY = y;
+    _viewportX = x;
+    _viewportY = y;
 
 
-		_viewportWidth = (width != -1) ? width : canvas.width;
-		_viewportHeight = (height != -1)? height : canvas.height;
+    _viewportWidth = (width != -1) ? width : canvas.width;
+    _viewportHeight = (height != -1)? height : canvas.height;
 
-		_gl.viewport( _viewportX, _viewportY, _viewportWidth, _viewportHeight );
+    _gl.viewport( _viewportX, _viewportY, _viewportWidth, _viewportHeight );
 
-	}
+  }
 
-	// Sets the scissor area from (x, y) to (x + width, y + height).
-	setScissor( int x, int y, int width, int height ) {
-		_gl.scissor( x, y, width, height );
-	}
+  // Sets the scissor area from (x, y) to (x + width, y + height).
+  setScissor( int x, int y, int width, int height ) {
+    _gl.scissor( x, y, width, height );
+  }
 
-	/// Enable the scissor test.
-	///
-	/// When this is enabled, only the pixels within the defined scissor area will
-	/// be affected by further renderer actions.
-	enableScissorTest( bool enable ) {
-		enable ? _gl.enable( gl.SCISSOR_TEST ) : _gl.disable( gl.SCISSOR_TEST );
-	}
+  /// Enable the scissor test.
+  ///
+  /// When this is enabled, only the pixels within the defined scissor area will
+  /// be affected by further renderer actions.
+  enableScissorTest( bool enable ) {
+    enable ? _gl.enable( gl.SCISSOR_TEST ) : _gl.disable( gl.SCISSOR_TEST );
+  }
 
-	// Clearing
-	setClearColorHex( num hex, num alpha ) {
+  // Clearing
+  setClearColorHex( num hex, num alpha ) {
 
-		_clearColor.setHex( hex );
-		_clearAlpha = alpha;
+    _clearColor.setHex( hex );
+    _clearAlpha = alpha;
 
-		_gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
+    _gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
 
-	}
+  }
 
-	/// Sets the clear color and opacity.
-	setClearColor( Color color, num alpha ) {
+  /// Sets the clear color and opacity.
+  setClearColor( Color color, num alpha ) {
 
-		_clearColor.copy( color );
-		_clearAlpha = alpha;
+    _clearColor.copy( color );
+    _clearAlpha = alpha;
 
-		_gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
+    _gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
 
-	}
+  }
 
-	/// Tells the renderer to clear its color, depth or stencil drawing buffer(s).
-	///
-	/// Arguments default to true.
-	clear( [ bool color = true, bool depth = true, bool stencil = true] ) {
+  /// Tells the renderer to clear its color, depth or stencil drawing buffer(s).
+  ///
+  /// Arguments default to true.
+  clear( [ bool color = true, bool depth = true, bool stencil = true] ) {
 
-		var bits = 0;
+    var bits = 0;
 
-		if ( color ) bits |= gl.COLOR_BUFFER_BIT;
-		if ( depth ) bits |= gl.DEPTH_BUFFER_BIT;
-		if ( stencil ) bits |= gl.STENCIL_BUFFER_BIT;
+    if ( color ) bits |= gl.COLOR_BUFFER_BIT;
+    if ( depth ) bits |= gl.DEPTH_BUFFER_BIT;
+    if ( stencil ) bits |= gl.STENCIL_BUFFER_BIT;
 
-		_gl.clear( bits );
+    _gl.clear( bits );
 
-	}
+  }
 
-	clearTarget( WebGLRenderTarget renderTarget, bool color, bool depth, bool stencil ) {
-		setRenderTarget( renderTarget );
-		clear( color, depth, stencil );
-	}
+  clearTarget( WebGLRenderTarget renderTarget, bool color, bool depth, bool stencil ) {
+    setRenderTarget( renderTarget );
+    clear( color, depth, stencil );
+  }
 
-	// Plugins
-	addPostPlugin( plugin ) {
-		plugin.init( this );
-		renderPluginsPost.add( plugin );
-	}
+  // Plugins
+  addPostPlugin( plugin ) {
+    plugin.init( this );
+    renderPluginsPost.add( plugin );
+  }
 
-	addPrePlugin( plugin ) {
-		plugin.init( this );
-		renderPluginsPre.add( plugin );
-	}
+  addPrePlugin( plugin ) {
+    plugin.init( this );
+    renderPluginsPre.add( plugin );
+  }
 
-	// Rendering
+  // Rendering
 
-	updateShadowMap( scene, camera ) {
+  updateShadowMap( scene, camera ) {
 
-		_currentProgram = null;
-		_oldBlending = -1;
-		_oldDepthTest = -1;
-		_oldDepthWrite = -1;
-		_currentGeometryGroupHash = -1;
-		_currentMaterialId = -1;
-		_lightsNeedUpdate = true;
-		_oldDoubleSided = -1;
-		_oldFlipSided = -1;
+    _currentProgram = null;
+    _oldBlending = -1;
+    _oldDepthTest = -1;
+    _oldDepthWrite = -1;
+    _currentGeometryGroupHash = -1;
+    _currentMaterialId = -1;
+    _lightsNeedUpdate = true;
+    _oldDoubleSided = -1;
+    _oldFlipSided = -1;
 
-		shadowMapPlugin.update( scene, camera );
+    shadowMapPlugin.update( scene, camera );
 
-	}
+  }
 
-	// Internal functions
+  // Internal functions
 
-	// Buffer allocation
+  // Buffer allocation
 
-	createParticleBuffers ( Geometry geometry ) {
+  createParticleBuffers ( Geometry geometry ) {
 
-		geometry.__webglVertexBuffer = _gl.createBuffer();
-		geometry.__webglColorBuffer = _gl.createBuffer();
+    geometry.__webglVertexBuffer = _gl.createBuffer();
+    geometry.__webglColorBuffer = _gl.createBuffer();
 
-		info.memory.geometries++;
+    info.memory.geometries++;
 
-	}
+  }
 
-	createLineBuffers ( Geometry geometry ) {
+  createLineBuffers ( Geometry geometry ) {
 
-		geometry.__webglVertexBuffer = _gl.createBuffer();
-		geometry.__webglColorBuffer = _gl.createBuffer();
-		geometry.__webglLineDistanceBuffer = _gl.createBuffer();
+    geometry.__webglVertexBuffer = _gl.createBuffer();
+    geometry.__webglColorBuffer = _gl.createBuffer();
+    geometry.__webglLineDistanceBuffer = _gl.createBuffer();
 
-		info.memory.geometries ++;
+    info.memory.geometries ++;
 
-	}
+  }
 
-	createRibbonBuffers ( Geometry geometry ) {
+  createRibbonBuffers ( Geometry geometry ) {
 
-		geometry.__webglVertexBuffer = _gl.createBuffer();
-		geometry.__webglColorBuffer = _gl.createBuffer();
-		geometry.__webglNormalBuffer = _gl.createBuffer();
+    geometry.__webglVertexBuffer = _gl.createBuffer();
+    geometry.__webglColorBuffer = _gl.createBuffer();
+    geometry.__webglNormalBuffer = _gl.createBuffer();
 
-		info.memory.geometries ++;
+    info.memory.geometries ++;
 
-	}
+  }
 
-	createMeshBuffers ( WebGLGeometry geometryGroup ) {
+  createMeshBuffers ( WebGLGeometry geometryGroup ) {
 
-		geometryGroup.__webglVertexBuffer = _gl.createBuffer();
-		geometryGroup.__webglNormalBuffer = _gl.createBuffer();
-		geometryGroup.__webglTangentBuffer = _gl.createBuffer();
-		geometryGroup.__webglColorBuffer = _gl.createBuffer();
-		geometryGroup.__webglUVBuffer = _gl.createBuffer();
-		geometryGroup.__webglUV2Buffer = _gl.createBuffer();
+    geometryGroup.__webglVertexBuffer = _gl.createBuffer();
+    geometryGroup.__webglNormalBuffer = _gl.createBuffer();
+    geometryGroup.__webglTangentBuffer = _gl.createBuffer();
+    geometryGroup.__webglColorBuffer = _gl.createBuffer();
+    geometryGroup.__webglUVBuffer = _gl.createBuffer();
+    geometryGroup.__webglUV2Buffer = _gl.createBuffer();
 
-		geometryGroup.__webglSkinIndicesBuffer = _gl.createBuffer();
-		geometryGroup.__webglSkinWeightsBuffer = _gl.createBuffer();
+    geometryGroup.__webglSkinIndicesBuffer = _gl.createBuffer();
+    geometryGroup.__webglSkinWeightsBuffer = _gl.createBuffer();
 
-		geometryGroup.__webglFaceBuffer = _gl.createBuffer();
-		geometryGroup.__webglLineBuffer = _gl.createBuffer();
+    geometryGroup.__webglFaceBuffer = _gl.createBuffer();
+    geometryGroup.__webglLineBuffer = _gl.createBuffer();
 
-		var m, ml;
+    var m, ml;
 
-		if ( geometryGroup.numMorphTargets != null ) {
+    if ( geometryGroup.numMorphTargets != null ) {
 
-			geometryGroup.__webglMorphTargetsBuffers = [];
+      geometryGroup.__webglMorphTargetsBuffers = [];
 
-			 ml = geometryGroup.numMorphTargets;
+       ml = geometryGroup.numMorphTargets;
 
-			for ( m = 0; m < ml; m ++ ) {
+      for ( m = 0; m < ml; m ++ ) {
 
-				geometryGroup.__webglMorphTargetsBuffers.add( _gl.createBuffer() );
+        geometryGroup.__webglMorphTargetsBuffers.add( _gl.createBuffer() );
 
-			}
+      }
 
-		}
+    }
 
-		if ( geometryGroup.numMorphNormals != null ) {
+    if ( geometryGroup.numMorphNormals != null ) {
 
-			geometryGroup.__webglMorphNormalsBuffers = [];
+      geometryGroup.__webglMorphNormalsBuffers = [];
 
-			ml = geometryGroup.numMorphNormals;
+      ml = geometryGroup.numMorphNormals;
 
-			for ( m = 0; m < ml; m ++ ) {
-				geometryGroup.__webglMorphNormalsBuffers.add( _gl.createBuffer() );
+      for ( m = 0; m < ml; m ++ ) {
+        geometryGroup.__webglMorphNormalsBuffers.add( _gl.createBuffer() );
 
-			}
+      }
 
-		}
+    }
 
-		info.memory.geometries++;
+    info.memory.geometries++;
 
-	}
+  }
 
-	// Events
+  // Events
 
-	onGeometryDispose( event ) {
+  onGeometryDispose( event ) {
 
-		var geometry = event.target;
+    var geometry = event.target;
 
-		geometry.removeEventListener( 'dispose', onGeometryDispose );
+    geometry.removeEventListener( 'dispose', onGeometryDispose );
 
-		deallocateGeometry( geometry );
+    deallocateGeometry( geometry );
 
-		info.memory.geometries --;
+    info.memory.geometries --;
 
-	}
+  }
 
-	onTextureDispose( event ) {
+  onTextureDispose( event ) {
 
-		var texture = event.target;
+    var texture = event.target;
 
-		texture.removeEventListener( 'dispose', onTextureDispose );
+    texture.removeEventListener( 'dispose', onTextureDispose );
 
-		deallocateTexture( texture );
+    deallocateTexture( texture );
 
-		info.memory.textures --;
+    info.memory.textures --;
 
-	}
+  }
 
-	onRenderTargetDispose( event ) {
+  onRenderTargetDispose( event ) {
 
-		var renderTarget = event.target;
+    var renderTarget = event.target;
 
-		renderTarget.removeEventListener( 'dispose', onRenderTargetDispose );
+    renderTarget.removeEventListener( 'dispose', onRenderTargetDispose );
 
-		deallocateRenderTarget( renderTarget );
+    deallocateRenderTarget( renderTarget );
 
-		info.memory.textures --;
+    info.memory.textures --;
 
-	}
+  }
 
-	onMaterialDispose( event ) {
+  onMaterialDispose( event ) {
 
-		var material = event.target;
+    var material = event.target;
 
-		material.removeEventListener( 'dispose', onMaterialDispose );
+    material.removeEventListener( 'dispose', onMaterialDispose );
 
-		deallocateMaterial( material );
+    deallocateMaterial( material );
 
-	}
+  }
 
-	// Buffer deallocation
-	deallocateGeometry( Geometry geometry ) {
+  // Buffer deallocation
+  deallocateGeometry( Geometry geometry ) {
 
-		geometry.__webglInit = false;
+    geometry.__webglInit = false;
 
-		if ( geometry.__webglVertexBuffer != null ) _gl.deleteBuffer( geometry.__webglVertexBuffer );
-		if ( geometry.__webglNormalBuffer != null  ) _gl.deleteBuffer( geometry.__webglNormalBuffer );
-		if ( geometry.__webglTangentBuffer != null  ) _gl.deleteBuffer( geometry.__webglTangentBuffer );
-		if ( geometry.__webglColorBuffer != null  ) _gl.deleteBuffer( geometry.__webglColorBuffer );
-		if ( geometry.__webglUVBuffer != null  ) _gl.deleteBuffer( geometry.__webglUVBuffer );
-		if ( geometry.__webglUV2Buffer != null  ) _gl.deleteBuffer( geometry.__webglUV2Buffer );
+    if ( geometry.__webglVertexBuffer != null ) _gl.deleteBuffer( geometry.__webglVertexBuffer );
+    if ( geometry.__webglNormalBuffer != null  ) _gl.deleteBuffer( geometry.__webglNormalBuffer );
+    if ( geometry.__webglTangentBuffer != null  ) _gl.deleteBuffer( geometry.__webglTangentBuffer );
+    if ( geometry.__webglColorBuffer != null  ) _gl.deleteBuffer( geometry.__webglColorBuffer );
+    if ( geometry.__webglUVBuffer != null  ) _gl.deleteBuffer( geometry.__webglUVBuffer );
+    if ( geometry.__webglUV2Buffer != null  ) _gl.deleteBuffer( geometry.__webglUV2Buffer );
 
-		if ( geometry.__webglSkinIndicesBuffer != null  ) _gl.deleteBuffer( geometry.__webglSkinIndicesBuffer );
-		if ( geometry.__webglSkinWeightsBuffer != null  ) _gl.deleteBuffer( geometry.__webglSkinWeightsBuffer );
+    if ( geometry.__webglSkinIndicesBuffer != null  ) _gl.deleteBuffer( geometry.__webglSkinIndicesBuffer );
+    if ( geometry.__webglSkinWeightsBuffer != null  ) _gl.deleteBuffer( geometry.__webglSkinWeightsBuffer );
 
-		if ( geometry.__webglFaceBuffer != null  ) _gl.deleteBuffer( geometry.__webglFaceBuffer );
-		if ( geometry.__webglLineBuffer != null  ) _gl.deleteBuffer( geometry.__webglLineBuffer );
+    if ( geometry.__webglFaceBuffer != null  ) _gl.deleteBuffer( geometry.__webglFaceBuffer );
+    if ( geometry.__webglLineBuffer != null  ) _gl.deleteBuffer( geometry.__webglLineBuffer );
 
-		if ( geometry.__webglLineDistanceBuffer != null  ) _gl.deleteBuffer( geometry.__webglLineDistanceBuffer );
+    if ( geometry.__webglLineDistanceBuffer != null  ) _gl.deleteBuffer( geometry.__webglLineDistanceBuffer );
 
-		// geometry groups
+    // geometry groups
 
-		if ( geometry.geometryGroups != null  ) {
+    if ( geometry.geometryGroups != null  ) {
 
-			for ( var g in geometry.geometryGroups ) {
+      for ( var g in geometry.geometryGroups ) {
 
-				var geometryGroup = geometry.geometryGroups[ g ];
+        var geometryGroup = geometry.geometryGroups[ g ];
 
-				if ( geometryGroup.numMorphTargets != null  ) {
+        if ( geometryGroup.numMorphTargets != null  ) {
 
-					for ( var m = 0, ml = geometryGroup.numMorphTargets; m < ml; m ++ ) {
+          for ( var m = 0, ml = geometryGroup.numMorphTargets; m < ml; m ++ ) {
 
-						_gl.deleteBuffer( geometryGroup.__webglMorphTargetsBuffers[ m ] );
+            _gl.deleteBuffer( geometryGroup.__webglMorphTargetsBuffers[ m ] );
 
-					}
+          }
 
-				}
+        }
 
-				if ( geometryGroup.numMorphNormals != null  ) {
+        if ( geometryGroup.numMorphNormals != null  ) {
 
-					for ( var m = 0, ml = geometryGroup.numMorphNormals; m < ml; m ++ ) {
+          for ( var m = 0, ml = geometryGroup.numMorphNormals; m < ml; m ++ ) {
 
-						_gl.deleteBuffer( geometryGroup.__webglMorphNormalsBuffers[ m ] );
+            _gl.deleteBuffer( geometryGroup.__webglMorphNormalsBuffers[ m ] );
 
-					}
+          }
 
-				}
+        }
 
-				deleteCustomAttributesBuffers( geometryGroup );
+        deleteCustomAttributesBuffers( geometryGroup );
 
-			}
+      }
 
-		}
+    }
 
-		deleteCustomAttributesBuffers( geometry );
+    deleteCustomAttributesBuffers( geometry );
 
-	}
+  }
 
-	deallocateTexture( Texture texture ) {
+  deallocateTexture( Texture texture ) {
 
-		if ( texture.image && texture.image.__webglTextureCube ) {
+    if ( texture.image && texture.image.__webglTextureCube ) {
 
-			// cube texture
+      // cube texture
 
-			_gl.deleteTexture( texture.image.__webglTextureCube );
+      _gl.deleteTexture( texture.image.__webglTextureCube );
 
-		} else {
+    } else {
 
-			// 2D texture
+      // 2D texture
 
-			if ( ! texture["__webglInit"] ) return;
+      if ( ! texture["__webglInit"] ) return;
 
-			texture["__webglInit"] = false;
-			_gl.deleteTexture( texture.__webglTexture );
+      texture["__webglInit"] = false;
+      _gl.deleteTexture( texture.__webglTexture );
 
-		}
+    }
 
-	}
+  }
 
-	deallocateRenderTarget( renderTarget ) {
+  deallocateRenderTarget( renderTarget ) {
 
-		if ( !renderTarget || ! renderTarget.__webglTexture ) return;
+    if ( !renderTarget || ! renderTarget.__webglTexture ) return;
 
-		_gl.deleteTexture( renderTarget.__webglTexture );
+    _gl.deleteTexture( renderTarget.__webglTexture );
 
-		if ( renderTarget is WebGLRenderTargetCube ) {
+    if ( renderTarget is WebGLRenderTargetCube ) {
 
-			for ( var i = 0; i < 6; i ++ ) {
+      for ( var i = 0; i < 6; i ++ ) {
 
-				_gl.deleteFramebuffer( renderTarget.__webglFramebuffer[ i ] );
-				_gl.deleteRenderbuffer( renderTarget.__webglRenderbuffer[ i ] );
+        _gl.deleteFramebuffer( renderTarget.__webglFramebuffer[ i ] );
+        _gl.deleteRenderbuffer( renderTarget.__webglRenderbuffer[ i ] );
 
-			}
+      }
 
-		} else {
+    } else {
 
-			_gl.deleteFramebuffer( renderTarget.__webglFramebuffer );
-			_gl.deleteRenderbuffer( renderTarget.__webglRenderbuffer );
+      _gl.deleteFramebuffer( renderTarget.__webglFramebuffer );
+      _gl.deleteRenderbuffer( renderTarget.__webglRenderbuffer );
 
-		}
+    }
 
-	}
+  }
 
-	deallocateMaterial( Material material ) {
+  deallocateMaterial( Material material ) {
 
-		var program = material._program;
+    var program = material._program;
 
-		if ( program == null ) return;
+    if ( program == null ) return;
 
-		material._program = null;
+    material._program = null;
 
-		// only deallocate GL program if this was the last use of shared program
-		// assumed there is only single copy of any program in the _programs list
-		// (that's how it's constructed)
+    // only deallocate GL program if this was the last use of shared program
+    // assumed there is only single copy of any program in the _programs list
+    // (that's how it's constructed)
 
-		var i, il;
-		Program programInfo;
-		var deleteProgram = false;
+    var i, il;
+    Program programInfo;
+    var deleteProgram = false;
 
-		for ( var i = 0, il = _programs.length; i < il; i ++ ) {
+    for ( var i = 0, il = _programs.length; i < il; i ++ ) {
 
-			programInfo = _programs[ i ];
+      programInfo = _programs[ i ];
 
-			if ( programInfo.glProgram == program ) {
+      if ( programInfo.glProgram == program ) {
 
-				programInfo.usedTimes --;
+        programInfo.usedTimes --;
 
-				if ( programInfo.usedTimes == 0 ) {
+        if ( programInfo.usedTimes == 0 ) {
 
-					deleteProgram = true;
+          deleteProgram = true;
 
-				}
+        }
 
-				break;
+        break;
 
-			}
+      }
 
-		}
+    }
 
-		if ( deleteProgram == true ) {
+    if ( deleteProgram == true ) {
 
-			// avoid using array.splice, this is costlier than creating new array from scratch
+      // avoid using array.splice, this is costlier than creating new array from scratch
 
-			var newPrograms = [];
+      var newPrograms = [];
 
-			for ( var i = 0, il = _programs.length; i < il; i ++ ) {
+      for ( var i = 0, il = _programs.length; i < il; i ++ ) {
 
-				programInfo = _programs[ i ];
+        programInfo = _programs[ i ];
 
-				if ( programInfo.glProgram != program ) {
+        if ( programInfo.glProgram != program ) {
 
-					newPrograms.add( programInfo );
+          newPrograms.add( programInfo );
 
-				}
+        }
 
-			}
+      }
 
-			_programs = newPrograms;
+      _programs = newPrograms;
 
-			_gl.deleteProgram( program );
+      _gl.deleteProgram( program );
 
-			info.memory.programs --;
+      info.memory.programs --;
 
-		}
+    }
 
-	}
+  }
 
-	deleteCustomAttributesBuffers( Geometry geometry ) {
+  deleteCustomAttributesBuffers( Geometry geometry ) {
 
-		if ( geometry.__webglCustomAttributesList ) {
+    if ( geometry.__webglCustomAttributesList ) {
 
-			for ( var id in geometry.__webglCustomAttributesList ) {
+      for ( var id in geometry.__webglCustomAttributesList ) {
 
-				_gl.deleteBuffer( geometry.__webglCustomAttributesList[ id ].buffer );
+        _gl.deleteBuffer( geometry.__webglCustomAttributesList[ id ].buffer );
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	// Buffer initialization
+  // Buffer initialization
 
-	initCustomAttributes ( Geometry geometry, Object3D object ) {
+  initCustomAttributes ( Geometry geometry, Object3D object ) {
 
-		var nvertices = geometry.vertices.length;
+    var nvertices = geometry.vertices.length;
 
-		var material = object.material;
+    var material = object.material;
 
-		if ( material is ShaderMaterial && material.attributes != null ) {
+    if ( material is ShaderMaterial && material.attributes != null ) {
 
-			if ( geometry.__webglCustomAttributesList == null ) {
+      if ( geometry.__webglCustomAttributesList == null ) {
 
-				geometry.__webglCustomAttributesList = [];
+        geometry.__webglCustomAttributesList = [];
 
-			}
+      }
 
-			material.attributes.forEach((key, attribute) {
+      material.attributes.forEach((key, attribute) {
 
-				if( !attribute.__webglInitialized || attribute.createUniqueBuffers ) {
+        if( !attribute.__webglInitialized || attribute.createUniqueBuffers ) {
 
-					attribute.__webglInitialized = true;
+          attribute.__webglInitialized = true;
 
-					attribute.array = new Float32List( nvertices * attribute.size );
+          attribute.array = new Float32List( nvertices * attribute.size );
 
-					attribute.buffer = new Buffer(_gl);
-					attribute.buffer.belongsToAttribute = key;
+          attribute.buffer = new Buffer(_gl);
+          attribute.buffer.belongsToAttribute = key;
 
-					attribute.needsUpdate = true;
+          attribute.needsUpdate = true;
 
-				}
+        }
 
-				geometry.__webglCustomAttributesList.add( attribute );
+        geometry.__webglCustomAttributesList.add( attribute );
 
-			});
+      });
 
-		}
+    }
 
-	}
+  }
 
-	initParticleBuffers ( Geometry geometry, Object3D object ) {
+  initParticleBuffers ( Geometry geometry, Object3D object ) {
 
-		var nvertices = geometry.vertices.length;
+    var nvertices = geometry.vertices.length;
 
-		geometry.__vertexArray = new Float32List( nvertices * 3 );
-		geometry.__colorArray = new Float32List( nvertices * 3 );
+    geometry.__vertexArray = new Float32List( nvertices * 3 );
+    geometry.__colorArray = new Float32List( nvertices * 3 );
 
-		geometry.__sortArray = [];
+    geometry.__sortArray = [];
 
-		geometry.__webglParticleCount = nvertices;
+    geometry.__webglParticleCount = nvertices;
 
-		initCustomAttributes ( geometry, object );
+    initCustomAttributes ( geometry, object );
 
-	}
+  }
 
-	initLineBuffers ( Geometry geometry, Object3D object ) {
+  initLineBuffers ( Geometry geometry, Object3D object ) {
 
-		var nvertices = geometry.vertices.length;
+    var nvertices = geometry.vertices.length;
 
-		geometry.__vertexArray = new Float32List( nvertices * 3 );
-		geometry.__colorArray = new Float32List( nvertices * 3 );
-		geometry.__lineDistanceArray = new Float32List( nvertices * 1 );
+    geometry.__vertexArray = new Float32List( nvertices * 3 );
+    geometry.__colorArray = new Float32List( nvertices * 3 );
+    geometry.__lineDistanceArray = new Float32List( nvertices * 1 );
 
-		geometry.__webglLineCount = nvertices;
+    geometry.__webglLineCount = nvertices;
 
-		initCustomAttributes ( geometry, object );
+    initCustomAttributes ( geometry, object );
 
-	}
+  }
 
-	initRibbonBuffers ( Geometry geometry, object ) {
+  initRibbonBuffers ( Geometry geometry, object ) {
 
-		var nvertices = geometry.vertices.length;
+    var nvertices = geometry.vertices.length;
 
-		geometry.__vertexArray = new Float32List( nvertices * 3 );
-		geometry.__colorArray = new Float32List( nvertices * 3 );
-		geometry.__normalArray = new Float32List( nvertices * 3 );
+    geometry.__vertexArray = new Float32List( nvertices * 3 );
+    geometry.__colorArray = new Float32List( nvertices * 3 );
+    geometry.__normalArray = new Float32List( nvertices * 3 );
 
-		geometry.__webglVertexCount = nvertices;
+    geometry.__webglVertexCount = nvertices;
 
-		initCustomAttributes ( geometry, object );
+    initCustomAttributes ( geometry, object );
 
-	}
+  }
 
-	initMeshBuffers ( WebGLGeometry geometryGroup, Object3D object ) {
+  initMeshBuffers ( WebGLGeometry geometryGroup, Object3D object ) {
 
-		var geometry = object.geometry,
-			faces3 = geometryGroup.faces3,
-			faces4 = geometryGroup.faces4,
+    var geometry = object.geometry,
+      faces3 = geometryGroup.faces3,
+      faces4 = geometryGroup.faces4,
 
-			nvertices = faces3.length * 3 + faces4.length * 4,
-			ntris     = faces3.length * 1 + faces4.length * 2,
-			nlines    = faces3.length * 3 + faces4.length * 4;
+      nvertices = faces3.length * 3 + faces4.length * 4,
+      ntris     = faces3.length * 1 + faces4.length * 2,
+      nlines    = faces3.length * 3 + faces4.length * 4;
 
-		Material material = getBufferMaterial( object, geometryGroup );
+    Material material = getBufferMaterial( object, geometryGroup );
 
-		var uvType = bufferGuessUVType( material ),
-			normalType = bufferGuessNormalType( material );
+    var uvType = bufferGuessUVType( material ),
+      normalType = bufferGuessNormalType( material );
 
-		//console.log( "uvType", uvType, "normalType", normalType, "vertexColorType", vertexColorType, object, geometryGroup, material );
+    //console.log( "uvType", uvType, "normalType", normalType, "vertexColorType", vertexColorType, object, geometryGroup, material );
 
-		geometryGroup.__vertexArray = new Float32List( nvertices * 3 );
+    geometryGroup.__vertexArray = new Float32List( nvertices * 3 );
 
-		if ( normalType != NoShading ) {
+    if ( normalType != NoShading ) {
 
-			geometryGroup.__normalArray = new Float32List( nvertices * 3 );
+      geometryGroup.__normalArray = new Float32List( nvertices * 3 );
 
-		}
+    }
 
-		if ( geometry.hasTangents ) {
+    if ( geometry.hasTangents ) {
 
-			geometryGroup.__tangentArray = new Float32List( nvertices * 4 );
+      geometryGroup.__tangentArray = new Float32List( nvertices * 4 );
 
-		}
+    }
 
-		if ( material.vertexColors != NoColors ) {
+    if ( material.vertexColors != NoColors ) {
 
-			geometryGroup.__colorArray = new Float32List( nvertices * 3 );
+      geometryGroup.__colorArray = new Float32List( nvertices * 3 );
 
-		}
+    }
 
-		if ( uvType ) {
+    if ( uvType ) {
 
-			if ( geometry.faceUvs.length > 0 || geometry.faceVertexUvs.length > 0 ) {
+      if ( geometry.faceUvs.length > 0 || geometry.faceVertexUvs.length > 0 ) {
 
-				geometryGroup.__uvArray = new Float32List( nvertices * 2 );
+        geometryGroup.__uvArray = new Float32List( nvertices * 2 );
 
-			}
+      }
 
-			if ( geometry.faceUvs.length > 1 || geometry.faceVertexUvs.length > 1 ) {
+      if ( geometry.faceUvs.length > 1 || geometry.faceVertexUvs.length > 1 ) {
 
-				geometryGroup.__uv2Array = new Float32List( nvertices * 2 );
+        geometryGroup.__uv2Array = new Float32List( nvertices * 2 );
 
-			}
+      }
 
-		}
+    }
 
-		if ( !object.geometry.skinWeights.isEmpty && !object.geometry.skinIndices.isEmpty ) {
+    if ( !object.geometry.skinWeights.isEmpty && !object.geometry.skinIndices.isEmpty ) {
 
-			geometryGroup.__skinIndexArray = new Float32List( nvertices * 4 );
-			geometryGroup.__skinWeightArray = new Float32List( nvertices * 4 );
+      geometryGroup.__skinIndexArray = new Float32List( nvertices * 4 );
+      geometryGroup.__skinWeightArray = new Float32List( nvertices * 4 );
 
-		}
+    }
 
-		geometryGroup.__faceArray = new Uint16List( ntris * 3 );
-		geometryGroup.__lineArray = new Uint16List( nlines * 2 );
+    geometryGroup.__faceArray = new Uint16List( ntris * 3 );
+    geometryGroup.__lineArray = new Uint16List( nlines * 2 );
 
-		var m, ml;
+    var m, ml;
 
-		if ( geometryGroup.numMorphTargets != null ) {
+    if ( geometryGroup.numMorphTargets != null ) {
 
-			geometryGroup.__morphTargetsArrays = [];
+      geometryGroup.__morphTargetsArrays = [];
 
-			ml = geometryGroup.numMorphTargets;
+      ml = geometryGroup.numMorphTargets;
 
-			for ( m = 0; m < ml; m ++ ) {
+      for ( m = 0; m < ml; m ++ ) {
 
-				geometryGroup.__morphTargetsArrays.add( new Float32List( nvertices * 3 ) );
+        geometryGroup.__morphTargetsArrays.add( new Float32List( nvertices * 3 ) );
 
-			}
+      }
 
-		}
+    }
 
-		if ( geometryGroup.numMorphNormals != null ) {
+    if ( geometryGroup.numMorphNormals != null ) {
 
-			geometryGroup.__morphNormalsArrays = [];
+      geometryGroup.__morphNormalsArrays = [];
 
-			ml = geometryGroup.numMorphNormals;
+      ml = geometryGroup.numMorphNormals;
 
-			for ( m = 0; m < ml; m ++ ) {
+      for ( m = 0; m < ml; m ++ ) {
 
-				geometryGroup.__morphNormalsArrays.add( new Float32List( nvertices * 3 ) );
+        geometryGroup.__morphNormalsArrays.add( new Float32List( nvertices * 3 ) );
 
-			}
+      }
 
-		}
+    }
 
-		geometryGroup.__webglFaceCount = ntris * 3;
-		geometryGroup.__webglLineCount = nlines * 2;
+    geometryGroup.__webglFaceCount = ntris * 3;
+    geometryGroup.__webglLineCount = nlines * 2;
 
 
-		// custom attributes
+    // custom attributes
 
-		if ( material is ShaderMaterial && material.attributes != null) {
+    if ( material is ShaderMaterial && material.attributes != null) {
 
-			if ( geometryGroup.__webglCustomAttributesList == null ) {
+      if ( geometryGroup.__webglCustomAttributesList == null ) {
 
-				geometryGroup.__webglCustomAttributesList = [];
+        geometryGroup.__webglCustomAttributesList = [];
 
-			}
+      }
 
-			material.attributes.forEach((key, attribute) {
+      material.attributes.forEach((key, attribute) {
 
-				if( !attribute.__webglInitialized || attribute.createUniqueBuffers ) {
+        if( !attribute.__webglInitialized || attribute.createUniqueBuffers ) {
 
-					attribute.__webglInitialized = true;
-					attribute.array = new Float32List( nvertices * attribute.size );
+          attribute.__webglInitialized = true;
+          attribute.array = new Float32List( nvertices * attribute.size );
 
-					var buffer = new Buffer(_gl);
-					buffer.belongsToAttribute = key;
-					attribute.buffer = buffer;
+          var buffer = new Buffer(_gl);
+          buffer.belongsToAttribute = key;
+          attribute.buffer = buffer;
 
           // Do a shallow copy of the attribute object so different geometryGroup chunks use different
-	        // attribute buffers which are correctly indexed in the setMeshBuffers function
+          // attribute buffers which are correctly indexed in the setMeshBuffers function
 
-	        var originalAttribute = attribute.clone();
-					originalAttribute.needsUpdate = true;
-					attribute.__original = originalAttribute;
+          var originalAttribute = attribute.clone();
+          originalAttribute.needsUpdate = true;
+          attribute.__original = originalAttribute;
 
-				}
+        }
 
-				geometryGroup.__webglCustomAttributesList.add( attribute );
+        geometryGroup.__webglCustomAttributesList.add( attribute );
 
-			});
+      });
 
-		}
+    }
 
-		geometryGroup.__inittedArrays = true;
+    geometryGroup.__inittedArrays = true;
 
-	}
+  }
 
-	Material getBufferMaterial( Object3D object, WebGLGeometry geometry ) {
+  Material getBufferMaterial( Object3D object, WebGLGeometry geometry ) {
 
-	  return (object.material is MeshFaceMaterial)
-			? (object.material as MeshFaceMaterial).materials[ geometry.materialIndex ]
-			: object.material;
+    return (object.material is MeshFaceMaterial)
+      ? (object.material as MeshFaceMaterial).materials[ geometry.materialIndex ]
+      : object.material;
 
-	}
+  }
 
-	bool materialNeedsSmoothNormals ( material ) {
+  bool materialNeedsSmoothNormals ( material ) {
 
-		return material != null && material.shading != null && material.shading == SmoothShading;
+    return material != null && material.shading != null && material.shading == SmoothShading;
 
-	}
+  }
 
-	int bufferGuessNormalType ( Material material ) {
+  int bufferGuessNormalType ( Material material ) {
 
-		// only MeshBasicMaterial and MeshDepthMaterial don't need normals
+    // only MeshBasicMaterial and MeshDepthMaterial don't need normals
 
-		if ( ( ( material is MeshBasicMaterial ) && ( material.envMap == null ) ) || (material is MeshDepthMaterial ) ) {
-			return NoShading;
-		}
+    if ( ( ( material is MeshBasicMaterial ) && ( material.envMap == null ) ) || (material is MeshDepthMaterial ) ) {
+      return NoShading;
+    }
 
-		if ( materialNeedsSmoothNormals(material) ) {
+    if ( materialNeedsSmoothNormals(material) ) {
 
-			return SmoothShading;
+      return SmoothShading;
 
-		} else {
+    } else {
 
-			return FlatShading;
+      return FlatShading;
 
-		}
+    }
 
-	}
+  }
 
-	bool bufferGuessUVType ( Material material ) {
+  bool bufferGuessUVType ( Material material ) {
 
-		// material must use some texture to require uvs
+    // material must use some texture to require uvs
 
-		if (((material is TextureMapping) && (material as TextureMapping).map != null)) {
-			return true;
-		}
+    if (((material is TextureMapping) && (material as TextureMapping).map != null)) {
+      return true;
+    }
 
-		if (material is EnvironmentMapping) {
-		  if (((material as EnvironmentMapping).lightMap != null) ||
+    if (material is EnvironmentMapping) {
+      if (((material as EnvironmentMapping).lightMap != null) ||
           ((material as EnvironmentMapping).specularMap != null)) {
-		    return true;
-		  }
-		}
+        return true;
+      }
+    }
 
-		if (material is BumpMapping) {
+    if (material is BumpMapping) {
       if (((material as BumpMapping).bumpMap != null) ||
           ((material as BumpMapping).normalMap != null)) {
         return true;
       }
     }
 
-		return (material is ShaderMaterial);
+    return (material is ShaderMaterial);
 
-	}
+  }
 
-	//
+  //
 
-	initDirectBuffers( BufferGeometry geometry ) {
+  initDirectBuffers( BufferGeometry geometry ) {
 
-		var a, attribute, type;
+    var a, attribute, type;
 
-		geometry.attributes.forEach((a, v) {
+    geometry.attributes.forEach((a, v) {
 
-			if ( a == "index" ) {
+      if ( a == "index" ) {
 
-				type = gl.ELEMENT_ARRAY_BUFFER;
+        type = gl.ELEMENT_ARRAY_BUFFER;
 
-			} else {
+      } else {
 
-				type = gl.ARRAY_BUFFER;
+        type = gl.ARRAY_BUFFER;
 
-			}
+      }
 
-			attribute = v;
+      attribute = v;
 
-			attribute.buffer = new Buffer(_gl);
-			attribute.buffer.bind(type);
-			_gl.bufferDataTyped(type, attribute.array, gl.STATIC_DRAW);
+      attribute.buffer = new Buffer(_gl);
+      attribute.buffer.bind(type);
+      _gl.bufferDataTyped(type, attribute.array, gl.STATIC_DRAW);
 
-		});
+    });
 
-	}
+  }
 
-	// Buffer setting
+  // Buffer setting
 
-	setParticleBuffers ( Geometry geometry, int hint, object ) {
+  setParticleBuffers ( Geometry geometry, int hint, object ) {
 
-		var v, c, vertex, offset, index, color,
+    var v, c, vertex, offset, index, color,
 
-		vertices = geometry.vertices,
-		vl = vertices.length,
+    vertices = geometry.vertices,
+    vl = vertices.length,
 
-		colors = geometry.colors,
-		cl = colors.length,
+    colors = geometry.colors,
+    cl = colors.length,
 
-		vertexArray = geometry.__vertexArray,
-		colorArray = geometry.__colorArray,
+    vertexArray = geometry.__vertexArray,
+    colorArray = geometry.__colorArray,
 
-		sortArray = geometry.__sortArray,
+    sortArray = geometry.__sortArray,
 
-		dirtyVertices = geometry.verticesNeedUpdate,
-		dirtyElements = geometry.elementsNeedUpdate,
-		dirtyColors = geometry.colorsNeedUpdate,
+    dirtyVertices = geometry.verticesNeedUpdate,
+    dirtyElements = geometry.elementsNeedUpdate,
+    dirtyColors = geometry.colorsNeedUpdate,
 
-		customAttributes = geometry.__webglCustomAttributesList,
-		i, il,
-		a, ca, cal, value,
-		customAttribute;
+    customAttributes = geometry.__webglCustomAttributesList,
+    i, il,
+    a, ca, cal, value,
+    customAttribute;
 
-		if ( object.sortParticles ) {
+    if ( object.sortParticles ) {
 
-			_projScreenMatrixPS.setFrom( _projScreenMatrix );
-			_projScreenMatrixPS.multiply( object.matrixWorld );
+      _projScreenMatrixPS.setFrom( _projScreenMatrix );
+      _projScreenMatrixPS.multiply( object.matrixWorld );
 
-			for ( v = 0; v < vl; v ++ ) {
+      for ( v = 0; v < vl; v ++ ) {
 
-				vertex = vertices[ v ];
+        vertex = vertices[ v ];
 
-				_vector3.setFrom(vertex);
-				_vector3.applyProjection(_projScreenMatrixPS);
+        _vector3.setFrom(vertex);
+        _vector3.applyProjection(_projScreenMatrixPS);
 
-				sortArray[ v ] = [ _vector3.z, v ];
+        sortArray[ v ] = [ _vector3.z, v ];
 
-			}
+      }
 
-			sortArray.sort( numericalSort );
+      sortArray.sort( numericalSort );
 
-			for ( v = 0; v < vl; v ++ ) {
+      for ( v = 0; v < vl; v ++ ) {
 
-				vertex = vertices[ sortArray[v][1] ];
+        vertex = vertices[ sortArray[v][1] ];
 
-				offset = v * 3;
+        offset = v * 3;
 
-				vertexArray[ offset ]     = vertex.x;
-				vertexArray[ offset + 1 ] = vertex.y;
-				vertexArray[ offset + 2 ] = vertex.z;
+        vertexArray[ offset ]     = vertex.x;
+        vertexArray[ offset + 1 ] = vertex.y;
+        vertexArray[ offset + 2 ] = vertex.z;
 
-			}
+      }
 
-			for ( c = 0; c < cl; c ++ ) {
+      for ( c = 0; c < cl; c ++ ) {
 
-				offset = c * 3;
+        offset = c * 3;
 
-				color = colors[ sortArray[c][1] ];
+        color = colors[ sortArray[c][1] ];
 
-				colorArray[ offset ]     = color.r;
-				colorArray[ offset + 1 ] = color.g;
-				colorArray[ offset + 2 ] = color.b;
+        colorArray[ offset ]     = color.r;
+        colorArray[ offset + 1 ] = color.g;
+        colorArray[ offset + 2 ] = color.b;
 
-			}
+      }
 
-			if ( customAttributes != null ) {
+      if ( customAttributes != null ) {
 
-				il = customAttributes.length;
-				for ( i = 0; i < il; i ++ ) {
+        il = customAttributes.length;
+        for ( i = 0; i < il; i ++ ) {
 
-					customAttribute = customAttributes[ i ];
+          customAttribute = customAttributes[ i ];
 
-					if ( ! ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) ) continue;
+          if ( ! ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) ) continue;
 
-					offset = 0;
+          offset = 0;
 
-					cal = customAttribute.value.length;
+          cal = customAttribute.value.length;
 
-					if ( customAttribute.size == 1 ) {
+          if ( customAttribute.size == 1 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							index = sortArray[ ca ][ 1 ];
+              index = sortArray[ ca ][ 1 ];
 
-							customAttribute.array[ ca ] = customAttribute.value[ index ];
+              customAttribute.array[ ca ] = customAttribute.value[ index ];
 
-						}
+            }
 
-					} else if ( customAttribute.size == 2 ) {
+          } else if ( customAttribute.size == 2 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							index = sortArray[ ca ][ 1 ];
+              index = sortArray[ ca ][ 1 ];
 
-							value = customAttribute.value[ index ];
+              value = customAttribute.value[ index ];
 
-							customAttribute.array[ offset ] 	= value.x;
-							customAttribute.array[ offset + 1 ] = value.y;
+              customAttribute.array[ offset ]   = value.x;
+              customAttribute.array[ offset + 1 ] = value.y;
 
-							offset += 2;
+              offset += 2;
 
-						}
+            }
 
-					} else if ( customAttribute.size == 3 ) {
+          } else if ( customAttribute.size == 3 ) {
 
-						if ( customAttribute.type == "c" ) {
+            if ( customAttribute.type == "c" ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								index = sortArray[ ca ][ 1 ];
+                index = sortArray[ ca ][ 1 ];
 
-								value = customAttribute.value[ index ];
+                value = customAttribute.value[ index ];
 
-								customAttribute.array[ offset ]     = value.r;
-								customAttribute.array[ offset + 1 ] = value.g;
-								customAttribute.array[ offset + 2 ] = value.b;
+                customAttribute.array[ offset ]     = value.r;
+                customAttribute.array[ offset + 1 ] = value.g;
+                customAttribute.array[ offset + 2 ] = value.b;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						} else {
+            } else {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								index = sortArray[ ca ][ 1 ];
+                index = sortArray[ ca ][ 1 ];
 
-								value = customAttribute.value[ index ];
+                value = customAttribute.value[ index ];
 
-								customAttribute.array[ offset ] 	= value.x;
-								customAttribute.array[ offset + 1 ] = value.y;
-								customAttribute.array[ offset + 2 ] = value.z;
+                customAttribute.array[ offset ]   = value.x;
+                customAttribute.array[ offset + 1 ] = value.y;
+                customAttribute.array[ offset + 2 ] = value.z;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						}
+            }
 
-					} else if ( customAttribute.size == 4 ) {
+          } else if ( customAttribute.size == 4 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							index = sortArray[ ca ][ 1 ];
+              index = sortArray[ ca ][ 1 ];
 
-							value = customAttribute.value[ index ];
+              value = customAttribute.value[ index ];
 
-							customAttribute.array[ offset ]      = value.x;
-							customAttribute.array[ offset + 1  ] = value.y;
-							customAttribute.array[ offset + 2  ] = value.z;
-							customAttribute.array[ offset + 3  ] = value.w;
+              customAttribute.array[ offset ]      = value.x;
+              customAttribute.array[ offset + 1  ] = value.y;
+              customAttribute.array[ offset + 2  ] = value.z;
+              customAttribute.array[ offset + 3  ] = value.w;
 
-							offset += 4;
+              offset += 4;
 
-						}
+            }
 
-					}
+          }
 
-				}
+        }
 
-			}
+      }
 
-		} else {
+    } else {
 
-			if ( dirtyVertices ) {
+      if ( dirtyVertices ) {
 
-				for ( v = 0; v < vl; v ++ ) {
+        for ( v = 0; v < vl; v ++ ) {
 
-					vertex = vertices[ v ];
+          vertex = vertices[ v ];
 
-					offset = v * 3;
+          offset = v * 3;
 
-					vertexArray[ offset ]     = vertex.x;
-					vertexArray[ offset + 1 ] = vertex.y;
-					vertexArray[ offset + 2 ] = vertex.z;
+          vertexArray[ offset ]     = vertex.x;
+          vertexArray[ offset + 1 ] = vertex.y;
+          vertexArray[ offset + 2 ] = vertex.z;
 
-				}
+        }
 
-			}
+      }
 
-			if ( dirtyColors ) {
+      if ( dirtyColors ) {
 
-				for ( c = 0; c < cl; c ++ ) {
+        for ( c = 0; c < cl; c ++ ) {
 
-					color = colors[ c ];
+          color = colors[ c ];
 
-					offset = c * 3;
+          offset = c * 3;
 
-					colorArray[ offset ]     = color.r;
-					colorArray[ offset + 1 ] = color.g;
-					colorArray[ offset + 2 ] = color.b;
+          colorArray[ offset ]     = color.r;
+          colorArray[ offset + 1 ] = color.g;
+          colorArray[ offset + 2 ] = color.b;
 
-				}
+        }
 
-			}
+      }
 
-			if ( customAttributes != null) {
+      if ( customAttributes != null) {
 
-				il = customAttributes.length;
-				for ( i = 0; i < il; i ++ ) {
+        il = customAttributes.length;
+        for ( i = 0; i < il; i ++ ) {
 
-					customAttribute = customAttributes[ i ];
+          customAttribute = customAttributes[ i ];
 
-					if ( customAttribute.needsUpdate &&
-						 ( customAttribute.boundTo == null ||
-						   customAttribute.boundTo == "vertices") ) {
+          if ( customAttribute.needsUpdate &&
+             ( customAttribute.boundTo == null ||
+               customAttribute.boundTo == "vertices") ) {
 
-						cal = customAttribute.value.length;
+            cal = customAttribute.value.length;
 
-						offset = 0;
+            offset = 0;
 
-						if ( customAttribute.size == 1 ) {
+            if ( customAttribute.size == 1 ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								customAttribute.array[ ca ] = customAttribute.value[ ca ];
+                customAttribute.array[ ca ] = customAttribute.value[ ca ];
 
-							}
+              }
 
-						} else if ( customAttribute.size == 2 ) {
+            } else if ( customAttribute.size == 2 ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ] 	= value.x;
-								customAttribute.array[ offset + 1 ] = value.y;
+                customAttribute.array[ offset ]   = value.x;
+                customAttribute.array[ offset + 1 ] = value.y;
 
-								offset += 2;
+                offset += 2;
 
-							}
+              }
 
-						} else if ( customAttribute.size == 3 ) {
+            } else if ( customAttribute.size == 3 ) {
 
-							if ( customAttribute.type == "c" ) {
+              if ( customAttribute.type == "c" ) {
 
-								for ( ca = 0; ca < cal; ca ++ ) {
+                for ( ca = 0; ca < cal; ca ++ ) {
 
-									value = customAttribute.value[ ca ];
+                  value = customAttribute.value[ ca ];
 
-									customAttribute.array[ offset ] 	= value.r;
-									customAttribute.array[ offset + 1 ] = value.g;
-									customAttribute.array[ offset + 2 ] = value.b;
+                  customAttribute.array[ offset ]   = value.r;
+                  customAttribute.array[ offset + 1 ] = value.g;
+                  customAttribute.array[ offset + 2 ] = value.b;
 
-									offset += 3;
+                  offset += 3;
 
-								}
+                }
 
-							} else {
+              } else {
 
-								for ( ca = 0; ca < cal; ca ++ ) {
+                for ( ca = 0; ca < cal; ca ++ ) {
 
-									value = customAttribute.value[ ca ];
+                  value = customAttribute.value[ ca ];
 
-									customAttribute.array[ offset ] 	= value.x;
-									customAttribute.array[ offset + 1 ] = value.y;
-									customAttribute.array[ offset + 2 ] = value.z;
+                  customAttribute.array[ offset ]   = value.x;
+                  customAttribute.array[ offset + 1 ] = value.y;
+                  customAttribute.array[ offset + 2 ] = value.z;
 
-									offset += 3;
+                  offset += 3;
 
-								}
+                }
 
-							}
+              }
 
-						} else if ( customAttribute.size == 4 ) {
+            } else if ( customAttribute.size == 4 ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ]      = value.x;
-								customAttribute.array[ offset + 1  ] = value.y;
-								customAttribute.array[ offset + 2  ] = value.z;
-								customAttribute.array[ offset + 3  ] = value.w;
+                customAttribute.array[ offset ]      = value.x;
+                customAttribute.array[ offset + 1  ] = value.y;
+                customAttribute.array[ offset + 2  ] = value.z;
+                customAttribute.array[ offset + 3  ] = value.w;
 
-								offset += 4;
+                offset += 4;
 
-							}
+              }
 
-						}
+            }
 
-					}
+          }
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		if ( dirtyVertices || object.sortParticles ) {
+    if ( dirtyVertices || object.sortParticles ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
 
-		}
+    }
 
-		if ( dirtyColors || object.sortParticles ) {
+    if ( dirtyColors || object.sortParticles ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
 
-		}
+    }
 
-		if ( customAttributes != null) {
+    if ( customAttributes != null) {
 
-			il = customAttributes.length;
-			for ( i = 0; i < il; i ++ ) {
+      il = customAttributes.length;
+      for ( i = 0; i < il; i ++ ) {
 
-				customAttribute = customAttributes[ i ];
+        customAttribute = customAttributes[ i ];
 
-				if ( customAttribute.needsUpdate || object.sortParticles ) {
+        if ( customAttribute.needsUpdate || object.sortParticles ) {
 
-					customAttribute.buffer.bind( gl.ARRAY_BUFFER );
-					_gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
+          customAttribute.buffer.bind( gl.ARRAY_BUFFER );
+          _gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
 
-	}
+  }
 
-	setLineBuffers ( Geometry geometry, int hint ) {
+  setLineBuffers ( Geometry geometry, int hint ) {
 
-		var v, c, d, vertex, offset, color,
+    var v, c, d, vertex, offset, color,
 
-		vertices = geometry.vertices,
-		colors = geometry.colors,
-		lineDistances = geometry.lineDistances,
+    vertices = geometry.vertices,
+    colors = geometry.colors,
+    lineDistances = geometry.lineDistances,
 
-		vl = vertices.length,
-		cl = colors.length,
-		dl = lineDistances.length,
+    vl = vertices.length,
+    cl = colors.length,
+    dl = lineDistances.length,
 
-		vertexArray = geometry.__vertexArray,
-		colorArray = geometry.__colorArray,
-		lineDistanceArray = geometry.__lineDistanceArray,
+    vertexArray = geometry.__vertexArray,
+    colorArray = geometry.__colorArray,
+    lineDistanceArray = geometry.__lineDistanceArray,
 
-		dirtyVertices = geometry.verticesNeedUpdate,
-		dirtyColors = geometry.colorsNeedUpdate,
-		dirtyLineDistances = geometry.lineDistancesNeedUpdate,
+    dirtyVertices = geometry.verticesNeedUpdate,
+    dirtyColors = geometry.colorsNeedUpdate,
+    dirtyLineDistances = geometry.lineDistancesNeedUpdate,
 
-		customAttributes = geometry.__webglCustomAttributesList,
+    customAttributes = geometry.__webglCustomAttributesList,
 
-		i, il,
-		a, ca, cal, value,
-		customAttribute;
+    i, il,
+    a, ca, cal, value,
+    customAttribute;
 
-		if ( dirtyVertices ) {
+    if ( dirtyVertices ) {
 
-			for ( v = 0; v < vl; v ++ ) {
+      for ( v = 0; v < vl; v ++ ) {
 
-				vertex = vertices[ v ];
+        vertex = vertices[ v ];
 
-				offset = v * 3;
+        offset = v * 3;
 
-				vertexArray[ offset ]     = vertex.x;
-				vertexArray[ offset + 1 ] = vertex.y;
-				vertexArray[ offset + 2 ] = vertex.z;
+        vertexArray[ offset ]     = vertex.x;
+        vertexArray[ offset + 1 ] = vertex.y;
+        vertexArray[ offset + 2 ] = vertex.z;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
 
-		}
+    }
 
-		if ( dirtyColors ) {
+    if ( dirtyColors ) {
 
-			for ( c = 0; c < cl; c ++ ) {
+      for ( c = 0; c < cl; c ++ ) {
 
-				color = colors[ c ];
+        color = colors[ c ];
 
-				offset = c * 3;
+        offset = c * 3;
 
-				colorArray[ offset ]     = color.r;
-				colorArray[ offset + 1 ] = color.g;
-				colorArray[ offset + 2 ] = color.b;
+        colorArray[ offset ]     = color.r;
+        colorArray[ offset + 1 ] = color.g;
+        colorArray[ offset + 2 ] = color.b;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
 
-		}
+    }
 
-		if ( dirtyLineDistances ) {
+    if ( dirtyLineDistances ) {
 
-			for ( d = 0; d < dl; d ++ ) {
+      for ( d = 0; d < dl; d ++ ) {
 
-				lineDistanceArray[ d ] = lineDistances[ d ];
+        lineDistanceArray[ d ] = lineDistances[ d ];
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglLineDistanceBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, lineDistanceArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglLineDistanceBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, lineDistanceArray, hint );
 
-		}
+    }
 
-		if ( customAttributes != null ) {
+    if ( customAttributes != null ) {
 
-			il = customAttributes.length;
-			for ( i = 0; i < il; i ++ ) {
+      il = customAttributes.length;
+      for ( i = 0; i < il; i ++ ) {
 
-				customAttribute = customAttributes[ i ];
+        customAttribute = customAttributes[ i ];
 
-				if ( customAttribute.needsUpdate &&
-					 ( customAttribute.boundTo == null ||
-					   customAttribute.boundTo == "vertices" ) ) {
+        if ( customAttribute.needsUpdate &&
+           ( customAttribute.boundTo == null ||
+             customAttribute.boundTo == "vertices" ) ) {
 
-					offset = 0;
+          offset = 0;
 
-					cal = customAttribute.value.length;
+          cal = customAttribute.value.length;
 
-					if ( customAttribute.size == 1 ) {
+          if ( customAttribute.size == 1 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							customAttribute.array[ ca ] = customAttribute.value[ ca ];
+              customAttribute.array[ ca ] = customAttribute.value[ ca ];
 
-						}
+            }
 
-					} else if ( customAttribute.size == 2 ) {
+          } else if ( customAttribute.size == 2 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							value = customAttribute.value[ ca ];
+              value = customAttribute.value[ ca ];
 
-							customAttribute.array[ offset ] 	= value.x;
-							customAttribute.array[ offset + 1 ] = value.y;
+              customAttribute.array[ offset ]   = value.x;
+              customAttribute.array[ offset + 1 ] = value.y;
 
-							offset += 2;
+              offset += 2;
 
-						}
+            }
 
-					} else if ( customAttribute.size == 3 ) {
+          } else if ( customAttribute.size == 3 ) {
 
-						if ( customAttribute.type == "c" ) {
+            if ( customAttribute.type == "c" ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ] 	= value.r;
-								customAttribute.array[ offset + 1 ] = value.g;
-								customAttribute.array[ offset + 2 ] = value.b;
+                customAttribute.array[ offset ]   = value.r;
+                customAttribute.array[ offset + 1 ] = value.g;
+                customAttribute.array[ offset + 2 ] = value.b;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						} else {
+            } else {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ] 	= value.x;
-								customAttribute.array[ offset + 1 ] = value.y;
-								customAttribute.array[ offset + 2 ] = value.z;
+                customAttribute.array[ offset ]   = value.x;
+                customAttribute.array[ offset + 1 ] = value.y;
+                customAttribute.array[ offset + 2 ] = value.z;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						}
+            }
 
-					} else if ( customAttribute.size == 4 ) {
+          } else if ( customAttribute.size == 4 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							value = customAttribute.value[ ca ];
+              value = customAttribute.value[ ca ];
 
-							customAttribute.array[ offset ] 	 = value.x;
-							customAttribute.array[ offset + 1  ] = value.y;
-							customAttribute.array[ offset + 2  ] = value.z;
-							customAttribute.array[ offset + 3  ] = value.w;
+              customAttribute.array[ offset ]    = value.x;
+              customAttribute.array[ offset + 1  ] = value.y;
+              customAttribute.array[ offset + 2  ] = value.z;
+              customAttribute.array[ offset + 3  ] = value.w;
 
-							offset += 4;
+              offset += 4;
 
-						}
+            }
 
-					}
+          }
 
-					customAttribute.buffer.bind( gl.ARRAY_BUFFER );
-					_gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
+          customAttribute.buffer.bind( gl.ARRAY_BUFFER );
+          _gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	setRibbonBuffers ( Geometry geometry, int hint ) {
+  setRibbonBuffers ( Geometry geometry, int hint ) {
 
-		var v, c, n, vertex, offset, color, normal,
+    var v, c, n, vertex, offset, color, normal,
 
-		i, il, ca, cal, customAttribute, value,
+    i, il, ca, cal, customAttribute, value,
 
-		vertices = geometry.vertices,
-		colors = geometry.colors,
-		normals = geometry.normals,
+    vertices = geometry.vertices,
+    colors = geometry.colors,
+    normals = geometry.normals,
 
-		vl = vertices.length,
-		cl = colors.length,
-		nl = normals.length,
+    vl = vertices.length,
+    cl = colors.length,
+    nl = normals.length,
 
-		vertexArray = geometry.__vertexArray,
-		colorArray = geometry.__colorArray,
-		normalArray = geometry.__normalArray,
+    vertexArray = geometry.__vertexArray,
+    colorArray = geometry.__colorArray,
+    normalArray = geometry.__normalArray,
 
-		dirtyVertices = geometry.verticesNeedUpdate,
-		dirtyColors = geometry.colorsNeedUpdate,
-		dirtyNormals = geometry.normalsNeedUpdate,
+    dirtyVertices = geometry.verticesNeedUpdate,
+    dirtyColors = geometry.colorsNeedUpdate,
+    dirtyNormals = geometry.normalsNeedUpdate,
 
-		customAttributes = geometry.__webglCustomAttributesList;
+    customAttributes = geometry.__webglCustomAttributesList;
 
-		if ( dirtyVertices ) {
+    if ( dirtyVertices ) {
 
-			for ( v = 0; v < vl; v ++ ) {
+      for ( v = 0; v < vl; v ++ ) {
 
-				vertex = vertices[ v ];
+        vertex = vertices[ v ];
 
-				offset = v * 3;
+        offset = v * 3;
 
-				vertexArray[ offset ]     = vertex.x;
-				vertexArray[ offset + 1 ] = vertex.y;
-				vertexArray[ offset + 2 ] = vertex.z;
+        vertexArray[ offset ]     = vertex.x;
+        vertexArray[ offset + 1 ] = vertex.y;
+        vertexArray[ offset + 2 ] = vertex.z;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglVertexBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint );
 
-		}
+    }
 
-		if ( dirtyColors ) {
+    if ( dirtyColors ) {
 
-			for ( c = 0; c < cl; c ++ ) {
+      for ( c = 0; c < cl; c ++ ) {
 
-				color = colors[ c ];
+        color = colors[ c ];
 
-				offset = c * 3;
+        offset = c * 3;
 
-				colorArray[ offset ]     = color.r;
-				colorArray[ offset + 1 ] = color.g;
-				colorArray[ offset + 2 ] = color.b;
+        colorArray[ offset ]     = color.r;
+        colorArray[ offset + 1 ] = color.g;
+        colorArray[ offset + 2 ] = color.b;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglColorBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
 
-		}
+    }
 
-		if ( dirtyNormals ) {
+    if ( dirtyNormals ) {
 
-			for ( n = 0; n < nl; n ++ ) {
+      for ( n = 0; n < nl; n ++ ) {
 
-				normal = normals[ n ];
+        normal = normals[ n ];
 
-				offset = n * 3;
+        offset = n * 3;
 
-				normalArray[ offset ]     = normal.x;
-				normalArray[ offset + 1 ] = normal.y;
-				normalArray[ offset + 2 ] = normal.z;
+        normalArray[ offset ]     = normal.x;
+        normalArray[ offset + 1 ] = normal.y;
+        normalArray[ offset + 2 ] = normal.z;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglNormalBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, normalArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometry.__webglNormalBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, normalArray, hint );
 
-		}
+    }
 
-		if ( customAttributes ) {
+    if ( customAttributes ) {
 
-			for ( var i = 0, il = customAttributes.length; i < il; i ++ ) {
+      for ( var i = 0, il = customAttributes.length; i < il; i ++ ) {
 
-				customAttribute = customAttributes[ i ];
+        customAttribute = customAttributes[ i ];
 
-				if ( customAttribute.needsUpdate &&
-					 ( customAttribute.boundTo == null ||
-					   customAttribute.boundTo == "vertices" ) ) {
+        if ( customAttribute.needsUpdate &&
+           ( customAttribute.boundTo == null ||
+             customAttribute.boundTo == "vertices" ) ) {
 
-					offset = 0;
+          offset = 0;
 
-					cal = customAttribute.value.length;
+          cal = customAttribute.value.length;
 
-					if ( customAttribute.size == 1 ) {
+          if ( customAttribute.size == 1 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							customAttribute.array[ ca ] = customAttribute.value[ ca ];
+              customAttribute.array[ ca ] = customAttribute.value[ ca ];
 
-						}
+            }
 
-					} else if ( customAttribute.size == 2 ) {
+          } else if ( customAttribute.size == 2 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							value = customAttribute.value[ ca ];
+              value = customAttribute.value[ ca ];
 
-							customAttribute.array[ offset ] 	= value.x;
-							customAttribute.array[ offset + 1 ] = value.y;
+              customAttribute.array[ offset ]   = value.x;
+              customAttribute.array[ offset + 1 ] = value.y;
 
-							offset += 2;
+              offset += 2;
 
-						}
+            }
 
-					} else if ( customAttribute.size == 3 ) {
+          } else if ( customAttribute.size == 3 ) {
 
-						if ( customAttribute.type == "c" ) {
+            if ( customAttribute.type == "c" ) {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ] 	= value.r;
-								customAttribute.array[ offset + 1 ] = value.g;
-								customAttribute.array[ offset + 2 ] = value.b;
+                customAttribute.array[ offset ]   = value.r;
+                customAttribute.array[ offset + 1 ] = value.g;
+                customAttribute.array[ offset + 2 ] = value.b;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						} else {
+            } else {
 
-							for ( ca = 0; ca < cal; ca ++ ) {
+              for ( ca = 0; ca < cal; ca ++ ) {
 
-								value = customAttribute.value[ ca ];
+                value = customAttribute.value[ ca ];
 
-								customAttribute.array[ offset ] 	= value.x;
-								customAttribute.array[ offset + 1 ] = value.y;
-								customAttribute.array[ offset + 2 ] = value.z;
+                customAttribute.array[ offset ]   = value.x;
+                customAttribute.array[ offset + 1 ] = value.y;
+                customAttribute.array[ offset + 2 ] = value.z;
 
-								offset += 3;
+                offset += 3;
 
-							}
+              }
 
-						}
+            }
 
-					} else if ( customAttribute.size == 4 ) {
+          } else if ( customAttribute.size == 4 ) {
 
-						for ( ca = 0; ca < cal; ca ++ ) {
+            for ( ca = 0; ca < cal; ca ++ ) {
 
-							value = customAttribute.value[ ca ];
+              value = customAttribute.value[ ca ];
 
-							customAttribute.array[ offset ] 	 = value.x;
-							customAttribute.array[ offset + 1  ] = value.y;
-							customAttribute.array[ offset + 2  ] = value.z;
-							customAttribute.array[ offset + 3  ] = value.w;
+              customAttribute.array[ offset ]    = value.x;
+              customAttribute.array[ offset + 1  ] = value.y;
+              customAttribute.array[ offset + 2  ] = value.z;
+              customAttribute.array[ offset + 3  ] = value.w;
 
-							offset += 4;
+              offset += 4;
 
-						}
+            }
 
-					}
+          }
 
-					customAttribute.buffer.bind( gl.ARRAY_BUFFER );
-					_gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
+          customAttribute.buffer.bind( gl.ARRAY_BUFFER );
+          _gl.bufferDataTyped( gl.ARRAY_BUFFER, customAttribute.array, hint );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	setMeshBuffers( WebGLGeometry geometryGroup, Object3D object, int hint, bool dispose, Material material ) {
+  setMeshBuffers( WebGLGeometry geometryGroup, Object3D object, int hint, bool dispose, Material material ) {
 
-		if ( ! geometryGroup.__inittedArrays ) {
+    if ( ! geometryGroup.__inittedArrays ) {
 
-			return;
+      return;
 
-		}
+    }
 
-		var normalType = bufferGuessNormalType( material ),
-		uvType = bufferGuessUVType( material ),
+    var normalType = bufferGuessNormalType( material ),
+    uvType = bufferGuessUVType( material ),
 
-		needsSmoothNormals = ( normalType == SmoothShading );
+    needsSmoothNormals = ( normalType == SmoothShading );
 
-		var f, fl, fi, face,
-		vertexNormals, faceNormal, normal,
-		vertexColors, faceColor,
-		vertexTangents,
-		uv, uv2, v1, v2, v3, v4, t1, t2, t3, t4, n1, n2, n3, n4,
-		c1, c2, c3, c4,
-		sw1, sw2, sw3, sw4,
-		si1, si2, si3, si4,
-		sa1, sa2, sa3, sa4,
-		sb1, sb2, sb3, sb4,
-		m, ml, i, il,
-		vn, uvi, uv2i,
-		vk, vkl, vka,
-		nka, chf, faceVertexNormals,
-		a,
+    var f, fl, fi, face,
+    vertexNormals, faceNormal, normal,
+    vertexColors, faceColor,
+    vertexTangents,
+    uv, uv2, v1, v2, v3, v4, t1, t2, t3, t4, n1, n2, n3, n4,
+    c1, c2, c3, c4,
+    sw1, sw2, sw3, sw4,
+    si1, si2, si3, si4,
+    sa1, sa2, sa3, sa4,
+    sb1, sb2, sb3, sb4,
+    m, ml, i, il,
+    vn, uvi, uv2i,
+    vk, vkl, vka,
+    nka, chf, faceVertexNormals,
+    a,
 
-		vertexIndex = 0,
+    vertexIndex = 0,
 
-		offset = 0,
-		offset_uv = 0,
-		offset_uv2 = 0,
-		offset_face = 0,
-		offset_normal = 0,
-		offset_tangent = 0,
-		offset_line = 0,
-		offset_color = 0,
-		offset_skin = 0,
-		offset_morphTarget = 0,
-		offset_custom = 0,
-		offset_customSrc = 0,
+    offset = 0,
+    offset_uv = 0,
+    offset_uv2 = 0,
+    offset_face = 0,
+    offset_normal = 0,
+    offset_tangent = 0,
+    offset_line = 0,
+    offset_color = 0,
+    offset_skin = 0,
+    offset_morphTarget = 0,
+    offset_custom = 0,
+    offset_customSrc = 0,
 
-		value,
+    value,
 
-		vertexArray = geometryGroup.__vertexArray,
-		uvArray = geometryGroup.__uvArray,
-		uv2Array = geometryGroup.__uv2Array,
-		normalArray = geometryGroup.__normalArray,
-		tangentArray = geometryGroup.__tangentArray,
-		colorArray = geometryGroup.__colorArray,
+    vertexArray = geometryGroup.__vertexArray,
+    uvArray = geometryGroup.__uvArray,
+    uv2Array = geometryGroup.__uv2Array,
+    normalArray = geometryGroup.__normalArray,
+    tangentArray = geometryGroup.__tangentArray,
+    colorArray = geometryGroup.__colorArray,
 
-		skinIndexArray = geometryGroup.__skinIndexArray,
-		skinWeightArray = geometryGroup.__skinWeightArray,
+    skinIndexArray = geometryGroup.__skinIndexArray,
+    skinWeightArray = geometryGroup.__skinWeightArray,
 
-		morphTargetsArrays = geometryGroup.__morphTargetsArrays,
-		morphNormalsArrays = geometryGroup.__morphNormalsArrays,
+    morphTargetsArrays = geometryGroup.__morphTargetsArrays,
+    morphNormalsArrays = geometryGroup.__morphNormalsArrays,
 
-		customAttributes = geometryGroup.__webglCustomAttributesList,
-		customAttribute,
+    customAttributes = geometryGroup.__webglCustomAttributesList,
+    customAttribute,
 
-		faceArray = geometryGroup.__faceArray,
-		lineArray = geometryGroup.__lineArray,
+    faceArray = geometryGroup.__faceArray,
+    lineArray = geometryGroup.__lineArray,
 
-		geometry = object.geometry, // this is shared for all chunks
+    geometry = object.geometry, // this is shared for all chunks
 
-		dirtyVertices = geometry.verticesNeedUpdate,
-		dirtyElements = geometry.elementsNeedUpdate,
-		dirtyUvs = geometry.uvsNeedUpdate,
-		dirtyNormals = geometry.normalsNeedUpdate,
-		dirtyTangents = geometry.tangentsNeedUpdate,
-		dirtyColors = geometry.colorsNeedUpdate,
-		dirtyMorphTargets = geometry.morphTargetsNeedUpdate,
+    dirtyVertices = geometry.verticesNeedUpdate,
+    dirtyElements = geometry.elementsNeedUpdate,
+    dirtyUvs = geometry.uvsNeedUpdate,
+    dirtyNormals = geometry.normalsNeedUpdate,
+    dirtyTangents = geometry.tangentsNeedUpdate,
+    dirtyColors = geometry.colorsNeedUpdate,
+    dirtyMorphTargets = geometry.morphTargetsNeedUpdate,
 
-		vertices = geometry.vertices,
-		chunk_faces3 = geometryGroup.faces3,
-		chunk_faces4 = geometryGroup.faces4,
-		obj_faces = geometry.faces,
+    vertices = geometry.vertices,
+    chunk_faces3 = geometryGroup.faces3,
+    chunk_faces4 = geometryGroup.faces4,
+    obj_faces = geometry.faces,
 
-		obj_uvs  = (geometry.faceVertexUvs.length == 0) ? [] : geometry.faceVertexUvs[ 0 ],
-		obj_uvs2 = (geometry.faceVertexUvs.length > 1) ? geometry.faceVertexUvs[ 1 ] : null,
+    obj_uvs  = (geometry.faceVertexUvs.length == 0) ? [] : geometry.faceVertexUvs[ 0 ],
+    obj_uvs2 = (geometry.faceVertexUvs.length > 1) ? geometry.faceVertexUvs[ 1 ] : null,
 
-		obj_colors = geometry.colors,
+    obj_colors = geometry.colors,
 
-		obj_skinIndices = geometry.skinIndices,
-		obj_skinWeights = geometry.skinWeights,
+    obj_skinIndices = geometry.skinIndices,
+    obj_skinWeights = geometry.skinWeights,
 
-		morphTargets = geometry.morphTargets,
-		morphNormals = geometry.morphNormals;
+    morphTargets = geometry.morphTargets,
+    morphNormals = geometry.morphNormals;
 
 
-		if ( dirtyVertices ) {
+    if ( dirtyVertices ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces3[ f ] ];
+        face = obj_faces[ chunk_faces3[ f ] ];
 
-				v1 = vertices[ face.a ];
-				v2 = vertices[ face.b ];
-				v3 = vertices[ face.c ];
+        v1 = vertices[ face.a ];
+        v2 = vertices[ face.b ];
+        v3 = vertices[ face.c ];
 
-				vertexArray[ offset ]     = v1.x;
-				vertexArray[ offset + 1 ] = v1.y;
-				vertexArray[ offset + 2 ] = v1.z;
+        vertexArray[ offset ]     = v1.x;
+        vertexArray[ offset + 1 ] = v1.y;
+        vertexArray[ offset + 2 ] = v1.z;
 
-				vertexArray[ offset + 3 ] = v2.x;
-				vertexArray[ offset + 4 ] = v2.y;
-				vertexArray[ offset + 5 ] = v2.z;
+        vertexArray[ offset + 3 ] = v2.x;
+        vertexArray[ offset + 4 ] = v2.y;
+        vertexArray[ offset + 5 ] = v2.z;
 
-				vertexArray[ offset + 6 ] = v3.x;
-				vertexArray[ offset + 7 ] = v3.y;
-				vertexArray[ offset + 8 ] = v3.z;
+        vertexArray[ offset + 6 ] = v3.x;
+        vertexArray[ offset + 7 ] = v3.y;
+        vertexArray[ offset + 8 ] = v3.z;
 
-				offset += 9;
+        offset += 9;
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces4[ f ] ];
+        face = obj_faces[ chunk_faces4[ f ] ];
 
-				v1 = vertices[ face.a ];
-				v2 = vertices[ face.b ];
-				v3 = vertices[ face.c ];
-				v4 = vertices[ face.d ];
+        v1 = vertices[ face.a ];
+        v2 = vertices[ face.b ];
+        v3 = vertices[ face.c ];
+        v4 = vertices[ face.d ];
 
-				vertexArray[ offset ]     = v1.x;
-				vertexArray[ offset + 1 ] = v1.y;
-				vertexArray[ offset + 2 ] = v1.z;
+        vertexArray[ offset ]     = v1.x;
+        vertexArray[ offset + 1 ] = v1.y;
+        vertexArray[ offset + 2 ] = v1.z;
 
-				vertexArray[ offset + 3 ] = v2.x;
-				vertexArray[ offset + 4 ] = v2.y;
-				vertexArray[ offset + 5 ] = v2.z;
+        vertexArray[ offset + 3 ] = v2.x;
+        vertexArray[ offset + 4 ] = v2.y;
+        vertexArray[ offset + 5 ] = v2.z;
 
-				vertexArray[ offset + 6 ] = v3.x;
-				vertexArray[ offset + 7 ] = v3.y;
-				vertexArray[ offset + 8 ] = v3.z;
+        vertexArray[ offset + 6 ] = v3.x;
+        vertexArray[ offset + 7 ] = v3.y;
+        vertexArray[ offset + 8 ] = v3.z;
 
-				vertexArray[ offset + 9 ]  = v4.x;
-				vertexArray[ offset + 10 ] = v4.y;
-				vertexArray[ offset + 11 ] = v4.z;
+        vertexArray[ offset + 9 ]  = v4.x;
+        vertexArray[ offset + 10 ] = v4.y;
+        vertexArray[ offset + 11 ] = v4.z;
 
-				offset += 12;
+        offset += 12;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint);
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, vertexArray, hint);
 
-		}
+    }
 
-		if ( dirtyMorphTargets ) {
+    if ( dirtyMorphTargets ) {
 
-			vkl = morphTargets.length;
-			for ( vk = 0; vk < vkl; vk ++ ) {
+      vkl = morphTargets.length;
+      for ( vk = 0; vk < vkl; vk ++ ) {
 
-				offset_morphTarget = 0;
+        offset_morphTarget = 0;
 
-				fl = chunk_faces3.length;
-				for ( f = 0; f < fl; f ++ ) {
+        fl = chunk_faces3.length;
+        for ( f = 0; f < fl; f ++ ) {
 
-					chf = chunk_faces3[ f ];
-					face = obj_faces[ chf ];
+          chf = chunk_faces3[ f ];
+          face = obj_faces[ chf ];
 
-					// morph positions
+          // morph positions
 
-					v1 = morphTargets[ vk ].vertices[ face.a ];
-					v2 = morphTargets[ vk ].vertices[ face.b ];
-					v3 = morphTargets[ vk ].vertices[ face.c ];
+          v1 = morphTargets[ vk ].vertices[ face.a ];
+          v2 = morphTargets[ vk ].vertices[ face.b ];
+          v3 = morphTargets[ vk ].vertices[ face.c ];
 
-					vka = morphTargetsArrays[ vk ];
+          vka = morphTargetsArrays[ vk ];
 
-					vka[ offset_morphTarget ] 	  = v1.x;
-					vka[ offset_morphTarget + 1 ] = v1.y;
-					vka[ offset_morphTarget + 2 ] = v1.z;
+          vka[ offset_morphTarget ]     = v1.x;
+          vka[ offset_morphTarget + 1 ] = v1.y;
+          vka[ offset_morphTarget + 2 ] = v1.z;
 
-					vka[ offset_morphTarget + 3 ] = v2.x;
-					vka[ offset_morphTarget + 4 ] = v2.y;
-					vka[ offset_morphTarget + 5 ] = v2.z;
+          vka[ offset_morphTarget + 3 ] = v2.x;
+          vka[ offset_morphTarget + 4 ] = v2.y;
+          vka[ offset_morphTarget + 5 ] = v2.z;
 
-					vka[ offset_morphTarget + 6 ] = v3.x;
-					vka[ offset_morphTarget + 7 ] = v3.y;
-					vka[ offset_morphTarget + 8 ] = v3.z;
+          vka[ offset_morphTarget + 6 ] = v3.x;
+          vka[ offset_morphTarget + 7 ] = v3.y;
+          vka[ offset_morphTarget + 8 ] = v3.z;
 
-					// morph normals
+          // morph normals
 
-					if ( (material is Morphing) && (material as Morphing).morphNormals ) {
+          if ( (material is Morphing) && (material as Morphing).morphNormals ) {
 
-						if ( needsSmoothNormals ) {
+            if ( needsSmoothNormals ) {
 
-							faceVertexNormals = morphNormals[ vk ].vertexNormals[ chf ];
+              faceVertexNormals = morphNormals[ vk ].vertexNormals[ chf ];
 
-							n1 = faceVertexNormals.a;
-							n2 = faceVertexNormals.b;
-							n3 = faceVertexNormals.c;
+              n1 = faceVertexNormals.a;
+              n2 = faceVertexNormals.b;
+              n3 = faceVertexNormals.c;
 
-						} else {
+            } else {
 
-							n1 = morphNormals[ vk ].faceNormals[ chf ];
-							n2 = n1;
-							n3 = n1;
+              n1 = morphNormals[ vk ].faceNormals[ chf ];
+              n2 = n1;
+              n3 = n1;
 
-						}
+            }
 
-						nka = morphNormalsArrays[ vk ];
+            nka = morphNormalsArrays[ vk ];
 
-						nka[ offset_morphTarget ] 	  = n1.x;
-						nka[ offset_morphTarget + 1 ] = n1.y;
-						nka[ offset_morphTarget + 2 ] = n1.z;
+            nka[ offset_morphTarget ]     = n1.x;
+            nka[ offset_morphTarget + 1 ] = n1.y;
+            nka[ offset_morphTarget + 2 ] = n1.z;
 
-						nka[ offset_morphTarget + 3 ] = n2.x;
-						nka[ offset_morphTarget + 4 ] = n2.y;
-						nka[ offset_morphTarget + 5 ] = n2.z;
+            nka[ offset_morphTarget + 3 ] = n2.x;
+            nka[ offset_morphTarget + 4 ] = n2.y;
+            nka[ offset_morphTarget + 5 ] = n2.z;
 
-						nka[ offset_morphTarget + 6 ] = n3.x;
-						nka[ offset_morphTarget + 7 ] = n3.y;
-						nka[ offset_morphTarget + 8 ] = n3.z;
+            nka[ offset_morphTarget + 6 ] = n3.x;
+            nka[ offset_morphTarget + 7 ] = n3.y;
+            nka[ offset_morphTarget + 8 ] = n3.z;
 
-					}
+          }
 
-					//
+          //
 
-					offset_morphTarget += 9;
+          offset_morphTarget += 9;
 
-				}
+        }
 
-				fl = chunk_faces4.length;
-				for ( f = 0; f < fl; f ++ ) {
+        fl = chunk_faces4.length;
+        for ( f = 0; f < fl; f ++ ) {
 
-					chf = chunk_faces4[ f ];
-					face = obj_faces[ chf ];
+          chf = chunk_faces4[ f ];
+          face = obj_faces[ chf ];
 
-					// morph positions
+          // morph positions
 
-					v1 = morphTargets[ vk ].vertices[ face.a ];
-					v2 = morphTargets[ vk ].vertices[ face.b ];
-					v3 = morphTargets[ vk ].vertices[ face.c ];
-					v4 = morphTargets[ vk ].vertices[ face.d ];
+          v1 = morphTargets[ vk ].vertices[ face.a ];
+          v2 = morphTargets[ vk ].vertices[ face.b ];
+          v3 = morphTargets[ vk ].vertices[ face.c ];
+          v4 = morphTargets[ vk ].vertices[ face.d ];
 
-					vka = morphTargetsArrays[ vk ];
+          vka = morphTargetsArrays[ vk ];
 
-					vka[ offset_morphTarget ] 	  = v1.x;
-					vka[ offset_morphTarget + 1 ] = v1.y;
-					vka[ offset_morphTarget + 2 ] = v1.z;
+          vka[ offset_morphTarget ]     = v1.x;
+          vka[ offset_morphTarget + 1 ] = v1.y;
+          vka[ offset_morphTarget + 2 ] = v1.z;
 
-					vka[ offset_morphTarget + 3 ] = v2.x;
-					vka[ offset_morphTarget + 4 ] = v2.y;
-					vka[ offset_morphTarget + 5 ] = v2.z;
+          vka[ offset_morphTarget + 3 ] = v2.x;
+          vka[ offset_morphTarget + 4 ] = v2.y;
+          vka[ offset_morphTarget + 5 ] = v2.z;
 
-					vka[ offset_morphTarget + 6 ] = v3.x;
-					vka[ offset_morphTarget + 7 ] = v3.y;
-					vka[ offset_morphTarget + 8 ] = v3.z;
+          vka[ offset_morphTarget + 6 ] = v3.x;
+          vka[ offset_morphTarget + 7 ] = v3.y;
+          vka[ offset_morphTarget + 8 ] = v3.z;
 
-					vka[ offset_morphTarget + 9 ]  = v4.x;
-					vka[ offset_morphTarget + 10 ] = v4.y;
-					vka[ offset_morphTarget + 11 ] = v4.z;
+          vka[ offset_morphTarget + 9 ]  = v4.x;
+          vka[ offset_morphTarget + 10 ] = v4.y;
+          vka[ offset_morphTarget + 11 ] = v4.z;
 
-					// morph normals
+          // morph normals
 
-					if ( (material is Morphing) && (material as Morphing).morphNormals ) {
+          if ( (material is Morphing) && (material as Morphing).morphNormals ) {
 
-						if ( needsSmoothNormals ) {
+            if ( needsSmoothNormals ) {
 
-							faceVertexNormals = morphNormals[ vk ].vertexNormals[ chf ];
+              faceVertexNormals = morphNormals[ vk ].vertexNormals[ chf ];
 
-							n1 = faceVertexNormals.a;
-							n2 = faceVertexNormals.b;
-							n3 = faceVertexNormals.c;
-							n4 = faceVertexNormals.d;
+              n1 = faceVertexNormals.a;
+              n2 = faceVertexNormals.b;
+              n3 = faceVertexNormals.c;
+              n4 = faceVertexNormals.d;
 
-						} else {
+            } else {
 
-							n1 = morphNormals[ vk ].faceNormals[ chf ];
-							n2 = n1;
-							n3 = n1;
-							n4 = n1;
+              n1 = morphNormals[ vk ].faceNormals[ chf ];
+              n2 = n1;
+              n3 = n1;
+              n4 = n1;
 
-						}
+            }
 
-						nka = morphNormalsArrays[ vk ];
+            nka = morphNormalsArrays[ vk ];
 
-						nka[ offset_morphTarget ] 	  = n1.x;
-						nka[ offset_morphTarget + 1 ] = n1.y;
-						nka[ offset_morphTarget + 2 ] = n1.z;
+            nka[ offset_morphTarget ]     = n1.x;
+            nka[ offset_morphTarget + 1 ] = n1.y;
+            nka[ offset_morphTarget + 2 ] = n1.z;
 
-						nka[ offset_morphTarget + 3 ] = n2.x;
-						nka[ offset_morphTarget + 4 ] = n2.y;
-						nka[ offset_morphTarget + 5 ] = n2.z;
+            nka[ offset_morphTarget + 3 ] = n2.x;
+            nka[ offset_morphTarget + 4 ] = n2.y;
+            nka[ offset_morphTarget + 5 ] = n2.z;
 
-						nka[ offset_morphTarget + 6 ] = n3.x;
-						nka[ offset_morphTarget + 7 ] = n3.y;
-						nka[ offset_morphTarget + 8 ] = n3.z;
+            nka[ offset_morphTarget + 6 ] = n3.x;
+            nka[ offset_morphTarget + 7 ] = n3.y;
+            nka[ offset_morphTarget + 8 ] = n3.z;
 
-						nka[ offset_morphTarget + 9 ]  = n4.x;
-						nka[ offset_morphTarget + 10 ] = n4.y;
-						nka[ offset_morphTarget + 11 ] = n4.z;
+            nka[ offset_morphTarget + 9 ]  = n4.x;
+            nka[ offset_morphTarget + 10 ] = n4.y;
+            nka[ offset_morphTarget + 11 ] = n4.z;
 
-					}
+          }
 
-					//
+          //
 
-					offset_morphTarget += 12;
+          offset_morphTarget += 12;
 
-				}
+        }
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ vk ] );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, morphTargetsArrays[ vk ], hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ vk ] );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, morphTargetsArrays[ vk ], hint );
 
-				if ( (material is Morphing) && (material as Morphing).morphNormals ) {
+        if ( (material is Morphing) && (material as Morphing).morphNormals ) {
 
-					_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ vk ] );
-					_gl.bufferDataTyped( gl.ARRAY_BUFFER, morphNormalsArrays[ vk ], hint );
+          _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ vk ] );
+          _gl.bufferDataTyped( gl.ARRAY_BUFFER, morphNormalsArrays[ vk ], hint );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		if ( !obj_skinWeights.isEmpty) {
+    if ( !obj_skinWeights.isEmpty) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces3[ f ]	];
+        face = obj_faces[ chunk_faces3[ f ]  ];
 
-				// weights
+        // weights
 
-				sw1 = obj_skinWeights[ face.a ];
-				sw2 = obj_skinWeights[ face.b ];
-				sw3 = obj_skinWeights[ face.c ];
+        sw1 = obj_skinWeights[ face.a ];
+        sw2 = obj_skinWeights[ face.b ];
+        sw3 = obj_skinWeights[ face.c ];
 
-				skinWeightArray[ offset_skin ]     = sw1.x;
-				skinWeightArray[ offset_skin + 1 ] = sw1.y;
-				skinWeightArray[ offset_skin + 2 ] = sw1.z;
-				skinWeightArray[ offset_skin + 3 ] = sw1.w;
+        skinWeightArray[ offset_skin ]     = sw1.x;
+        skinWeightArray[ offset_skin + 1 ] = sw1.y;
+        skinWeightArray[ offset_skin + 2 ] = sw1.z;
+        skinWeightArray[ offset_skin + 3 ] = sw1.w;
 
-				skinWeightArray[ offset_skin + 4 ] = sw2.x;
-				skinWeightArray[ offset_skin + 5 ] = sw2.y;
-				skinWeightArray[ offset_skin + 6 ] = sw2.z;
-				skinWeightArray[ offset_skin + 7 ] = sw2.w;
+        skinWeightArray[ offset_skin + 4 ] = sw2.x;
+        skinWeightArray[ offset_skin + 5 ] = sw2.y;
+        skinWeightArray[ offset_skin + 6 ] = sw2.z;
+        skinWeightArray[ offset_skin + 7 ] = sw2.w;
 
-				skinWeightArray[ offset_skin + 8 ]  = sw3.x;
-				skinWeightArray[ offset_skin + 9 ]  = sw3.y;
-				skinWeightArray[ offset_skin + 10 ] = sw3.z;
-				skinWeightArray[ offset_skin + 11 ] = sw3.w;
+        skinWeightArray[ offset_skin + 8 ]  = sw3.x;
+        skinWeightArray[ offset_skin + 9 ]  = sw3.y;
+        skinWeightArray[ offset_skin + 10 ] = sw3.z;
+        skinWeightArray[ offset_skin + 11 ] = sw3.w;
 
-				// indices
+        // indices
 
-				si1 = obj_skinIndices[ face.a ];
-				si2 = obj_skinIndices[ face.b ];
-				si3 = obj_skinIndices[ face.c ];
+        si1 = obj_skinIndices[ face.a ];
+        si2 = obj_skinIndices[ face.b ];
+        si3 = obj_skinIndices[ face.c ];
 
-				skinIndexArray[ offset_skin ]     = si1.x;
-				skinIndexArray[ offset_skin + 1 ] = si1.y;
-				skinIndexArray[ offset_skin + 2 ] = si1.z;
-				skinIndexArray[ offset_skin + 3 ] = si1.w;
+        skinIndexArray[ offset_skin ]     = si1.x;
+        skinIndexArray[ offset_skin + 1 ] = si1.y;
+        skinIndexArray[ offset_skin + 2 ] = si1.z;
+        skinIndexArray[ offset_skin + 3 ] = si1.w;
 
-				skinIndexArray[ offset_skin + 4 ] = si2.x;
-				skinIndexArray[ offset_skin + 5 ] = si2.y;
-				skinIndexArray[ offset_skin + 6 ] = si2.z;
-				skinIndexArray[ offset_skin + 7 ] = si2.w;
+        skinIndexArray[ offset_skin + 4 ] = si2.x;
+        skinIndexArray[ offset_skin + 5 ] = si2.y;
+        skinIndexArray[ offset_skin + 6 ] = si2.z;
+        skinIndexArray[ offset_skin + 7 ] = si2.w;
 
-				skinIndexArray[ offset_skin + 8 ]  = si3.x;
-				skinIndexArray[ offset_skin + 9 ]  = si3.y;
-				skinIndexArray[ offset_skin + 10 ] = si3.z;
-				skinIndexArray[ offset_skin + 11 ] = si3.w;
+        skinIndexArray[ offset_skin + 8 ]  = si3.x;
+        skinIndexArray[ offset_skin + 9 ]  = si3.y;
+        skinIndexArray[ offset_skin + 10 ] = si3.z;
+        skinIndexArray[ offset_skin + 11 ] = si3.w;
 
-				offset_skin += 12;
+        offset_skin += 12;
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces4[ f ] ];
+        face = obj_faces[ chunk_faces4[ f ] ];
 
-				// weights
+        // weights
 
-				sw1 = obj_skinWeights[ face.a ];
-				sw2 = obj_skinWeights[ face.b ];
-				sw3 = obj_skinWeights[ face.c ];
-				sw4 = obj_skinWeights[ face.d ];
+        sw1 = obj_skinWeights[ face.a ];
+        sw2 = obj_skinWeights[ face.b ];
+        sw3 = obj_skinWeights[ face.c ];
+        sw4 = obj_skinWeights[ face.d ];
 
-				skinWeightArray[ offset_skin ]     = sw1.x;
-				skinWeightArray[ offset_skin + 1 ] = sw1.y;
-				skinWeightArray[ offset_skin + 2 ] = sw1.z;
-				skinWeightArray[ offset_skin + 3 ] = sw1.w;
+        skinWeightArray[ offset_skin ]     = sw1.x;
+        skinWeightArray[ offset_skin + 1 ] = sw1.y;
+        skinWeightArray[ offset_skin + 2 ] = sw1.z;
+        skinWeightArray[ offset_skin + 3 ] = sw1.w;
 
-				skinWeightArray[ offset_skin + 4 ] = sw2.x;
-				skinWeightArray[ offset_skin + 5 ] = sw2.y;
-				skinWeightArray[ offset_skin + 6 ] = sw2.z;
-				skinWeightArray[ offset_skin + 7 ] = sw2.w;
+        skinWeightArray[ offset_skin + 4 ] = sw2.x;
+        skinWeightArray[ offset_skin + 5 ] = sw2.y;
+        skinWeightArray[ offset_skin + 6 ] = sw2.z;
+        skinWeightArray[ offset_skin + 7 ] = sw2.w;
 
-				skinWeightArray[ offset_skin + 8 ]  = sw3.x;
-				skinWeightArray[ offset_skin + 9 ]  = sw3.y;
-				skinWeightArray[ offset_skin + 10 ] = sw3.z;
-				skinWeightArray[ offset_skin + 11 ] = sw3.w;
+        skinWeightArray[ offset_skin + 8 ]  = sw3.x;
+        skinWeightArray[ offset_skin + 9 ]  = sw3.y;
+        skinWeightArray[ offset_skin + 10 ] = sw3.z;
+        skinWeightArray[ offset_skin + 11 ] = sw3.w;
 
-				skinWeightArray[ offset_skin + 12 ] = sw4.x;
-				skinWeightArray[ offset_skin + 13 ] = sw4.y;
-				skinWeightArray[ offset_skin + 14 ] = sw4.z;
-				skinWeightArray[ offset_skin + 15 ] = sw4.w;
+        skinWeightArray[ offset_skin + 12 ] = sw4.x;
+        skinWeightArray[ offset_skin + 13 ] = sw4.y;
+        skinWeightArray[ offset_skin + 14 ] = sw4.z;
+        skinWeightArray[ offset_skin + 15 ] = sw4.w;
 
-				// indices
+        // indices
 
-				si1 = obj_skinIndices[ face.a ];
-				si2 = obj_skinIndices[ face.b ];
-				si3 = obj_skinIndices[ face.c ];
-				si4 = obj_skinIndices[ face.d ];
+        si1 = obj_skinIndices[ face.a ];
+        si2 = obj_skinIndices[ face.b ];
+        si3 = obj_skinIndices[ face.c ];
+        si4 = obj_skinIndices[ face.d ];
 
-				skinIndexArray[ offset_skin ]     = si1.x;
-				skinIndexArray[ offset_skin + 1 ] = si1.y;
-				skinIndexArray[ offset_skin + 2 ] = si1.z;
-				skinIndexArray[ offset_skin + 3 ] = si1.w;
+        skinIndexArray[ offset_skin ]     = si1.x;
+        skinIndexArray[ offset_skin + 1 ] = si1.y;
+        skinIndexArray[ offset_skin + 2 ] = si1.z;
+        skinIndexArray[ offset_skin + 3 ] = si1.w;
 
-				skinIndexArray[ offset_skin + 4 ] = si2.x;
-				skinIndexArray[ offset_skin + 5 ] = si2.y;
-				skinIndexArray[ offset_skin + 6 ] = si2.z;
-				skinIndexArray[ offset_skin + 7 ] = si2.w;
+        skinIndexArray[ offset_skin + 4 ] = si2.x;
+        skinIndexArray[ offset_skin + 5 ] = si2.y;
+        skinIndexArray[ offset_skin + 6 ] = si2.z;
+        skinIndexArray[ offset_skin + 7 ] = si2.w;
 
-				skinIndexArray[ offset_skin + 8 ]  = si3.x;
-				skinIndexArray[ offset_skin + 9 ]  = si3.y;
-				skinIndexArray[ offset_skin + 10 ] = si3.z;
-				skinIndexArray[ offset_skin + 11 ] = si3.w;
+        skinIndexArray[ offset_skin + 8 ]  = si3.x;
+        skinIndexArray[ offset_skin + 9 ]  = si3.y;
+        skinIndexArray[ offset_skin + 10 ] = si3.z;
+        skinIndexArray[ offset_skin + 11 ] = si3.w;
 
-				skinIndexArray[ offset_skin + 12 ] = si4.x;
-				skinIndexArray[ offset_skin + 13 ] = si4.y;
-				skinIndexArray[ offset_skin + 14 ] = si4.z;
-				skinIndexArray[ offset_skin + 15 ] = si4.w;
+        skinIndexArray[ offset_skin + 12 ] = si4.x;
+        skinIndexArray[ offset_skin + 13 ] = si4.y;
+        skinIndexArray[ offset_skin + 14 ] = si4.z;
+        skinIndexArray[ offset_skin + 15 ] = si4.w;
 
-				offset_skin += 16;
+        offset_skin += 16;
 
-			}
+      }
 
-			if ( offset_skin > 0 ) {
+      if ( offset_skin > 0 ) {
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinIndicesBuffer );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, skinIndexArray, hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinIndicesBuffer );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, skinIndexArray, hint );
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinWeightsBuffer );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, skinWeightArray, hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinWeightsBuffer );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, skinWeightArray, hint );
 
-			}
+      }
 
-		}
+    }
 
-		if ( dirtyColors && (material.vertexColors != NoColors) ) {
+    if ( dirtyColors && (material.vertexColors != NoColors) ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces3[ f ]	];
+        face = obj_faces[ chunk_faces3[ f ]  ];
 
-				vertexColors = face.vertexColors;
-				faceColor = face.color;
+        vertexColors = face.vertexColors;
+        faceColor = face.color;
 
-				if ( (vertexColors.length == 3) && (material.vertexColors == VertexColors) ) {
+        if ( (vertexColors.length == 3) && (material.vertexColors == VertexColors) ) {
 
-					c1 = vertexColors[ 0 ];
-					c2 = vertexColors[ 1 ];
-					c3 = vertexColors[ 2 ];
+          c1 = vertexColors[ 0 ];
+          c2 = vertexColors[ 1 ];
+          c3 = vertexColors[ 2 ];
 
-				} else {
+        } else {
 
-					c1 = faceColor;
-					c2 = faceColor;
-					c3 = faceColor;
+          c1 = faceColor;
+          c2 = faceColor;
+          c3 = faceColor;
 
-				}
+        }
 
-				colorArray[ offset_color ]     = c1.r;
-				colorArray[ offset_color + 1 ] = c1.g;
-				colorArray[ offset_color + 2 ] = c1.b;
+        colorArray[ offset_color ]     = c1.r;
+        colorArray[ offset_color + 1 ] = c1.g;
+        colorArray[ offset_color + 2 ] = c1.b;
 
-				colorArray[ offset_color + 3 ] = c2.r;
-				colorArray[ offset_color + 4 ] = c2.g;
-				colorArray[ offset_color + 5 ] = c2.b;
+        colorArray[ offset_color + 3 ] = c2.r;
+        colorArray[ offset_color + 4 ] = c2.g;
+        colorArray[ offset_color + 5 ] = c2.b;
 
-				colorArray[ offset_color + 6 ] = c3.r;
-				colorArray[ offset_color + 7 ] = c3.g;
-				colorArray[ offset_color + 8 ] = c3.b;
+        colorArray[ offset_color + 6 ] = c3.r;
+        colorArray[ offset_color + 7 ] = c3.g;
+        colorArray[ offset_color + 8 ] = c3.b;
 
-				offset_color += 9;
+        offset_color += 9;
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces4[ f ] ];
+        face = obj_faces[ chunk_faces4[ f ] ];
 
-				vertexColors = face.vertexColors;
-				faceColor = face.color;
+        vertexColors = face.vertexColors;
+        faceColor = face.color;
 
-				if ( vertexColors.length == 4 && (material.vertexColors == VertexColors) ) {
+        if ( vertexColors.length == 4 && (material.vertexColors == VertexColors) ) {
 
-					c1 = vertexColors[ 0 ];
-					c2 = vertexColors[ 1 ];
-					c3 = vertexColors[ 2 ];
-					c4 = vertexColors[ 3 ];
+          c1 = vertexColors[ 0 ];
+          c2 = vertexColors[ 1 ];
+          c3 = vertexColors[ 2 ];
+          c4 = vertexColors[ 3 ];
 
-				} else {
+        } else {
 
-					c1 = faceColor;
-					c2 = faceColor;
-					c3 = faceColor;
-					c4 = faceColor;
+          c1 = faceColor;
+          c2 = faceColor;
+          c3 = faceColor;
+          c4 = faceColor;
 
-				}
+        }
 
-				colorArray[ offset_color ]     = c1.r;
-				colorArray[ offset_color + 1 ] = c1.g;
-				colorArray[ offset_color + 2 ] = c1.b;
+        colorArray[ offset_color ]     = c1.r;
+        colorArray[ offset_color + 1 ] = c1.g;
+        colorArray[ offset_color + 2 ] = c1.b;
 
-				colorArray[ offset_color + 3 ] = c2.r;
-				colorArray[ offset_color + 4 ] = c2.g;
-				colorArray[ offset_color + 5 ] = c2.b;
+        colorArray[ offset_color + 3 ] = c2.r;
+        colorArray[ offset_color + 4 ] = c2.g;
+        colorArray[ offset_color + 5 ] = c2.b;
 
-				colorArray[ offset_color + 6 ] = c3.r;
-				colorArray[ offset_color + 7 ] = c3.g;
-				colorArray[ offset_color + 8 ] = c3.b;
+        colorArray[ offset_color + 6 ] = c3.r;
+        colorArray[ offset_color + 7 ] = c3.g;
+        colorArray[ offset_color + 8 ] = c3.b;
 
-				colorArray[ offset_color + 9 ]  = c4.r;
-				colorArray[ offset_color + 10 ] = c4.g;
-				colorArray[ offset_color + 11 ] = c4.b;
+        colorArray[ offset_color + 9 ]  = c4.r;
+        colorArray[ offset_color + 10 ] = c4.g;
+        colorArray[ offset_color + 11 ] = c4.b;
 
-				offset_color += 12;
+        offset_color += 12;
 
-			}
+      }
 
-			if ( offset_color > 0 ) {
+      if ( offset_color > 0 ) {
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglColorBuffer );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglColorBuffer );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, colorArray, hint );
 
-			}
+      }
 
-		}
+    }
 
-		if ( dirtyTangents && geometry.hasTangents ) {
+    if ( dirtyTangents && geometry.hasTangents ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces3[ f ]	];
+        face = obj_faces[ chunk_faces3[ f ]  ];
 
-				vertexTangents = face.vertexTangents;
+        vertexTangents = face.vertexTangents;
 
-				t1 = vertexTangents[ 0 ];
-				t2 = vertexTangents[ 1 ];
-				t3 = vertexTangents[ 2 ];
+        t1 = vertexTangents[ 0 ];
+        t2 = vertexTangents[ 1 ];
+        t3 = vertexTangents[ 2 ];
 
-				tangentArray[ offset_tangent ]     = t1.x;
-				tangentArray[ offset_tangent + 1 ] = t1.y;
-				tangentArray[ offset_tangent + 2 ] = t1.z;
-				tangentArray[ offset_tangent + 3 ] = t1.w;
+        tangentArray[ offset_tangent ]     = t1.x;
+        tangentArray[ offset_tangent + 1 ] = t1.y;
+        tangentArray[ offset_tangent + 2 ] = t1.z;
+        tangentArray[ offset_tangent + 3 ] = t1.w;
 
-				tangentArray[ offset_tangent + 4 ] = t2.x;
-				tangentArray[ offset_tangent + 5 ] = t2.y;
-				tangentArray[ offset_tangent + 6 ] = t2.z;
-				tangentArray[ offset_tangent + 7 ] = t2.w;
+        tangentArray[ offset_tangent + 4 ] = t2.x;
+        tangentArray[ offset_tangent + 5 ] = t2.y;
+        tangentArray[ offset_tangent + 6 ] = t2.z;
+        tangentArray[ offset_tangent + 7 ] = t2.w;
 
-				tangentArray[ offset_tangent + 8 ]  = t3.x;
-				tangentArray[ offset_tangent + 9 ]  = t3.y;
-				tangentArray[ offset_tangent + 10 ] = t3.z;
-				tangentArray[ offset_tangent + 11 ] = t3.w;
+        tangentArray[ offset_tangent + 8 ]  = t3.x;
+        tangentArray[ offset_tangent + 9 ]  = t3.y;
+        tangentArray[ offset_tangent + 10 ] = t3.z;
+        tangentArray[ offset_tangent + 11 ] = t3.w;
 
-				offset_tangent += 12;
+        offset_tangent += 12;
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces4[ f ] ];
+        face = obj_faces[ chunk_faces4[ f ] ];
 
-				vertexTangents = face.vertexTangents;
+        vertexTangents = face.vertexTangents;
 
-				t1 = vertexTangents[ 0 ];
-				t2 = vertexTangents[ 1 ];
-				t3 = vertexTangents[ 2 ];
-				t4 = vertexTangents[ 3 ];
+        t1 = vertexTangents[ 0 ];
+        t2 = vertexTangents[ 1 ];
+        t3 = vertexTangents[ 2 ];
+        t4 = vertexTangents[ 3 ];
 
-				tangentArray[ offset_tangent ]     = t1.x;
-				tangentArray[ offset_tangent + 1 ] = t1.y;
-				tangentArray[ offset_tangent + 2 ] = t1.z;
-				tangentArray[ offset_tangent + 3 ] = t1.w;
+        tangentArray[ offset_tangent ]     = t1.x;
+        tangentArray[ offset_tangent + 1 ] = t1.y;
+        tangentArray[ offset_tangent + 2 ] = t1.z;
+        tangentArray[ offset_tangent + 3 ] = t1.w;
 
-				tangentArray[ offset_tangent + 4 ] = t2.x;
-				tangentArray[ offset_tangent + 5 ] = t2.y;
-				tangentArray[ offset_tangent + 6 ] = t2.z;
-				tangentArray[ offset_tangent + 7 ] = t2.w;
+        tangentArray[ offset_tangent + 4 ] = t2.x;
+        tangentArray[ offset_tangent + 5 ] = t2.y;
+        tangentArray[ offset_tangent + 6 ] = t2.z;
+        tangentArray[ offset_tangent + 7 ] = t2.w;
 
-				tangentArray[ offset_tangent + 8 ]  = t3.x;
-				tangentArray[ offset_tangent + 9 ]  = t3.y;
-				tangentArray[ offset_tangent + 10 ] = t3.z;
-				tangentArray[ offset_tangent + 11 ] = t3.w;
+        tangentArray[ offset_tangent + 8 ]  = t3.x;
+        tangentArray[ offset_tangent + 9 ]  = t3.y;
+        tangentArray[ offset_tangent + 10 ] = t3.z;
+        tangentArray[ offset_tangent + 11 ] = t3.w;
 
-				tangentArray[ offset_tangent + 12 ] = t4.x;
-				tangentArray[ offset_tangent + 13 ] = t4.y;
-				tangentArray[ offset_tangent + 14 ] = t4.z;
-				tangentArray[ offset_tangent + 15 ] = t4.w;
+        tangentArray[ offset_tangent + 12 ] = t4.x;
+        tangentArray[ offset_tangent + 13 ] = t4.y;
+        tangentArray[ offset_tangent + 14 ] = t4.z;
+        tangentArray[ offset_tangent + 15 ] = t4.w;
 
-				offset_tangent += 16;
+        offset_tangent += 16;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglTangentBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, tangentArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglTangentBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, tangentArray, hint );
 
-		}
+    }
 
-		if ( dirtyNormals && (normalType != NoShading) ) {
+    if ( dirtyNormals && (normalType != NoShading) ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces3[ f ]	];
+        face = obj_faces[ chunk_faces3[ f ]  ];
 
-				vertexNormals = face.vertexNormals;
-				faceNormal = face.normal;
+        vertexNormals = face.vertexNormals;
+        faceNormal = face.normal;
 
-				if ( vertexNormals.length == 3 && needsSmoothNormals ) {
+        if ( vertexNormals.length == 3 && needsSmoothNormals ) {
 
-					for ( i = 0; i < 3; i ++ ) {
+          for ( i = 0; i < 3; i ++ ) {
 
-						vn = vertexNormals[ i ];
+            vn = vertexNormals[ i ];
 
-						normalArray[ offset_normal ]     = vn.x;
-						normalArray[ offset_normal + 1 ] = vn.y;
-						normalArray[ offset_normal + 2 ] = vn.z;
+            normalArray[ offset_normal ]     = vn.x;
+            normalArray[ offset_normal + 1 ] = vn.y;
+            normalArray[ offset_normal + 2 ] = vn.z;
 
-						offset_normal += 3;
+            offset_normal += 3;
 
-					}
+          }
 
-				} else {
+        } else {
 
-					for ( i = 0; i < 3; i ++ ) {
+          for ( i = 0; i < 3; i ++ ) {
 
-						normalArray[ offset_normal ]     = faceNormal.x;
-						normalArray[ offset_normal + 1 ] = faceNormal.y;
-						normalArray[ offset_normal + 2 ] = faceNormal.z;
+            normalArray[ offset_normal ]     = faceNormal.x;
+            normalArray[ offset_normal + 1 ] = faceNormal.y;
+            normalArray[ offset_normal + 2 ] = faceNormal.z;
 
-						offset_normal += 3;
+            offset_normal += 3;
 
-					}
+          }
 
-				}
+        }
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				face = obj_faces[ chunk_faces4[ f ] ];
+        face = obj_faces[ chunk_faces4[ f ] ];
 
-				vertexNormals = face.vertexNormals;
-				faceNormal = face.normal;
+        vertexNormals = face.vertexNormals;
+        faceNormal = face.normal;
 
-				if ( vertexNormals.length == 4 && needsSmoothNormals ) {
+        if ( vertexNormals.length == 4 && needsSmoothNormals ) {
 
-					for ( i = 0; i < 4; i ++ ) {
+          for ( i = 0; i < 4; i ++ ) {
 
-						vn = vertexNormals[ i ];
+            vn = vertexNormals[ i ];
 
-						normalArray[ offset_normal ]     = vn.x;
-						normalArray[ offset_normal + 1 ] = vn.y;
-						normalArray[ offset_normal + 2 ] = vn.z;
+            normalArray[ offset_normal ]     = vn.x;
+            normalArray[ offset_normal + 1 ] = vn.y;
+            normalArray[ offset_normal + 2 ] = vn.z;
 
-						offset_normal += 3;
+            offset_normal += 3;
 
-					}
+          }
 
-				} else {
+        } else {
 
-					for ( i = 0; i < 4; i ++ ) {
+          for ( i = 0; i < 4; i ++ ) {
 
-						normalArray[ offset_normal ]     = faceNormal.x;
-						normalArray[ offset_normal + 1 ] = faceNormal.y;
-						normalArray[ offset_normal + 2 ] = faceNormal.z;
+            normalArray[ offset_normal ]     = faceNormal.x;
+            normalArray[ offset_normal + 1 ] = faceNormal.y;
+            normalArray[ offset_normal + 2 ] = faceNormal.z;
 
-						offset_normal += 3;
+            offset_normal += 3;
 
-					}
+          }
 
-				}
+        }
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglNormalBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, normalArray, hint );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglNormalBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, normalArray, hint );
 
-		}
+    }
 
-		if ( dirtyUvs && !obj_uvs.isEmpty && uvType ) {
+    if ( dirtyUvs && !obj_uvs.isEmpty && uvType ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				fi = chunk_faces3[ f ];
+        fi = chunk_faces3[ f ];
 
-				uv = obj_uvs[ fi ];
+        uv = obj_uvs[ fi ];
 
-				if ( uv == null ) continue;
+        if ( uv == null ) continue;
 
-				for ( i = 0; i < 3; i ++ ) {
+        for ( i = 0; i < 3; i ++ ) {
 
-					uvi = uv[ i ];
+          uvi = uv[ i ];
 
-					uvArray[ offset_uv ]     = uvi.u;
-					uvArray[ offset_uv + 1 ] = uvi.v;
+          uvArray[ offset_uv ]     = uvi.u;
+          uvArray[ offset_uv + 1 ] = uvi.v;
 
-					offset_uv += 2;
+          offset_uv += 2;
 
-				}
+        }
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				fi = chunk_faces4[ f ];
+        fi = chunk_faces4[ f ];
 
-				uv = obj_uvs[ fi ];
+        uv = obj_uvs[ fi ];
 
-				if ( uv == null ) continue;
+        if ( uv == null ) continue;
 
-				for ( i = 0; i < 4; i ++ ) {
+        for ( i = 0; i < 4; i ++ ) {
 
-					uvi = uv[ i ];
+          uvi = uv[ i ];
 
-					uvArray[ offset_uv ]     = uvi.u;
-					uvArray[ offset_uv + 1 ] = uvi.v;
+          uvArray[ offset_uv ]     = uvi.u;
+          uvArray[ offset_uv + 1 ] = uvi.v;
 
-					offset_uv += 2;
+          offset_uv += 2;
 
-				}
+        }
 
-			}
+      }
 
-			if ( offset_uv > 0 ) {
+      if ( offset_uv > 0 ) {
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUVBuffer );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, uvArray, hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUVBuffer );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, uvArray, hint );
 
-			}
+      }
 
-		}
+    }
 
-		if ( dirtyUvs && (obj_uvs2 != null) && uvType ) {
+    if ( dirtyUvs && (obj_uvs2 != null) && uvType ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				fi = chunk_faces3[ f ];
+        fi = chunk_faces3[ f ];
 
-				uv2 = obj_uvs2[ fi ];
+        uv2 = obj_uvs2[ fi ];
 
-				if ( uv2 == null ) continue;
+        if ( uv2 == null ) continue;
 
-				for ( i = 0; i < 3; i ++ ) {
+        for ( i = 0; i < 3; i ++ ) {
 
-					uv2i = uv2[ i ];
+          uv2i = uv2[ i ];
 
-					uv2Array[ offset_uv2 ]     = uv2i.u;
-					uv2Array[ offset_uv2 + 1 ] = uv2i.v;
+          uv2Array[ offset_uv2 ]     = uv2i.u;
+          uv2Array[ offset_uv2 + 1 ] = uv2i.v;
 
-					offset_uv2 += 2;
+          offset_uv2 += 2;
 
-				}
+        }
 
-			}
+      }
 
-			fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				fi = chunk_faces4[ f ];
+        fi = chunk_faces4[ f ];
 
-				uv2 = obj_uvs2[ fi ];
+        uv2 = obj_uvs2[ fi ];
 
-				if ( uv2 == null ) continue;
+        if ( uv2 == null ) continue;
 
-				for ( i = 0; i < 4; i ++ ) {
+        for ( i = 0; i < 4; i ++ ) {
 
-					uv2i = uv2[ i ];
+          uv2i = uv2[ i ];
 
-					uv2Array[ offset_uv2 ]     = uv2i.u;
-					uv2Array[ offset_uv2 + 1 ] = uv2i.v;
+          uv2Array[ offset_uv2 ]     = uv2i.u;
+          uv2Array[ offset_uv2 + 1 ] = uv2i.v;
 
-					offset_uv2 += 2;
+          offset_uv2 += 2;
 
-				}
+        }
 
-			}
+      }
 
-			if ( offset_uv2 > 0 ) {
+      if ( offset_uv2 > 0 ) {
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUV2Buffer );
-				_gl.bufferDataTyped( gl.ARRAY_BUFFER, uv2Array, hint );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUV2Buffer );
+        _gl.bufferDataTyped( gl.ARRAY_BUFFER, uv2Array, hint );
 
-			}
+      }
 
-		}
+    }
 
-		if ( dirtyElements ) {
+    if ( dirtyElements ) {
 
-			fl = chunk_faces3.length;
-			for ( f = 0; f < fl; f ++ ) {
+      fl = chunk_faces3.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				faceArray[ offset_face ] 	 = vertexIndex;
-				faceArray[ offset_face + 1 ] = vertexIndex + 1;
-				faceArray[ offset_face + 2 ] = vertexIndex + 2;
+        faceArray[ offset_face ]    = vertexIndex;
+        faceArray[ offset_face + 1 ] = vertexIndex + 1;
+        faceArray[ offset_face + 2 ] = vertexIndex + 2;
 
-				offset_face += 3;
+        offset_face += 3;
 
-				lineArray[ offset_line ]     = vertexIndex;
-				lineArray[ offset_line + 1 ] = vertexIndex + 1;
+        lineArray[ offset_line ]     = vertexIndex;
+        lineArray[ offset_line + 1 ] = vertexIndex + 1;
 
-				lineArray[ offset_line + 2 ] = vertexIndex;
-				lineArray[ offset_line + 3 ] = vertexIndex + 2;
+        lineArray[ offset_line + 2 ] = vertexIndex;
+        lineArray[ offset_line + 3 ] = vertexIndex + 2;
 
-				lineArray[ offset_line + 4 ] = vertexIndex + 1;
-				lineArray[ offset_line + 5 ] = vertexIndex + 2;
+        lineArray[ offset_line + 4 ] = vertexIndex + 1;
+        lineArray[ offset_line + 5 ] = vertexIndex + 2;
 
-				offset_line += 6;
+        offset_line += 6;
 
-				vertexIndex += 3;
+        vertexIndex += 3;
 
-			}
+      }
 
-			 fl = chunk_faces4.length;
-			for ( f = 0; f < fl; f ++ ) {
+       fl = chunk_faces4.length;
+      for ( f = 0; f < fl; f ++ ) {
 
-				faceArray[ offset_face ]     = vertexIndex;
-				faceArray[ offset_face + 1 ] = vertexIndex + 1;
-				faceArray[ offset_face + 2 ] = vertexIndex + 3;
+        faceArray[ offset_face ]     = vertexIndex;
+        faceArray[ offset_face + 1 ] = vertexIndex + 1;
+        faceArray[ offset_face + 2 ] = vertexIndex + 3;
 
-				faceArray[ offset_face + 3 ] = vertexIndex + 1;
-				faceArray[ offset_face + 4 ] = vertexIndex + 2;
-				faceArray[ offset_face + 5 ] = vertexIndex + 3;
+        faceArray[ offset_face + 3 ] = vertexIndex + 1;
+        faceArray[ offset_face + 4 ] = vertexIndex + 2;
+        faceArray[ offset_face + 5 ] = vertexIndex + 3;
 
-				offset_face += 6;
+        offset_face += 6;
 
-				lineArray[ offset_line ]     = vertexIndex;
-				lineArray[ offset_line + 1 ] = vertexIndex + 1;
+        lineArray[ offset_line ]     = vertexIndex;
+        lineArray[ offset_line + 1 ] = vertexIndex + 1;
 
-				lineArray[ offset_line + 2 ] = vertexIndex;
-				lineArray[ offset_line + 3 ] = vertexIndex + 3;
+        lineArray[ offset_line + 2 ] = vertexIndex;
+        lineArray[ offset_line + 3 ] = vertexIndex + 3;
 
-				lineArray[ offset_line + 4 ] = vertexIndex + 1;
-				lineArray[ offset_line + 5 ] = vertexIndex + 2;
+        lineArray[ offset_line + 4 ] = vertexIndex + 1;
+        lineArray[ offset_line + 5 ] = vertexIndex + 2;
 
-				lineArray[ offset_line + 6 ] = vertexIndex + 2;
-				lineArray[ offset_line + 7 ] = vertexIndex + 3;
+        lineArray[ offset_line + 6 ] = vertexIndex + 2;
+        lineArray[ offset_line + 7 ] = vertexIndex + 3;
 
-				offset_line += 8;
+        offset_line += 8;
 
-				vertexIndex += 4;
+        vertexIndex += 4;
 
-			}
+      }
 
-			_gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglFaceBuffer );
-			_gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, faceArray, hint );
+      _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglFaceBuffer );
+      _gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, faceArray, hint );
 
-			_gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglLineBuffer );
-			_gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, lineArray, hint );
+      _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglLineBuffer );
+      _gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, lineArray, hint );
 
-		}
+    }
 
-		if ( customAttributes != null) {
+    if ( customAttributes != null) {
 
-			il = customAttributes.length;
-			for ( i = 0; i < il; i ++ ) {
+      il = customAttributes.length;
+      for ( i = 0; i < il; i ++ ) {
 
-				customAttribute = customAttributes[ i ];
+        customAttribute = customAttributes[ i ];
 
-				if ( ! customAttribute.__original.needsUpdate ) continue;
+        if ( ! customAttribute.__original.needsUpdate ) continue;
 
-				offset_custom = 0;
-				offset_customSrc = 0;
+        offset_custom = 0;
+        offset_customSrc = 0;
 
-				if ( customAttribute.size == 1 ) {
+        if ( customAttribute.size == 1 ) {
 
-					if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
+          if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces3[ f ]	];
+              face = obj_faces[ chunk_faces3[ f ]  ];
 
-							customAttribute.array[ offset_custom ] 	   = customAttribute.value[ face.a ];
-							customAttribute.array[ offset_custom + 1 ] = customAttribute.value[ face.b ];
-							customAttribute.array[ offset_custom + 2 ] = customAttribute.value[ face.c ];
+              customAttribute.array[ offset_custom ]      = customAttribute.value[ face.a ];
+              customAttribute.array[ offset_custom + 1 ] = customAttribute.value[ face.b ];
+              customAttribute.array[ offset_custom + 2 ] = customAttribute.value[ face.c ];
 
-							offset_custom += 3;
+              offset_custom += 3;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces4[ f ] ];
+              face = obj_faces[ chunk_faces4[ f ] ];
 
-							customAttribute.array[ offset_custom ] 	   = customAttribute.value[ face.a ];
-							customAttribute.array[ offset_custom + 1 ] = customAttribute.value[ face.b ];
-							customAttribute.array[ offset_custom + 2 ] = customAttribute.value[ face.c ];
-							customAttribute.array[ offset_custom + 3 ] = customAttribute.value[ face.d ];
+              customAttribute.array[ offset_custom ]      = customAttribute.value[ face.a ];
+              customAttribute.array[ offset_custom + 1 ] = customAttribute.value[ face.b ];
+              customAttribute.array[ offset_custom + 2 ] = customAttribute.value[ face.c ];
+              customAttribute.array[ offset_custom + 3 ] = customAttribute.value[ face.d ];
 
-							offset_custom += 4;
+              offset_custom += 4;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faces" ) {
+          } else if ( customAttribute.boundTo == "faces" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							customAttribute.array[ offset_custom ] 	   = value;
-							customAttribute.array[ offset_custom + 1 ] = value;
-							customAttribute.array[ offset_custom + 2 ] = value;
+              customAttribute.array[ offset_custom ]      = value;
+              customAttribute.array[ offset_custom + 1 ] = value;
+              customAttribute.array[ offset_custom + 2 ] = value;
 
-							offset_custom += 3;
+              offset_custom += 3;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							customAttribute.array[ offset_custom ] 	   = value;
-							customAttribute.array[ offset_custom + 1 ] = value;
-							customAttribute.array[ offset_custom + 2 ] = value;
-							customAttribute.array[ offset_custom + 3 ] = value;
+              customAttribute.array[ offset_custom ]      = value;
+              customAttribute.array[ offset_custom + 1 ] = value;
+              customAttribute.array[ offset_custom + 2 ] = value;
+              customAttribute.array[ offset_custom + 3 ] = value;
 
-							offset_custom += 4;
+              offset_custom += 4;
 
-						}
+            }
 
-					}
+          }
 
-				} else if ( customAttribute.size == 2 ) {
+        } else if ( customAttribute.size == 2 ) {
 
-					if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
+          if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces3[ f ]	];
+              face = obj_faces[ chunk_faces3[ f ]  ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
 
-							customAttribute.array[ offset_custom ] 	   = v1.x;
-							customAttribute.array[ offset_custom + 1 ] = v1.y;
+              customAttribute.array[ offset_custom ]      = v1.x;
+              customAttribute.array[ offset_custom + 1 ] = v1.y;
 
-							customAttribute.array[ offset_custom + 2 ] = v2.x;
-							customAttribute.array[ offset_custom + 3 ] = v2.y;
+              customAttribute.array[ offset_custom + 2 ] = v2.x;
+              customAttribute.array[ offset_custom + 3 ] = v2.y;
 
-							customAttribute.array[ offset_custom + 4 ] = v3.x;
-							customAttribute.array[ offset_custom + 5 ] = v3.y;
+              customAttribute.array[ offset_custom + 4 ] = v3.x;
+              customAttribute.array[ offset_custom + 5 ] = v3.y;
 
-							offset_custom += 6;
+              offset_custom += 6;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces4[ f ] ];
+              face = obj_faces[ chunk_faces4[ f ] ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
-							v4 = customAttribute.value[ face.d ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
+              v4 = customAttribute.value[ face.d ];
 
-							customAttribute.array[ offset_custom ] 	   = v1.x;
-							customAttribute.array[ offset_custom + 1 ] = v1.y;
+              customAttribute.array[ offset_custom ]      = v1.x;
+              customAttribute.array[ offset_custom + 1 ] = v1.y;
 
-							customAttribute.array[ offset_custom + 2 ] = v2.x;
-							customAttribute.array[ offset_custom + 3 ] = v2.y;
+              customAttribute.array[ offset_custom + 2 ] = v2.x;
+              customAttribute.array[ offset_custom + 3 ] = v2.y;
 
-							customAttribute.array[ offset_custom + 4 ] = v3.x;
-							customAttribute.array[ offset_custom + 5 ] = v3.y;
+              customAttribute.array[ offset_custom + 4 ] = v3.x;
+              customAttribute.array[ offset_custom + 5 ] = v3.y;
 
-							customAttribute.array[ offset_custom + 6 ] = v4.x;
-							customAttribute.array[ offset_custom + 7 ] = v4.y;
+              customAttribute.array[ offset_custom + 6 ] = v4.x;
+              customAttribute.array[ offset_custom + 7 ] = v4.y;
 
-							offset_custom += 8;
+              offset_custom += 8;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faces" ) {
+          } else if ( customAttribute.boundTo == "faces" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
 
-							customAttribute.array[ offset_custom ] 	   = v1.x;
-							customAttribute.array[ offset_custom + 1 ] = v1.y;
+              customAttribute.array[ offset_custom ]      = v1.x;
+              customAttribute.array[ offset_custom + 1 ] = v1.y;
 
-							customAttribute.array[ offset_custom + 2 ] = v2.x;
-							customAttribute.array[ offset_custom + 3 ] = v2.y;
+              customAttribute.array[ offset_custom + 2 ] = v2.x;
+              customAttribute.array[ offset_custom + 3 ] = v2.y;
 
-							customAttribute.array[ offset_custom + 4 ] = v3.x;
-							customAttribute.array[ offset_custom + 5 ] = v3.y;
+              customAttribute.array[ offset_custom + 4 ] = v3.x;
+              customAttribute.array[ offset_custom + 5 ] = v3.y;
 
-							offset_custom += 6;
+              offset_custom += 6;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
-							v4 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
+              v4 = value;
 
-							customAttribute.array[ offset_custom ] 	   = v1.x;
-							customAttribute.array[ offset_custom + 1 ] = v1.y;
+              customAttribute.array[ offset_custom ]      = v1.x;
+              customAttribute.array[ offset_custom + 1 ] = v1.y;
 
-							customAttribute.array[ offset_custom + 2 ] = v2.x;
-							customAttribute.array[ offset_custom + 3 ] = v2.y;
+              customAttribute.array[ offset_custom + 2 ] = v2.x;
+              customAttribute.array[ offset_custom + 3 ] = v2.y;
 
-							customAttribute.array[ offset_custom + 4 ] = v3.x;
-							customAttribute.array[ offset_custom + 5 ] = v3.y;
+              customAttribute.array[ offset_custom + 4 ] = v3.x;
+              customAttribute.array[ offset_custom + 5 ] = v3.y;
 
-							customAttribute.array[ offset_custom + 6 ] = v4.x;
-							customAttribute.array[ offset_custom + 7 ] = v4.y;
+              customAttribute.array[ offset_custom + 6 ] = v4.x;
+              customAttribute.array[ offset_custom + 7 ] = v4.y;
 
-							offset_custom += 8;
+              offset_custom += 8;
 
-						}
+            }
 
-					}
+          }
 
-				} else if ( customAttribute.size == 3 ) {
+        } else if ( customAttribute.size == 3 ) {
 
-					var pp;
+          var pp;
 
-					if ( customAttribute.type == "c" ) {
+          if ( customAttribute.type == "c" ) {
 
-						pp = [ "r", "g", "b" ];
+            pp = [ "r", "g", "b" ];
 
-					} else {
+          } else {
 
-						pp = [ "x", "y", "z" ];
+            pp = [ "x", "y", "z" ];
 
-					}
+          }
 
-					if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
+          if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces3[ f ]	];
+              face = obj_faces[ chunk_faces3[ f ]  ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
 
-							customAttribute.array[ offset_custom ] 	   = v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom ]      = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
 
-							offset_custom += 9;
+              offset_custom += 9;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces4[ f ] ];
+              face = obj_faces[ chunk_faces4[ f ] ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
-							v4 = customAttribute.value[ face.d ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
+              v4 = customAttribute.value[ face.d ];
 
-							customAttribute.array[ offset_custom  ] 	= v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom  ]   = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faces" ) {
+          } else if ( customAttribute.boundTo == "faces" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
 
-							customAttribute.array[ offset_custom ] 	   = v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom ]      = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
 
-							offset_custom += 9;
+              offset_custom += 9;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
-							v4 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
+              v4 = value;
 
-							customAttribute.array[ offset_custom  ] 	= v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom  ]   = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faceVertices" ) {
+          } else if ( customAttribute.boundTo == "faceVertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							v1 = value[ 0 ];
-							v2 = value[ 1 ];
-							v3 = value[ 2 ];
+              v1 = value[ 0 ];
+              v2 = value[ 1 ];
+              v3 = value[ 2 ];
 
-							customAttribute.array[ offset_custom ] 	   = v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom ]      = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1 ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2 ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3 ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4 ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5 ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6 ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7 ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8 ] = v3[ pp[ 2 ] ];
 
-							offset_custom += 9;
+              offset_custom += 9;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							v1 = value[ 0 ];
-							v2 = value[ 1 ];
-							v3 = value[ 2 ];
-							v4 = value[ 3 ];
+              v1 = value[ 0 ];
+              v2 = value[ 1 ];
+              v3 = value[ 2 ];
+              v4 = value[ 3 ];
 
-							customAttribute.array[ offset_custom  ] 	= v1[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom  ]   = v1[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 1  ] = v1[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 2  ] = v1[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 3  ] = v2[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 4  ] = v2[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 5  ] = v2[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 6  ] = v3[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 7  ] = v3[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 8  ] = v3[ pp[ 2 ] ];
 
-							customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
-							customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
-							customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
+              customAttribute.array[ offset_custom + 9  ] = v4[ pp[ 0 ] ];
+              customAttribute.array[ offset_custom + 10 ] = v4[ pp[ 1 ] ];
+              customAttribute.array[ offset_custom + 11 ] = v4[ pp[ 2 ] ];
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-					}
+          }
 
-				} else if ( customAttribute.size == 4 ) {
+        } else if ( customAttribute.size == 4 ) {
 
-					if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
+          if ( customAttribute.boundTo == null || customAttribute.boundTo == "vertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces3[ f ]	];
+              face = obj_faces[ chunk_faces3[ f ]  ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							face = obj_faces[ chunk_faces4[ f ] ];
+              face = obj_faces[ chunk_faces4[ f ] ];
 
-							v1 = customAttribute.value[ face.a ];
-							v2 = customAttribute.value[ face.b ];
-							v3 = customAttribute.value[ face.c ];
-							v4 = customAttribute.value[ face.d ];
+              v1 = customAttribute.value[ face.a ];
+              v2 = customAttribute.value[ face.b ];
+              v3 = customAttribute.value[ face.c ];
+              v4 = customAttribute.value[ face.d ];
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							customAttribute.array[ offset_custom + 12 ] = v4.x;
-							customAttribute.array[ offset_custom + 13 ] = v4.y;
-							customAttribute.array[ offset_custom + 14 ] = v4.z;
-							customAttribute.array[ offset_custom + 15 ] = v4.w;
+              customAttribute.array[ offset_custom + 12 ] = v4.x;
+              customAttribute.array[ offset_custom + 13 ] = v4.y;
+              customAttribute.array[ offset_custom + 14 ] = v4.z;
+              customAttribute.array[ offset_custom + 15 ] = v4.w;
 
-							offset_custom += 16;
+              offset_custom += 16;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faces" ) {
+          } else if ( customAttribute.boundTo == "faces" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							v1 = value;
-							v2 = value;
-							v3 = value;
-							v4 = value;
+              v1 = value;
+              v2 = value;
+              v3 = value;
+              v4 = value;
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							customAttribute.array[ offset_custom + 12 ] = v4.x;
-							customAttribute.array[ offset_custom + 13 ] = v4.y;
-							customAttribute.array[ offset_custom + 14 ] = v4.z;
-							customAttribute.array[ offset_custom + 15 ] = v4.w;
+              customAttribute.array[ offset_custom + 12 ] = v4.x;
+              customAttribute.array[ offset_custom + 13 ] = v4.y;
+              customAttribute.array[ offset_custom + 14 ] = v4.z;
+              customAttribute.array[ offset_custom + 15 ] = v4.w;
 
-							offset_custom += 16;
+              offset_custom += 16;
 
-						}
+            }
 
-					} else if ( customAttribute.boundTo == "faceVertices" ) {
+          } else if ( customAttribute.boundTo == "faceVertices" ) {
 
-						fl = chunk_faces3.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces3.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces3[ f ] ];
+              value = customAttribute.value[ chunk_faces3[ f ] ];
 
-							v1 = value[ 0 ];
-							v2 = value[ 1 ];
-							v3 = value[ 2 ];
+              v1 = value[ 0 ];
+              v2 = value[ 1 ];
+              v3 = value[ 2 ];
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							offset_custom += 12;
+              offset_custom += 12;
 
-						}
+            }
 
-						fl = chunk_faces4.length;
-						for ( f = 0; f < fl; f ++ ) {
+            fl = chunk_faces4.length;
+            for ( f = 0; f < fl; f ++ ) {
 
-							value = customAttribute.value[ chunk_faces4[ f ] ];
+              value = customAttribute.value[ chunk_faces4[ f ] ];
 
-							v1 = value[ 0 ];
-							v2 = value[ 1 ];
-							v3 = value[ 2 ];
-							v4 = value[ 3 ];
+              v1 = value[ 0 ];
+              v2 = value[ 1 ];
+              v3 = value[ 2 ];
+              v4 = value[ 3 ];
 
-							customAttribute.array[ offset_custom  ] 	= v1.x;
-							customAttribute.array[ offset_custom + 1  ] = v1.y;
-							customAttribute.array[ offset_custom + 2  ] = v1.z;
-							customAttribute.array[ offset_custom + 3  ] = v1.w;
+              customAttribute.array[ offset_custom  ]   = v1.x;
+              customAttribute.array[ offset_custom + 1  ] = v1.y;
+              customAttribute.array[ offset_custom + 2  ] = v1.z;
+              customAttribute.array[ offset_custom + 3  ] = v1.w;
 
-							customAttribute.array[ offset_custom + 4  ] = v2.x;
-							customAttribute.array[ offset_custom + 5  ] = v2.y;
-							customAttribute.array[ offset_custom + 6  ] = v2.z;
-							customAttribute.array[ offset_custom + 7  ] = v2.w;
+              customAttribute.array[ offset_custom + 4  ] = v2.x;
+              customAttribute.array[ offset_custom + 5  ] = v2.y;
+              customAttribute.array[ offset_custom + 6  ] = v2.z;
+              customAttribute.array[ offset_custom + 7  ] = v2.w;
 
-							customAttribute.array[ offset_custom + 8  ] = v3.x;
-							customAttribute.array[ offset_custom + 9  ] = v3.y;
-							customAttribute.array[ offset_custom + 10 ] = v3.z;
-							customAttribute.array[ offset_custom + 11 ] = v3.w;
+              customAttribute.array[ offset_custom + 8  ] = v3.x;
+              customAttribute.array[ offset_custom + 9  ] = v3.y;
+              customAttribute.array[ offset_custom + 10 ] = v3.z;
+              customAttribute.array[ offset_custom + 11 ] = v3.w;
 
-							customAttribute.array[ offset_custom + 12 ] = v4.x;
-							customAttribute.array[ offset_custom + 13 ] = v4.y;
-							customAttribute.array[ offset_custom + 14 ] = v4.z;
-							customAttribute.array[ offset_custom + 15 ] = v4.w;
+              customAttribute.array[ offset_custom + 12 ] = v4.x;
+              customAttribute.array[ offset_custom + 13 ] = v4.y;
+              customAttribute.array[ offset_custom + 14 ] = v4.z;
+              customAttribute.array[ offset_custom + 15 ] = v4.w;
 
-							offset_custom += 16;
+              offset_custom += 16;
 
-						}
+            }
 
-					}
+          }
 
-				}
+        }
 
-				customAttribute.buffer.bind(gl.ARRAY_BUFFER);
+        customAttribute.buffer.bind(gl.ARRAY_BUFFER);
 
-        		_gl.bufferDataTyped(gl.ARRAY_BUFFER, customAttribute.array, hint);
+            _gl.bufferDataTyped(gl.ARRAY_BUFFER, customAttribute.array, hint);
 
-			}
+      }
 
-		}
+    }
 
-		if ( dispose ) {
+    if ( dispose ) {
 
-			geometryGroup.__inittedArrays = false; //delete geometryGroup.__inittedArrays"];
-			geometryGroup.__colorArray = null; //delete geometryGroup.__colorArray"];
-			geometryGroup.__normalArray = null; //delete geometryGroup.__normalArray"];
-			geometryGroup.__tangentArray = null; //delete geometryGroup.__tangentArray"];
-			geometryGroup.__uvArray = null; //delete geometryGroup.__uvArray"];
-			geometryGroup.__uv2Array = null; //delete geometryGroup.__uv2Array"];
-			geometryGroup.__faceArray = null; //delete geometryGroup.__faceArray"];
-			geometryGroup.__vertexArray = null; //delete geometryGroup.__vertexArray"];
-			geometryGroup.__lineArray = null; //delete geometryGroup.__lineArray"];
-			geometryGroup.__skinIndexArray = null; //delete geometryGroup.__skinIndexArray"];
-			geometryGroup.__skinWeightArray = null; //delete geometryGroup.__skinWeightArray"];
+      geometryGroup.__inittedArrays = false; //delete geometryGroup.__inittedArrays"];
+      geometryGroup.__colorArray = null; //delete geometryGroup.__colorArray"];
+      geometryGroup.__normalArray = null; //delete geometryGroup.__normalArray"];
+      geometryGroup.__tangentArray = null; //delete geometryGroup.__tangentArray"];
+      geometryGroup.__uvArray = null; //delete geometryGroup.__uvArray"];
+      geometryGroup.__uv2Array = null; //delete geometryGroup.__uv2Array"];
+      geometryGroup.__faceArray = null; //delete geometryGroup.__faceArray"];
+      geometryGroup.__vertexArray = null; //delete geometryGroup.__vertexArray"];
+      geometryGroup.__lineArray = null; //delete geometryGroup.__lineArray"];
+      geometryGroup.__skinIndexArray = null; //delete geometryGroup.__skinIndexArray"];
+      geometryGroup.__skinWeightArray = null; //delete geometryGroup.__skinWeightArray"];
 
-		}
+    }
 
-	}
+  }
 
-	setDirectBuffers ( BufferGeometry geometry, int hint, bool dispose ) {
+  setDirectBuffers ( BufferGeometry geometry, int hint, bool dispose ) {
 
-		var attributes = geometry.attributes;
+    var attributes = geometry.attributes;
 
-		var index = geometry.aIndex;
-		var position = geometry.aPosition;
-		var normal = geometry.aNormal;
-		var uv = geometry.aUV;
-		var color = geometry.aColor;
-		var tangent = geometry.aTangent;
+    var index = geometry.aIndex;
+    var position = geometry.aPosition;
+    var normal = geometry.aNormal;
+    var uv = geometry.aUV;
+    var color = geometry.aColor;
+    var tangent = geometry.aTangent;
 
-		if ( geometry.elementsNeedUpdate && index != null ) {
+    if ( geometry.elementsNeedUpdate && index != null ) {
 
-			index.buffer.bind( gl.ELEMENT_ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, index.array, hint );
+      index.buffer.bind( gl.ELEMENT_ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ELEMENT_ARRAY_BUFFER, index.array, hint );
 
-		}
+    }
 
-		if ( geometry.verticesNeedUpdate && position != null ) {
+    if ( geometry.verticesNeedUpdate && position != null ) {
 
-			position.buffer.bind( gl.ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, position.array, hint );
+      position.buffer.bind( gl.ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, position.array, hint );
 
-		}
+    }
 
-		if ( geometry.normalsNeedUpdate && normal != null ) {
+    if ( geometry.normalsNeedUpdate && normal != null ) {
 
-			normal.buffer.bind( gl.ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, normal.array, hint );
+      normal.buffer.bind( gl.ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, normal.array, hint );
 
-		}
+    }
 
-		if ( geometry.uvsNeedUpdate && uv != null ) {
+    if ( geometry.uvsNeedUpdate && uv != null ) {
 
-			uv.buffer.bind( gl.ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, uv.array, hint );
+      uv.buffer.bind( gl.ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, uv.array, hint );
 
-		}
+    }
 
-		if ( geometry.colorsNeedUpdate && color != null ) {
+    if ( geometry.colorsNeedUpdate && color != null ) {
 
-			color.buffer.bind( gl.ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, color.array, hint );
+      color.buffer.bind( gl.ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, color.array, hint );
 
-		}
+    }
 
-		if ( geometry.tangentsNeedUpdate && tangent != null ) {
+    if ( geometry.tangentsNeedUpdate && tangent != null ) {
 
-			tangent.buffer.bind( gl.ARRAY_BUFFER );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, tangent.array, hint );
+      tangent.buffer.bind( gl.ARRAY_BUFFER );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, tangent.array, hint );
 
-		}
+    }
 
-		if ( dispose ) {
+    if ( dispose ) {
 
-		  geometry.attributes.forEach((_, attribute) {
-			 attribute.array = null; //delete geometry.attributes[ i ].array;
-			});
+      geometry.attributes.forEach((_, attribute) {
+       attribute.array = null; //delete geometry.attributes[ i ].array;
+      });
 
-		}
+    }
 
-	}
+  }
 
-	// Buffer rendering
+  // Buffer rendering
 
-	renderBufferImmediate ( Object3D object, program, material ) {
+  renderBufferImmediate ( Object3D object, program, material ) {
 
-		if ( object.hasPositions && object.__webglVertexBuffer == null ) object.__webglVertexBuffer = _gl.createBuffer();
-		if ( object.hasNormals && object.__webglNormalBuffer == null ) object.__webglNormalBuffer = _gl.createBuffer();
-		if ( object.hasUvs && object.__webglUVBuffer == null ) object.__webglUVBuffer = _gl.createBuffer();
-		if ( object.hasColors && object.__webglColorBuffer == null ) object.__webglColorBuffer = _gl.createBuffer();
+    if ( object.hasPositions && object.__webglVertexBuffer == null ) object.__webglVertexBuffer = _gl.createBuffer();
+    if ( object.hasNormals && object.__webglNormalBuffer == null ) object.__webglNormalBuffer = _gl.createBuffer();
+    if ( object.hasUvs && object.__webglUVBuffer == null ) object.__webglUVBuffer = _gl.createBuffer();
+    if ( object.hasColors && object.__webglColorBuffer == null ) object.__webglColorBuffer = _gl.createBuffer();
 
-		if ( object.hasPositions ) {
+    if ( object.hasPositions ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglVertexBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, object.positionArray, gl.DYNAMIC_DRAW );
-			_gl.enableVertexAttribArray( program.attributes["position"] );
-			_gl.vertexAttribPointer( program.attributes["position"], 3, gl.FLOAT, false, 0, 0 );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglVertexBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, object.positionArray, gl.DYNAMIC_DRAW );
+      _gl.enableVertexAttribArray( program.attributes["position"] );
+      _gl.vertexAttribPointer( program.attributes["position"], 3, gl.FLOAT, false, 0, 0 );
 
-		}
+    }
 
-		if ( object.hasNormals ) {
+    if ( object.hasNormals ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglNormalBuffer );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglNormalBuffer );
 
-			if ( material.shading == FlatShading ) {
+      if ( material.shading == FlatShading ) {
 
-				var nx, ny, nz,
-					nax, nbx, ncx, nay, nby, ncy, naz, nbz, ncz,
-					normalArray,
-					i, il = object.count * 3;
+        var nx, ny, nz,
+          nax, nbx, ncx, nay, nby, ncy, naz, nbz, ncz,
+          normalArray,
+          i, il = object.count * 3;
 
-				for( i = 0; i < il; i += 9 ) {
+        for( i = 0; i < il; i += 9 ) {
 
-					normalArray = object.normalArray;
+          normalArray = object.normalArray;
 
-					nax  = normalArray[ i ];
-					nay  = normalArray[ i + 1 ];
-					naz  = normalArray[ i + 2 ];
+          nax  = normalArray[ i ];
+          nay  = normalArray[ i + 1 ];
+          naz  = normalArray[ i + 2 ];
 
-					nbx  = normalArray[ i + 3 ];
-					nby  = normalArray[ i + 4 ];
-					nbz  = normalArray[ i + 5 ];
+          nbx  = normalArray[ i + 3 ];
+          nby  = normalArray[ i + 4 ];
+          nbz  = normalArray[ i + 5 ];
 
-					ncx  = normalArray[ i + 6 ];
-					ncy  = normalArray[ i + 7 ];
-					ncz  = normalArray[ i + 8 ];
+          ncx  = normalArray[ i + 6 ];
+          ncy  = normalArray[ i + 7 ];
+          ncz  = normalArray[ i + 8 ];
 
-					nx = ( nax + nbx + ncx ) / 3;
-					ny = ( nay + nby + ncy ) / 3;
-					nz = ( naz + nbz + ncz ) / 3;
+          nx = ( nax + nbx + ncx ) / 3;
+          ny = ( nay + nby + ncy ) / 3;
+          nz = ( naz + nbz + ncz ) / 3;
 
-					normalArray[ i ] 	 = nx;
-					normalArray[ i + 1 ] = ny;
-					normalArray[ i + 2 ] = nz;
+          normalArray[ i ]    = nx;
+          normalArray[ i + 1 ] = ny;
+          normalArray[ i + 2 ] = nz;
 
-					normalArray[ i + 3 ] = nx;
-					normalArray[ i + 4 ] = ny;
-					normalArray[ i + 5 ] = nz;
+          normalArray[ i + 3 ] = nx;
+          normalArray[ i + 4 ] = ny;
+          normalArray[ i + 5 ] = nz;
 
-					normalArray[ i + 6 ] = nx;
-					normalArray[ i + 7 ] = ny;
-					normalArray[ i + 8 ] = nz;
+          normalArray[ i + 6 ] = nx;
+          normalArray[ i + 7 ] = ny;
+          normalArray[ i + 8 ] = nz;
 
-				}
+        }
 
-			}
+      }
 
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, object.normalArray, gl.DYNAMIC_DRAW );
-			_gl.enableVertexAttribArray( program.attributes["normal"] );
-			_gl.vertexAttribPointer( program.attributes["normal"], 3, gl.FLOAT, false, 0, 0 );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, object.normalArray, gl.DYNAMIC_DRAW );
+      _gl.enableVertexAttribArray( program.attributes["normal"] );
+      _gl.vertexAttribPointer( program.attributes["normal"], 3, gl.FLOAT, false, 0, 0 );
 
-		}
+    }
 
-		if ( object.hasUvs && material.map ) {
+    if ( object.hasUvs && material.map ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglUVBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, object.uvArray, gl.DYNAMIC_DRAW );
-			_gl.enableVertexAttribArray( program.attributes["uv"] );
-			_gl.vertexAttribPointer( program.attributes["uv"], 2, gl.FLOAT, false, 0, 0 );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglUVBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, object.uvArray, gl.DYNAMIC_DRAW );
+      _gl.enableVertexAttribArray( program.attributes["uv"] );
+      _gl.vertexAttribPointer( program.attributes["uv"], 2, gl.FLOAT, false, 0, 0 );
 
-		}
+    }
 
-		if ( object.hasColors && material.vertexColors != NoColors ) {
+    if ( object.hasColors && material.vertexColors != NoColors ) {
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglColorBuffer );
-			_gl.bufferDataTyped( gl.ARRAY_BUFFER, object.colorArray, gl.DYNAMIC_DRAW );
-			_gl.enableVertexAttribArray( program.attributes["color"] );
-			_gl.vertexAttribPointer( program.attributes["color"], 3, gl.FLOAT, false, 0, 0 );
+      _gl.bindBuffer( gl.ARRAY_BUFFER, object.__webglColorBuffer );
+      _gl.bufferDataTyped( gl.ARRAY_BUFFER, object.colorArray, gl.DYNAMIC_DRAW );
+      _gl.enableVertexAttribArray( program.attributes["color"] );
+      _gl.vertexAttribPointer( program.attributes["color"], 3, gl.FLOAT, false, 0, 0 );
 
-		}
+    }
 
-		_gl.drawArrays( gl.TRIANGLES, 0, object.count );
+    _gl.drawArrays( gl.TRIANGLES, 0, object.count );
 
-		object.count = 0;
+    object.count = 0;
 
-	}
+  }
 
-	renderBufferDirect ( Camera camera, List<Light> lights, fog, Material material, BufferGeometry geometry, Object object ) {
+  renderBufferDirect ( Camera camera, List<Light> lights, fog, Material material, BufferGeometry geometry, Object object ) {
 
-		if ( !material.visible ) return;
+    if ( !material.visible ) return;
 
-		var program, attributes, linewidth, primitives, a, attribute;
+    var program, attributes, linewidth, primitives, a, attribute;
 
-		program = setProgram( camera, lights, fog, material, object );
+    program = setProgram( camera, lights, fog, material, object );
 
-		attributes = program.attributes;
+    attributes = program.attributes;
 
-		var updateBuffers = false,
-			wireframeBit = ((material is Wireframe) && (material as Wireframe).wireframe) ? 1 : 0,
-			geometryHash = ( geometry.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
+    var updateBuffers = false,
+      wireframeBit = ((material is Wireframe) && (material as Wireframe).wireframe) ? 1 : 0,
+      geometryHash = ( geometry.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
 
-		if ( geometryHash != _currentGeometryGroupHash ) {
+    if ( geometryHash != _currentGeometryGroupHash ) {
 
-			_currentGeometryGroupHash = geometryHash;
-			updateBuffers = true;
+      _currentGeometryGroupHash = geometryHash;
+      updateBuffers = true;
 
-		}
+    }
 
-		if ( updateBuffers ) {
+    if ( updateBuffers ) {
 
-			disableAttributes();
+      disableAttributes();
 
-		}
+    }
 
-		// render mesh
+    // render mesh
 
-		if ( object is Mesh ) {
+    if ( object is Mesh ) {
 
-			var index = geometry.aIndex;
+      var index = geometry.aIndex;
 
-			// indexed triangles
+      // indexed triangles
 
-			if ( index != null) {
+      if ( index != null) {
 
-				var offsets = geometry.offsets;
+        var offsets = geometry.offsets;
 
-				// if there is more than 1 chunk
-				// must set attribute pointers to use new offsets for each chunk
-				// even if geometry and materials didn't change
+        // if there is more than 1 chunk
+        // must set attribute pointers to use new offsets for each chunk
+        // even if geometry and materials didn't change
 
-				if ( offsets.length > 1 ) updateBuffers = true;
+        if ( offsets.length > 1 ) updateBuffers = true;
 
-				for ( var i = 0, il = offsets.length; i < il; i ++ ) {
+        for ( var i = 0, il = offsets.length; i < il; i ++ ) {
 
-					var startIndex = offsets[ i ].index;
+          var startIndex = offsets[ i ].index;
 
-					if ( updateBuffers ) {
+          if ( updateBuffers ) {
 
-						// vertices
+            // vertices
 
-						var position = geometry.attributes[ "position" ];
-						var positionSize = position.itemSize;
+            var position = geometry.attributes[ "position" ];
+            var positionSize = position.itemSize;
 
-						position.buffer.bind( gl.ARRAY_BUFFER );
-						enableAttribute( attributes["position"] );
-						_gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, startIndex * positionSize * 4 ); // 4 bytes per Float32
+            position.buffer.bind( gl.ARRAY_BUFFER );
+            enableAttribute( attributes["position"] );
+            _gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, startIndex * positionSize * 4 ); // 4 bytes per Float32
 
-						// normals
+            // normals
 
-						var normal = geometry.attributes[ "normal" ];
+            var normal = geometry.attributes[ "normal" ];
 
-						if ( attributes["normal"] >= 0 && normal != null) {
+            if ( attributes["normal"] >= 0 && normal != null) {
 
-							var normalSize = normal.itemSize;
+              var normalSize = normal.itemSize;
 
-							normal.buffer.bind( gl.ARRAY_BUFFER );
-							enableAttribute( attributes["normal"] );
-							_gl.vertexAttribPointer( attributes["normal"], normalSize, gl.FLOAT, false, 0, startIndex * normalSize * 4 );
+              normal.buffer.bind( gl.ARRAY_BUFFER );
+              enableAttribute( attributes["normal"] );
+              _gl.vertexAttribPointer( attributes["normal"], normalSize, gl.FLOAT, false, 0, startIndex * normalSize * 4 );
 
-						}
+            }
 
-						// uvs
+            // uvs
 
-						var uv = geometry.attributes[ "uv" ];
+            var uv = geometry.attributes[ "uv" ];
 
-						if ( attributes["uv"] >= 0 && uv != null ) {
+            if ( attributes["uv"] >= 0 && uv != null ) {
 
-							var uvSize = uv.itemSize;
+              var uvSize = uv.itemSize;
 
-							uv.buffer.bind( gl.ARRAY_BUFFER );
-							enableAttribute( attributes["uv"]);
-							_gl.vertexAttribPointer( attributes["uv"], uvSize, gl.FLOAT, false, 0, startIndex * uvSize * 4 );
+              uv.buffer.bind( gl.ARRAY_BUFFER );
+              enableAttribute( attributes["uv"]);
+              _gl.vertexAttribPointer( attributes["uv"], uvSize, gl.FLOAT, false, 0, startIndex * uvSize * 4 );
 
-						}
+            }
 
-						// colors
+            // colors
 
-						var color = geometry.attributes[ "color" ];
+            var color = geometry.attributes[ "color" ];
 
-						if ( attributes["color"] >= 0 && color != null ) {
+            if ( attributes["color"] >= 0 && color != null ) {
 
-							var colorSize = color.itemSize;
+              var colorSize = color.itemSize;
 
-							color.buffer.bind( gl.ARRAY_BUFFER );
-							enableAttribute( attributes["color"] );
-							_gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, startIndex * colorSize * 4 );
+              color.buffer.bind( gl.ARRAY_BUFFER );
+              enableAttribute( attributes["color"] );
+              _gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, startIndex * colorSize * 4 );
 
-						}
+            }
 
-						// tangents
+            // tangents
 
-						var tangent = geometry.attributes[ "tangent" ];
+            var tangent = geometry.attributes[ "tangent" ];
 
-						if ( attributes["tangent"] >= 0 && tangent != null ) {
+            if ( attributes["tangent"] >= 0 && tangent != null ) {
 
-							var tangentSize = tangent.itemSize;
+              var tangentSize = tangent.itemSize;
 
-							tangent.buffer.bind( gl.ARRAY_BUFFER );
-							enableAttribute( attributes["tangent"] );
-							_gl.vertexAttribPointer( attributes["tangent"], tangentSize, gl.FLOAT, false, 0, startIndex * tangentSize * 4 );
+              tangent.buffer.bind( gl.ARRAY_BUFFER );
+              enableAttribute( attributes["tangent"] );
+              _gl.vertexAttribPointer( attributes["tangent"], tangentSize, gl.FLOAT, false, 0, startIndex * tangentSize * 4 );
 
-						}
+            }
 
-						// indices
+            // indices
 
-						index.buffer.bind( gl.ELEMENT_ARRAY_BUFFER );
+            index.buffer.bind( gl.ELEMENT_ARRAY_BUFFER );
 
-					}
+          }
 
-					// render indexed triangles
+          // render indexed triangles
 
-					_gl.drawElements( gl.TRIANGLES, offsets[ i ].count, gl.UNSIGNED_SHORT, offsets[ i ].start * 2 ); // 2 bytes per Uint16
+          _gl.drawElements( gl.TRIANGLES, offsets[ i ].count, gl.UNSIGNED_SHORT, offsets[ i ].start * 2 ); // 2 bytes per Uint16
 
-					info.render.calls ++;
-					info.render.vertices += offsets[ i ].count; // not really true, here vertices can be shared
-					info.render.faces += offsets[ i ].count ~/ 3;
+          info.render.calls ++;
+          info.render.vertices += offsets[ i ].count; // not really true, here vertices can be shared
+          info.render.faces += offsets[ i ].count ~/ 3;
 
-				}
+        }
 
-			// non-indexed triangles
+      // non-indexed triangles
 
-			} else {
+      } else {
 
-			  GeometryAttribute<Float32List> position = geometry.aPosition;
-
-				if ( updateBuffers ) {
-
-					// vertices
-
-
-					var positionSize = position.itemSize;
-
-					position.buffer.bind( gl.ARRAY_BUFFER );
-					enableAttribute( attributes["position"] );
-					_gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, 0 );
-
-					// normals
-
-					GeometryAttribute<Float32List> normal = geometry.aNormal;
-
-					if ( attributes["normal"] >= 0 && normal != null ) {
-
-						var normalSize = normal.itemSize;
-
-						normal.buffer.bind( gl.ARRAY_BUFFER );
-						enableAttribute( attributes["normal"] );
-						_gl.vertexAttribPointer( attributes["normal"], normalSize, gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// uvs
-
-					GeometryAttribute<Float32List> uv = geometry.aUV;
-
-					if ( attributes["uv"] >= 0 && uv != null ) {
-
-						var uvSize = uv.itemSize;
-
-						uv.buffer.bind( gl.ARRAY_BUFFER );
-						enableAttribute( attributes["uv"] );
-						_gl.vertexAttribPointer( attributes["uv"], uvSize, gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// colors
-
-					GeometryAttribute<Float32List> color = geometry.aColor;
-
-					if ( attributes["color"] >= 0 && color != null ) {
-
-						var colorSize = color.itemSize;
-
-						color.buffer.bind( gl.ARRAY_BUFFER );
-						enableAttribute( attributes["color"] );
-						_gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, 0 );
-
-					}
-
-					// tangents
-
-					GeometryAttribute<Float32List> tangent = geometry.aTangent;
-
-					if ( attributes["tangent"] >= 0 && tangent != null ) {
-
-						var tangentSize = tangent.itemSize;
-
-						tangent.buffer.bind( gl.ARRAY_BUFFER );
-						enableAttribute( attributes["tangent"] );
-						_gl.vertexAttribPointer( attributes["tangent"], tangentSize, gl.FLOAT, false, 0, 0 );
-
-					}
-				}
-
-				// render non-indexed triangles
-
-				_gl.drawArrays( gl.TRIANGLES, 0, position.numItems ~/ 3 );
-
-				info.render.calls ++;
-				info.render.vertices += position.numItems ~/ 3;
-				info.render.faces += position.numItems ~/ 3 ~/ 3;
-
-			}
-
-		// render particles
-
-		} else if ( object is ParticleSystem ) {
-
-			if ( updateBuffers ) {
-
-				// vertices
-
-				var position = geometry.attributes[ "position" ];
-				var positionSize = position.itemSize;
-
-				position.buffer.bind( gl.ARRAY_BUFFER );
-				enableAttribute( attributes["position"] );
-				_gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, 0 );
-
-				// colors
-
-				var color = geometry.attributes[ "color" ];
-
-				if ( attributes["color"] >= 0 && color != null ) {
-
-					var colorSize = color.itemSize;
-
-					color.buffer.bind( gl.ARRAY_BUFFER );
-					enableAttribute( attributes["color"] );
-					_gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, 0 );
-
-				}
-
-				// render particles
-
-				_gl.drawArrays( gl.POINTS, 0, position.numItems ~/ 3);
-
-				info.render.calls ++;
-				info.render.points += position.numItems ~/ 3;
-
-			}
-
-		}
-
-	}
-
-	renderBuffer ( Camera camera, List<Light> lights, Fog fog, Material material, WebGLGeometry geometryGroup, Object3D object ) {
-
-
-		if ( !material.visible ) return;
-
-		var program, attributes, linewidth, primitives, a, attribute, i, il;
-
-		program = setProgram( camera, lights, fog, material, object );
-
-		attributes = program.attributes;
-
-		var updateBuffers = false,
-			wireframeBit = ((material is Wireframe) && (material as Wireframe).wireframe) ? 1 : 0,
-			geometryGroupHash = ( geometryGroup.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
-
-		if ( geometryGroupHash != _currentGeometryGroupHash ) {
-
-			_currentGeometryGroupHash = geometryGroupHash;
-			updateBuffers = true;
-
-		}
+        GeometryAttribute<Float32List> position = geometry.aPosition;
 
         if ( updateBuffers ) {
 
-			disableAttributes();
+          // vertices
 
-		}
-		// vertices
 
-		if ( ((material is! Morphing) || ((material is Morphing) && !(material as Morphing).morphTargets)) && attributes["position"] >= 0 ) {
+          var positionSize = position.itemSize;
 
-			if ( updateBuffers ) {
+          position.buffer.bind( gl.ARRAY_BUFFER );
+          enableAttribute( attributes["position"] );
+          _gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, 0 );
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
-				enableAttribute( attributes["position"] );
-				_gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
+          // normals
 
-			}
+          GeometryAttribute<Float32List> normal = geometry.aNormal;
 
-		} else {
+          if ( attributes["normal"] >= 0 && normal != null ) {
 
-			if ( (object is Mesh) && object.morphTargetBase != 0 ) {
+            var normalSize = normal.itemSize;
 
-				setupMorphTargets( material, geometryGroup, object );
+            normal.buffer.bind( gl.ARRAY_BUFFER );
+            enableAttribute( attributes["normal"] );
+            _gl.vertexAttribPointer( attributes["normal"], normalSize, gl.FLOAT, false, 0, 0 );
 
-			}
+          }
 
-		}
+          // uvs
 
+          GeometryAttribute<Float32List> uv = geometry.aUV;
 
-		if ( updateBuffers ) {
+          if ( attributes["uv"] >= 0 && uv != null ) {
 
-			// custom attributes
+            var uvSize = uv.itemSize;
 
-			// Use the per-geometryGroup custom attribute arrays which are setup in initMeshBuffers
+            uv.buffer.bind( gl.ARRAY_BUFFER );
+            enableAttribute( attributes["uv"] );
+            _gl.vertexAttribPointer( attributes["uv"], uvSize, gl.FLOAT, false, 0, 0 );
 
-			if ( geometryGroup.__webglCustomAttributesList != null) {
+          }
 
-			  il = geometryGroup.__webglCustomAttributesList.length;
-				for ( i = 0; i < il; i ++ ) {
+          // colors
 
-					attribute = geometryGroup.__webglCustomAttributesList[ i ];
+          GeometryAttribute<Float32List> color = geometry.aColor;
 
-					if( attributes[ attribute.buffer.belongsToAttribute ] >= 0 ) {
+          if ( attributes["color"] >= 0 && color != null ) {
 
-						attribute.buffer.bind(gl.ARRAY_BUFFER);
-						enableAttribute( attributes[ attribute.buffer.belongsToAttribute ] );
-						_gl.vertexAttribPointer( attributes[ attribute.buffer.belongsToAttribute ], attribute.size, gl.FLOAT, false, 0, 0 );
+            var colorSize = color.itemSize;
 
-					}
+            color.buffer.bind( gl.ARRAY_BUFFER );
+            enableAttribute( attributes["color"] );
+            _gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, 0 );
 
-				}
+          }
 
-			}
+          // tangents
 
+          GeometryAttribute<Float32List> tangent = geometry.aTangent;
 
-			// colors
+          if ( attributes["tangent"] >= 0 && tangent != null ) {
 
-			if ( attributes["color"] >= 0 ) {
+            var tangentSize = tangent.itemSize;
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglColorBuffer );
-				enableAttribute( attributes["color"] );
-				_gl.vertexAttribPointer( attributes["color"], 3, gl.FLOAT, false, 0, 0 );
+            tangent.buffer.bind( gl.ARRAY_BUFFER );
+            enableAttribute( attributes["tangent"] );
+            _gl.vertexAttribPointer( attributes["tangent"], tangentSize, gl.FLOAT, false, 0, 0 );
 
-			}
+          }
+        }
 
-			// normals
+        // render non-indexed triangles
 
-			if ( attributes["normal"] >= 0 ) {
+        _gl.drawArrays( gl.TRIANGLES, 0, position.numItems ~/ 3 );
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglNormalBuffer );
-				enableAttribute( attributes["normal"] );
-				_gl.vertexAttribPointer( attributes["normal"], 3, gl.FLOAT, false, 0, 0 );
+        info.render.calls ++;
+        info.render.vertices += position.numItems ~/ 3;
+        info.render.faces += position.numItems ~/ 3 ~/ 3;
 
-			}
+      }
 
-			// tangents
+    // render particles
 
-			if ( attributes["tangent"] >= 0 ) {
+    } else if ( object is ParticleSystem ) {
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglTangentBuffer );
-				enableAttribute( attributes["tangent"] );
-				_gl.vertexAttribPointer( attributes["tangent"], 4, gl.FLOAT, false, 0, 0 );
+      if ( updateBuffers ) {
 
-			}
+        // vertices
 
-			// uvs
+        var position = geometry.attributes[ "position" ];
+        var positionSize = position.itemSize;
 
-			if ( attributes["uv"] >= 0 ) {
+        position.buffer.bind( gl.ARRAY_BUFFER );
+        enableAttribute( attributes["position"] );
+        _gl.vertexAttribPointer( attributes["position"], positionSize, gl.FLOAT, false, 0, 0 );
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUVBuffer );
-				enableAttribute( attributes["uv"] );
-				_gl.vertexAttribPointer( attributes["uv"], 2, gl.FLOAT, false, 0, 0 );
+        // colors
 
+        var color = geometry.attributes[ "color" ];
 
-			}
+        if ( attributes["color"] >= 0 && color != null ) {
 
-			if ( attributes["uv2"] >= 0 ) {
+          var colorSize = color.itemSize;
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUV2Buffer );
-				enableAttribute( attributes["uv2"] );
-				_gl.vertexAttribPointer( attributes["uv2"], 2, gl.FLOAT, false, 0, 0 );
+          color.buffer.bind( gl.ARRAY_BUFFER );
+          enableAttribute( attributes["color"] );
+          _gl.vertexAttribPointer( attributes["color"], colorSize, gl.FLOAT, false, 0, 0 );
 
-			}
+        }
 
-			if ( (material is Skinning) && (material as Skinning).skinning &&
-				 attributes["skinIndex"] >= 0 && attributes["skinWeight"] >= 0 ) {
+        // render particles
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinIndicesBuffer );
-				enableAttribute( attributes["skinIndex"] );
-				_gl.vertexAttribPointer( attributes["skinIndex"], 4, gl.FLOAT, false, 0, 0 );
+        _gl.drawArrays( gl.POINTS, 0, position.numItems ~/ 3);
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinWeightsBuffer );
-				enableAttribute( attributes["skinWeight"] );
-				_gl.vertexAttribPointer( attributes["skinWeight"], 4, gl.FLOAT, false, 0, 0 );
+        info.render.calls ++;
+        info.render.points += position.numItems ~/ 3;
 
-			}
+      }
 
-			// line distances
+    }
 
-			if ( attributes["lineDistance"] >= 0 ) {
+  }
 
-				_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglLineDistanceBuffer );
-				enableAttribute( attributes["lineDistance"] );
-				_gl.vertexAttribPointer( attributes["lineDistance"], 1, gl.FLOAT, false, 0, 0 );
+  renderBuffer ( Camera camera, List<Light> lights, Fog fog, Material material, WebGLGeometry geometryGroup, Object3D object ) {
 
-			}
-		}
 
-		// render mesh
+    if ( !material.visible ) return;
 
-		if ( object is Mesh ) {
+    var program, attributes, linewidth, primitives, a, attribute, i, il;
 
-			// wireframe
+    program = setProgram( camera, lights, fog, material, object );
 
-			if ( material is Wireframe && (material as Wireframe).wireframe ) {
+    attributes = program.attributes;
 
-				setLineWidth( (material as Wireframe).wireframeLinewidth );
+    var updateBuffers = false,
+      wireframeBit = ((material is Wireframe) && (material as Wireframe).wireframe) ? 1 : 0,
+      geometryGroupHash = ( geometryGroup.id * 0xffffff ) + ( program.id * 2 ) + wireframeBit;
 
-				if ( updateBuffers ) _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglLineBuffer );
-				_gl.drawElements( gl.LINES, geometryGroup.__webglLineCount, gl.UNSIGNED_SHORT, 0 );
+    if ( geometryGroupHash != _currentGeometryGroupHash ) {
 
-			// triangles
+      _currentGeometryGroupHash = geometryGroupHash;
+      updateBuffers = true;
 
-			} else {
+    }
 
-				if ( updateBuffers ) _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglFaceBuffer );
-				_gl.drawElements( gl.TRIANGLES, geometryGroup.__webglFaceCount, gl.UNSIGNED_SHORT, 0 );
+        if ( updateBuffers ) {
 
-			}
+      disableAttributes();
 
-			info.render.calls ++;
-			info.render.vertices += geometryGroup.__webglFaceCount;
-			info.render.faces += geometryGroup.__webglFaceCount ~/ 3;
+    }
+    // vertices
 
-		// render lines
+    if ( ((material is! Morphing) || ((material is Morphing) && !(material as Morphing).morphTargets)) && attributes["position"] >= 0 ) {
 
-		} else if ( object is Line ) {
+      if ( updateBuffers ) {
 
-			primitives = ( object.type == LineStrip ) ? gl.LINE_STRIP : gl.LINES;
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
+        enableAttribute( attributes["position"] );
+        _gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
 
-			setLineWidth( (material is LineBasicMaterial)? material.linewidth : 0);
+      }
 
-			_gl.drawArrays( primitives, 0, geometryGroup.__webglLineCount );
+    } else {
 
-			info.render.calls ++;
+      if ( (object is Mesh) && object.morphTargetBase != 0 ) {
 
-		// render particles
+        setupMorphTargets( material, geometryGroup, object );
 
-		} else if ( object is ParticleSystem ) {
+      }
 
-			_gl.drawArrays( gl.POINTS, 0, geometryGroup.__webglParticleCount );
+    }
 
-			info.render.calls ++;
-			info.render.points += geometryGroup.__webglParticleCount;
 
-		// render ribbon
+    if ( updateBuffers ) {
 
-		} else if ( object is Ribbon ) {
+      // custom attributes
 
-			_gl.drawArrays( gl.TRIANGLE_STRIP, 0, geometryGroup.__webglVertexCount );
+      // Use the per-geometryGroup custom attribute arrays which are setup in initMeshBuffers
 
-			info.render.calls ++;
+      if ( geometryGroup.__webglCustomAttributesList != null) {
 
-		}
+        il = geometryGroup.__webglCustomAttributesList.length;
+        for ( i = 0; i < il; i ++ ) {
 
-	}
+          attribute = geometryGroup.__webglCustomAttributesList[ i ];
 
-	enableAttribute( attribute ) {
+          if( attributes[ attribute.buffer.belongsToAttribute ] >= 0 ) {
 
-	  var k = attribute.toString();
+            attribute.buffer.bind(gl.ARRAY_BUFFER);
+            enableAttribute( attributes[ attribute.buffer.belongsToAttribute ] );
+            _gl.vertexAttribPointer( attributes[ attribute.buffer.belongsToAttribute ], attribute.size, gl.FLOAT, false, 0, 0 );
 
-		if ( _enabledAttributes[ k ] == null ||  !_enabledAttributes[ k ] ) {
+          }
 
-			_gl.enableVertexAttribArray( attribute );
-			_enabledAttributes[ k ] = true;
+        }
 
-		}
+      }
 
-	}
 
-	disableAttributes() {
+      // colors
 
-		_enabledAttributes.forEach((attribute, enabled) {
+      if ( attributes["color"] >= 0 ) {
 
-			if ( enabled ) {
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglColorBuffer );
+        enableAttribute( attributes["color"] );
+        _gl.vertexAttribPointer( attributes["color"], 3, gl.FLOAT, false, 0, 0 );
 
-				_gl.disableVertexAttribArray( int.parse(attribute) );
-				_enabledAttributes[ attribute ] = false;
+      }
 
-			}
+      // normals
 
-		});
+      if ( attributes["normal"] >= 0 ) {
 
-	}
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglNormalBuffer );
+        enableAttribute( attributes["normal"] );
+        _gl.vertexAttribPointer( attributes["normal"], 3, gl.FLOAT, false, 0, 0 );
 
-	setupMorphTargets ( Material material, WebGLGeometry geometryGroup, Mesh object ) {
+      }
 
-		// set base
+      // tangents
 
-		var attributes = material._program.attributes;
+      if ( attributes["tangent"] >= 0 ) {
 
-		if ( object.morphTargetBase != -1 && attributes["position"] >= 0) {
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglTangentBuffer );
+        enableAttribute( attributes["tangent"] );
+        _gl.vertexAttribPointer( attributes["tangent"], 4, gl.FLOAT, false, 0, 0 );
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ object.morphTargetBase ] );
-			enableAttribute( attributes["position"] );
-			_gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
+      }
 
-		} else if ( attributes["position"] >= 0 ) {
+      // uvs
 
-			_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
-			enableAttribute( attributes["position"] );
-			_gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
+      if ( attributes["uv"] >= 0 ) {
 
-		}
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUVBuffer );
+        enableAttribute( attributes["uv"] );
+        _gl.vertexAttribPointer( attributes["uv"], 2, gl.FLOAT, false, 0, 0 );
 
-		if ( (material is Morphing) && object.morphTargetForcedOrder.length > 0) {
 
-			// set forced order
+      }
 
-			var m = 0;
-			var order = object.morphTargetForcedOrder;
-			var influences = object.morphTargetInfluences;
+      if ( attributes["uv2"] >= 0 ) {
 
-			while ( m < (material as Morphing).numSupportedMorphTargets && m < order.length ) {
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglUV2Buffer );
+        enableAttribute( attributes["uv2"] );
+        _gl.vertexAttribPointer( attributes["uv2"], 2, gl.FLOAT, false, 0, 0 );
 
-				if ( attributes[ "morphTarget" + m ] >= 0 ) {
-					_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ order[ m ] ] );
-					enableAttribute( attributes[ "morphTarget" + m ] );
-					_gl.vertexAttribPointer( attributes[ "morphTarget$m"], 3, gl.FLOAT, false, 0, 0 );
-				}
+      }
 
-				if ( attributes[ "morphNormal" + m ] >= 0 && (material as Morphing).morphNormals ) {
+      if ( (material is Skinning) && (material as Skinning).skinning &&
+         attributes["skinIndex"] >= 0 && attributes["skinWeight"] >= 0 ) {
 
-					_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ order[ m ] ] );
-					enableAttribute( attributes[ "morphNormal" + m ] );
-					_gl.vertexAttribPointer( attributes[ "morphNormal$m" ], 3, gl.FLOAT, false, 0, 0 );
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinIndicesBuffer );
+        enableAttribute( attributes["skinIndex"] );
+        _gl.vertexAttribPointer( attributes["skinIndex"], 4, gl.FLOAT, false, 0, 0 );
 
-				}
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglSkinWeightsBuffer );
+        enableAttribute( attributes["skinWeight"] );
+        _gl.vertexAttribPointer( attributes["skinWeight"], 4, gl.FLOAT, false, 0, 0 );
 
-				object.__webglMorphTargetInfluences[ m ] = influences[ order[ m ] ].toDouble();
+      }
 
-				m ++;
-			}
+      // line distances
 
-		} else {
+      if ( attributes["lineDistance"] >= 0 ) {
 
-			// find the most influencing
+        _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglLineDistanceBuffer );
+        enableAttribute( attributes["lineDistance"] );
+        _gl.vertexAttribPointer( attributes["lineDistance"], 1, gl.FLOAT, false, 0, 0 );
 
-			var influence;
-			List<List> activeInfluenceIndices = [];
-			var influences = (object is Mesh) ? object.morphTargetInfluences : 0;
-			var i, il = influences.length;
+      }
+    }
 
-			for ( i = 0; i < il; i ++ ) {
+    // render mesh
 
-				influence = influences[ i ];
+    if ( object is Mesh ) {
 
-				if ( influence > 0 ) {
+      // wireframe
 
-					activeInfluenceIndices.add( [ i, influence ] );
+      if ( material is Wireframe && (material as Wireframe).wireframe ) {
 
-				}
+        setLineWidth( (material as Wireframe).wireframeLinewidth );
 
-			}
+        if ( updateBuffers ) _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglLineBuffer );
+        _gl.drawElements( gl.LINES, geometryGroup.__webglLineCount, gl.UNSIGNED_SHORT, 0 );
 
-			if ( activeInfluenceIndices.length > (material as Morphing).numSupportedMorphTargets ) {
+      // triangles
 
-				activeInfluenceIndices.sort( numericalSort );
-				activeInfluenceIndices.length = (material as Morphing).numSupportedMorphTargets;
+      } else {
 
-			} else if ( activeInfluenceIndices.length > (material as Morphing).numSupportedMorphNormals ) {
+        if ( updateBuffers ) _gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, geometryGroup.__webglFaceBuffer );
+        _gl.drawElements( gl.TRIANGLES, geometryGroup.__webglFaceCount, gl.UNSIGNED_SHORT, 0 );
 
-				activeInfluenceIndices.sort( numericalSort );
+      }
 
-			} else if ( activeInfluenceIndices.length == 0 ) {
+      info.render.calls ++;
+      info.render.vertices += geometryGroup.__webglFaceCount;
+      info.render.faces += geometryGroup.__webglFaceCount ~/ 3;
 
-				activeInfluenceIndices.add( [ 0, 0 ] );
+    // render lines
 
-			};
+    } else if ( object is Line ) {
 
-			var influenceIndex, m = 0;
+      primitives = ( object.type == LineStrip ) ? gl.LINE_STRIP : gl.LINES;
 
-			if (material is Morphing) {
-  			while ( m <  (material as Morphing).numSupportedMorphTargets ) {
+      setLineWidth( (material is LineBasicMaterial)? material.linewidth : 0);
 
-  				if ( m < activeInfluenceIndices.length && activeInfluenceIndices[ m ] != null && !activeInfluenceIndices[ m ].isEmpty) {
+      _gl.drawArrays( primitives, 0, geometryGroup.__webglLineCount );
 
-  					influenceIndex = activeInfluenceIndices[ m ][ 0 ];
+      info.render.calls ++;
 
-  					_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ influenceIndex ] );
-  					enableAttribute( attributes[ "morphTarget$m" ] );
-  					_gl.vertexAttribPointer( attributes[ "morphTarget$m" ], 3, gl.FLOAT, false, 0, 0 );
+    // render particles
 
-  					if ( (material as Morphing).morphNormals ) {
+    } else if ( object is ParticleSystem ) {
 
-  						_gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ influenceIndex ] );
-  						enableAttribute( attributes[ "morphNormal$m" ] );
-  						_gl.vertexAttribPointer( attributes[ "morphNormal$m" ], 3, gl.FLOAT, false, 0, 0 );
+      _gl.drawArrays( gl.POINTS, 0, geometryGroup.__webglParticleCount );
 
-  					}
+      info.render.calls ++;
+      info.render.points += geometryGroup.__webglParticleCount;
 
-  					object.__webglMorphTargetInfluences[ m ] = influences[ influenceIndex ].toDouble();
+    // render ribbon
 
-  				} else {
+    } else if ( object is Ribbon ) {
 
-  					object.__webglMorphTargetInfluences[ m ] = 0.0;
+      _gl.drawArrays( gl.TRIANGLE_STRIP, 0, geometryGroup.__webglVertexCount );
 
-  				}
+      info.render.calls ++;
 
-  				m ++;
+    }
 
-  			}
-			}
+  }
 
-		}
+  enableAttribute( attribute ) {
 
-		// load updated influences uniform
+    var k = attribute.toString();
 
-		if ( material._program.uniforms["morphTargetInfluences"] != null ) {
+    if ( _enabledAttributes[ k ] == null ||  !_enabledAttributes[ k ] ) {
 
-			_gl.uniform1fv( material._program.uniforms["morphTargetInfluences"], object.__webglMorphTargetInfluences );
+      _gl.enableVertexAttribArray( attribute );
+      _enabledAttributes[ k ] = true;
 
-		}
+    }
 
-	}
+  }
 
-	// Sorting
+  disableAttributes() {
 
-	painterSort ( a, b ) => (a.z.isNaN || b.z.isNaN || a.z.isInfinite || b.z.isInfinite) ? 0 : (b.z - a.z).toInt();
+    _enabledAttributes.forEach((attribute, enabled) {
 
-	numericalSort ( a, b ) => (b[ 0 ] - a[ 0 ]).toInt();
+      if ( enabled ) {
 
+        _gl.disableVertexAttribArray( int.parse(attribute) );
+        _enabledAttributes[ attribute ] = false;
 
-	// Rendering
+      }
 
-	@override
-	render ( Scene scene, Camera camera) => _render( scene, camera);
+    });
 
-	_render ( Scene scene, Camera camera, {renderTarget: null, forceClear: false} ) {
+  }
 
-		var i, il;
+  setupMorphTargets ( Material material, WebGLGeometry geometryGroup, Mesh object ) {
 
-		WebGLObject webglObject;
-		Object3D object;
-		var renderList;
+    // set base
 
-		List lights = scene.lights;
-		Fog fog = scene.fog;
+    var attributes = material._program.attributes;
 
-		// reset caching for this frame
+    if ( object.morphTargetBase != -1 && attributes["position"] >= 0) {
 
-		_currentMaterialId = -1;
-		_lightsNeedUpdate = true;
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ object.morphTargetBase ] );
+      enableAttribute( attributes["position"] );
+      _gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
 
-		// update scene graph
+    } else if ( attributes["position"] >= 0 ) {
 
-		if ( autoUpdateScene ) scene.updateMatrixWorld();
+      _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglVertexBuffer );
+      enableAttribute( attributes["position"] );
+      _gl.vertexAttribPointer( attributes["position"], 3, gl.FLOAT, false, 0, 0 );
 
-		// update camera matrices and frustum
+    }
 
-		if ( camera.parent == null ) camera.updateMatrixWorld();
+    if ( (material is Morphing) && object.morphTargetForcedOrder.length > 0) {
 
-		camera.matrixWorldInverse.copyInverse(camera.matrixWorld);
+      // set forced order
 
-		_projScreenMatrix.setFrom(camera.projectionMatrix).multiply(camera.matrixWorldInverse);
-		_frustum.setFromMatrix( _projScreenMatrix );
+      var m = 0;
+      var order = object.morphTargetForcedOrder;
+      var influences = object.morphTargetInfluences;
 
-		// update WebGL objects
+      while ( m < (material as Morphing).numSupportedMorphTargets && m < order.length ) {
 
-		if ( autoUpdateObjects ) initWebGLObjects( scene );
+        if ( attributes[ "morphTarget" + m ] >= 0 ) {
+          _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ order[ m ] ] );
+          enableAttribute( attributes[ "morphTarget" + m ] );
+          _gl.vertexAttribPointer( attributes[ "morphTarget$m"], 3, gl.FLOAT, false, 0, 0 );
+        }
 
-		// custom render plugins (pre pass)
+        if ( attributes[ "morphNormal" + m ] >= 0 && (material as Morphing).morphNormals ) {
 
-		renderPlugins( renderPluginsPre, scene, camera );
+          _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ order[ m ] ] );
+          enableAttribute( attributes[ "morphNormal" + m ] );
+          _gl.vertexAttribPointer( attributes[ "morphNormal$m" ], 3, gl.FLOAT, false, 0, 0 );
 
-		//
+        }
 
-		info.render.calls = 0;
-		info.render.vertices = 0;
-		info.render.faces = 0;
-		info.render.points = 0;
+        object.__webglMorphTargetInfluences[ m ] = influences[ order[ m ] ].toDouble();
 
-		setRenderTarget( renderTarget );
+        m ++;
+      }
 
-		if ( autoClear || forceClear ) {
+    } else {
 
-			clear( autoClearColor, autoClearDepth, autoClearStencil );
+      // find the most influencing
 
-		}
+      var influence;
+      List<List> activeInfluenceIndices = [];
+      var influences = (object is Mesh) ? object.morphTargetInfluences : 0;
+      var i, il = influences.length;
 
-		// set matrices for regular objects (frustum culled)
+      for ( i = 0; i < il; i ++ ) {
 
-		renderList = scene.__webglObjects;
+        influence = influences[ i ];
 
-		il = renderList.length;
+        if ( influence > 0 ) {
 
-		for ( i = 0; i < il; i ++ ) {
+          activeInfluenceIndices.add( [ i, influence ] );
 
-			webglObject = renderList[ i ];
-			object = webglObject.object;
+        }
 
-			webglObject.render = false;
+      }
 
-			if ( object.visible ) {
+      if ( activeInfluenceIndices.length > (material as Morphing).numSupportedMorphTargets ) {
 
-				if ( ! ( object is Mesh || object is ParticleSystem ) || ! ( object.frustumCulled ) || _frustum.contains( object ) ) {
+        activeInfluenceIndices.sort( numericalSort );
+        activeInfluenceIndices.length = (material as Morphing).numSupportedMorphTargets;
 
+      } else if ( activeInfluenceIndices.length > (material as Morphing).numSupportedMorphNormals ) {
 
-					setupMatrices( object, camera );
+        activeInfluenceIndices.sort( numericalSort );
 
-					unrollBufferMaterial( webglObject );
+      } else if ( activeInfluenceIndices.length == 0 ) {
 
-					webglObject.render = true;
+        activeInfluenceIndices.add( [ 0, 0 ] );
 
-					if ( sortObjects ) {
+      };
 
-						if ( object.renderDepth != null ) {
+      var influenceIndex, m = 0;
 
-							webglObject.z = object.renderDepth;
+      if (material is Morphing) {
+        while ( m <  (material as Morphing).numSupportedMorphTargets ) {
 
-						} else {
-							_vector3 = object.matrixWorld.getTranslation();
-							_vector3.applyProjection(_projScreenMatrix);
+          if ( m < activeInfluenceIndices.length && activeInfluenceIndices[ m ] != null && !activeInfluenceIndices[ m ].isEmpty) {
 
-							webglObject.z = _vector3.z;
+            influenceIndex = activeInfluenceIndices[ m ][ 0 ];
 
-						}
+            _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphTargetsBuffers[ influenceIndex ] );
+            enableAttribute( attributes[ "morphTarget$m" ] );
+            _gl.vertexAttribPointer( attributes[ "morphTarget$m" ], 3, gl.FLOAT, false, 0, 0 );
 
-					}
+            if ( (material as Morphing).morphNormals ) {
 
-				}
+              _gl.bindBuffer( gl.ARRAY_BUFFER, geometryGroup.__webglMorphNormalsBuffers[ influenceIndex ] );
+              enableAttribute( attributes[ "morphNormal$m" ] );
+              _gl.vertexAttribPointer( attributes[ "morphNormal$m" ], 3, gl.FLOAT, false, 0, 0 );
 
-			}
+            }
 
-		}
+            object.__webglMorphTargetInfluences[ m ] = influences[ influenceIndex ].toDouble();
 
-		if ( sortObjects ) {
+          } else {
 
-			renderList.sort( painterSort );
+            object.__webglMorphTargetInfluences[ m ] = 0.0;
 
-		}
+          }
 
-		// set matrices for immediate objects
+          m ++;
 
-		renderList = scene.__webglObjectsImmediate;
+        }
+      }
 
-		il = renderList.length;
+    }
 
-		for ( i = 0; i < il; i ++ ) {
+    // load updated influences uniform
 
-			webglObject = renderList[ i ];
-			object = webglObject.object;
+    if ( material._program.uniforms["morphTargetInfluences"] != null ) {
 
-			if ( object.visible ) {
+      _gl.uniform1fv( material._program.uniforms["morphTargetInfluences"], object.__webglMorphTargetInfluences );
 
-				setupMatrices( object, camera );
+    }
 
-				unrollImmediateBufferMaterial( webglObject );
+  }
 
-			}
+  // Sorting
 
-		}
+  painterSort ( a, b ) => (a.z.isNaN || b.z.isNaN || a.z.isInfinite || b.z.isInfinite) ? 0 : (b.z - a.z).toInt();
 
-		if ( scene.overrideMaterial != null ) {
+  numericalSort ( a, b ) => (b[ 0 ] - a[ 0 ]).toInt();
 
-			var material = scene.overrideMaterial;
 
-			setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
-			setDepthTest( material.depthTest );
-			setDepthWrite( material.depthWrite );
-			setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+  // Rendering
 
-			renderObjects( scene.__webglObjects, false, "", camera, lights, fog, true, material );
-			renderObjectsImmediate( scene.__webglObjectsImmediate, "", camera, lights, fog, false, material );
+  @override
+  render ( Scene scene, Camera camera) => _render( scene, camera);
 
-		} else {
+  _render ( Scene scene, Camera camera, {renderTarget: null, forceClear: false} ) {
 
-			var material = null;
+    var i, il;
 
-			// opaque pass (front-to-back order)
+    WebGLObject webglObject;
+    Object3D object;
+    var renderList;
 
-			setBlending( NoBlending );
+    List lights = scene.lights;
+    Fog fog = scene.fog;
 
-			renderObjects( scene.__webglObjects, true, "opaque", camera, lights, fog, false, material );
-			renderObjectsImmediate( scene.__webglObjectsImmediate, "opaque", camera, lights, fog, false, material );
+    // reset caching for this frame
 
-			// transparent pass (back-to-front order)
+    _currentMaterialId = -1;
+    _lightsNeedUpdate = true;
 
-			renderObjects( scene.__webglObjects, false, "transparent", camera, lights, fog, true, material );
-			renderObjectsImmediate( scene.__webglObjectsImmediate, "transparent", camera, lights, fog, true, material );
+    // update scene graph
 
-		}
+    if ( autoUpdateScene ) scene.updateMatrixWorld();
 
-		// custom render plugins (post pass)
+    // update camera matrices and frustum
 
-		renderPlugins( renderPluginsPost, scene, camera );
+    if ( camera.parent == null ) camera.updateMatrixWorld();
 
+    camera.matrixWorldInverse.copyInverse(camera.matrixWorld);
 
-		// Generate mipmap if we're using any kind of mipmap filtering
+    _projScreenMatrix.setFrom(camera.projectionMatrix).multiply(camera.matrixWorldInverse);
+    _frustum.setFromMatrix( _projScreenMatrix );
 
-		if ( (renderTarget != null ) && renderTarget.generateMipmaps && renderTarget.minFilter != NearestFilter && renderTarget.minFilter != LinearFilter ) {
+    // update WebGL objects
 
-			updateRenderTargetMipmap( renderTarget );
+    if ( autoUpdateObjects ) initWebGLObjects( scene );
 
-		}
+    // custom render plugins (pre pass)
 
-		// Ensure depth buffer writing is enabled so it can be cleared on next render
+    renderPlugins( renderPluginsPre, scene, camera );
 
-		setDepthTest( true );
-		setDepthWrite( true );
+    //
 
-		// _gl.finish();
+    info.render.calls = 0;
+    info.render.vertices = 0;
+    info.render.faces = 0;
+    info.render.points = 0;
 
-	}
+    setRenderTarget( renderTarget );
 
-	renderPlugins( List plugins, Scene scene, Camera camera ) {
+    if ( autoClear || forceClear ) {
 
-		plugins.forEach((plugin) {
-			// reset state for plugin (to start from clean slate)
+      clear( autoClearColor, autoClearDepth, autoClearStencil );
 
-			_currentProgram = null;
-			_currentCamera = null;
+    }
 
-			_oldBlending = -1;
-			_oldDepthTest = -1;
-			_oldDepthWrite = -1;
-			_oldDoubleSided = -1;
-			_oldFlipSided = -1;
-			_currentGeometryGroupHash = -1;
-			_currentMaterialId = -1;
+    // set matrices for regular objects (frustum culled)
 
-			_lightsNeedUpdate = true;
+    renderList = scene.__webglObjects;
 
-			plugin.render( scene, camera, _currentWidth, _currentHeight );
+    il = renderList.length;
 
-			// reset state after plugin (anything could have changed)
+    for ( i = 0; i < il; i ++ ) {
 
-			_currentProgram = null;
-			_currentCamera = null;
+      webglObject = renderList[ i ];
+      object = webglObject.object;
 
-			_oldBlending = -1;
-			_oldDepthTest = -1;
-			_oldDepthWrite = -1;
-			_oldDoubleSided = -1;
-			_oldFlipSided = -1;
-			_currentGeometryGroupHash = -1;
-			_currentMaterialId = -1;
+      webglObject.render = false;
 
-			_lightsNeedUpdate = true;
+      if ( object.visible ) {
 
-		});
+        if ( ! ( object is Mesh || object is ParticleSystem ) || ! ( object.frustumCulled ) || _frustum.contains( object ) ) {
 
-	}
 
-	renderObjects (  List<WebGLObject> renderList,
-	                 bool reverse, String materialType,
-	                 Camera camera,
-	                 List<Light> lights,
-	                 fog,
-	                 useBlending,
-	                 [overrideMaterial = null] ) {
+          setupMatrices( object, camera );
 
-		WebGLObject webglObject;
-		var object, buffer, material;
-		num start, end, delta;
+          unrollBufferMaterial( webglObject );
 
-		if ( reverse ) {
+          webglObject.render = true;
 
-			start = renderList.length - 1;
-			end = -1;
-			delta = -1;
+          if ( sortObjects ) {
 
-		} else {
+            if ( object.renderDepth != null ) {
 
-			start = 0;
-			end = renderList.length;
-			delta = 1;
-		}
+              webglObject.z = object.renderDepth;
 
-		for ( var i = start; i != end; i += delta ) {
+            } else {
+              _vector3 = object.matrixWorld.getTranslation();
+              _vector3.applyProjection(_projScreenMatrix);
 
-			webglObject = renderList[ i ];
+              webglObject.z = _vector3.z;
 
-			if ( webglObject.render ) {
+            }
 
-				object = webglObject.object;
-				buffer = webglObject.buffer;
+          }
 
-				if ( overrideMaterial != null ) {
+        }
 
-					material = overrideMaterial;
+      }
 
-				} else {
+    }
 
-					material = (materialType == "opaque")? webglObject.opaque : webglObject.transparent;
+    if ( sortObjects ) {
 
-					if ( material == null ) continue;
+      renderList.sort( painterSort );
 
-					if ( useBlending ) setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
+    }
 
-					setDepthTest( material.depthTest );
-					setDepthWrite( material.depthWrite );
-					setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+    // set matrices for immediate objects
 
-				}
+    renderList = scene.__webglObjectsImmediate;
 
-				setMaterialFaces( material );
+    il = renderList.length;
 
-				if ( buffer is BufferGeometry ) {
+    for ( i = 0; i < il; i ++ ) {
 
-					renderBufferDirect( camera, lights, fog, material, buffer, object );
+      webglObject = renderList[ i ];
+      object = webglObject.object;
 
-				} else {
+      if ( object.visible ) {
 
-					renderBuffer( camera, lights, fog, material, buffer, object );
+        setupMatrices( object, camera );
 
-				}
+        unrollImmediateBufferMaterial( webglObject );
 
-			}
+      }
 
-		}
+    }
 
-	}
+    if ( scene.overrideMaterial != null ) {
 
-	renderObjectsImmediate ( renderList, materialType, camera, lights, fog, useBlending, [overrideMaterial] ) {
+      var material = scene.overrideMaterial;
 
-		var webglObject, object, material, program, il;
+      setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
+      setDepthTest( material.depthTest );
+      setDepthWrite( material.depthWrite );
+      setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
-		il = renderList.length;
+      renderObjects( scene.__webglObjects, false, "", camera, lights, fog, true, material );
+      renderObjectsImmediate( scene.__webglObjectsImmediate, "", camera, lights, fog, false, material );
 
-		for ( var i = 0; i < il; i ++ ) {
+    } else {
 
-			webglObject = renderList[ i ];
-			object = webglObject.object;
+      var material = null;
 
-			if ( object.visible ) {
+      // opaque pass (front-to-back order)
 
-				if ( overrideMaterial ) {
+      setBlending( NoBlending );
 
-					material = overrideMaterial;
+      renderObjects( scene.__webglObjects, true, "opaque", camera, lights, fog, false, material );
+      renderObjectsImmediate( scene.__webglObjectsImmediate, "opaque", camera, lights, fog, false, material );
 
-				} else {
+      // transparent pass (back-to-front order)
 
-					material = webglObject[ materialType ];
+      renderObjects( scene.__webglObjects, false, "transparent", camera, lights, fog, true, material );
+      renderObjectsImmediate( scene.__webglObjectsImmediate, "transparent", camera, lights, fog, true, material );
 
-					if ( ! material ) continue;
+    }
 
-					if ( useBlending ) setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
+    // custom render plugins (post pass)
 
-					setDepthTest( material.depthTest );
-					setDepthWrite( material.depthWrite );
-					setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
+    renderPlugins( renderPluginsPost, scene, camera );
 
-				}
 
-				renderImmediateObject( camera, lights, fog, material, object );
+    // Generate mipmap if we're using any kind of mipmap filtering
 
-			}
+    if ( (renderTarget != null ) && renderTarget.generateMipmaps && renderTarget.minFilter != NearestFilter && renderTarget.minFilter != LinearFilter ) {
 
-		}
+      updateRenderTargetMipmap( renderTarget );
 
-	}
+    }
 
-	renderImmediateObject( Camera camera, List<Light> lights, Fog fog, Material material, object ) {
+    // Ensure depth buffer writing is enabled so it can be cleared on next render
 
-		var program = setProgram( camera, lights, fog, material, object );
+    setDepthTest( true );
+    setDepthWrite( true );
 
-		_currentGeometryGroupHash = -1;
+    // _gl.finish();
 
-		setMaterialFaces( material );
+  }
 
-		if ( object.immediateRenderCallback ) {
+  renderPlugins( List plugins, Scene scene, Camera camera ) {
 
-			object.immediateRenderCallback( program, _gl, _frustum );
+    plugins.forEach((plugin) {
+      // reset state for plugin (to start from clean slate)
 
-		} else {
+      _currentProgram = null;
+      _currentCamera = null;
 
-			object.render( ( object ) { renderBufferImmediate( object, program, material ); } );
+      _oldBlending = -1;
+      _oldDepthTest = -1;
+      _oldDepthWrite = -1;
+      _oldDoubleSided = -1;
+      _oldFlipSided = -1;
+      _currentGeometryGroupHash = -1;
+      _currentMaterialId = -1;
 
-		}
+      _lightsNeedUpdate = true;
 
-	}
+      plugin.render( scene, camera, _currentWidth, _currentHeight );
 
-	unrollImmediateBufferMaterial ( WebGLObject webglobject ) {
+      // reset state after plugin (anything could have changed)
 
-		var object = webglobject.object,
-		    material = object.material;
+      _currentProgram = null;
+      _currentCamera = null;
 
-		if ( material.transparent ) {
+      _oldBlending = -1;
+      _oldDepthTest = -1;
+      _oldDepthWrite = -1;
+      _oldDoubleSided = -1;
+      _oldFlipSided = -1;
+      _currentGeometryGroupHash = -1;
+      _currentMaterialId = -1;
 
-		  webglobject.transparent = material;
-		  webglobject.opaque = null;
+      _lightsNeedUpdate = true;
 
-		} else {
+    });
 
-		  webglobject.opaque = material;
-		  webglobject.transparent = null;
+  }
 
-		}
+  renderObjects (  List<WebGLObject> renderList,
+                   bool reverse, String materialType,
+                   Camera camera,
+                   List<Light> lights,
+                   fog,
+                   useBlending,
+                   [overrideMaterial = null] ) {
 
-	}
+    WebGLObject webglObject;
+    var object, buffer, material;
+    num start, end, delta;
 
-	unrollBufferMaterial ( WebGLObject webglobject ) {
+    if ( reverse ) {
 
-	  Object3D object = webglobject.object;
-	  WebGLGeometry buffer = webglobject.buffer;
-		Material meshMaterial = object.material;
-		int materialIndex;
-		Material material;
+      start = renderList.length - 1;
+      end = -1;
+      delta = -1;
 
+    } else {
 
-		if ( meshMaterial is MeshFaceMaterial ) {
+      start = 0;
+      end = renderList.length;
+      delta = 1;
+    }
 
-			materialIndex = buffer.materialIndex;
+    for ( var i = start; i != end; i += delta ) {
 
-			if ( materialIndex >= 0 ) {
+      webglObject = renderList[ i ];
 
-				material = meshMaterial.materials[ materialIndex ];
+      if ( webglObject.render ) {
 
-				if ( material.transparent ) {
+        object = webglObject.object;
+        buffer = webglObject.buffer;
 
-				  webglobject.transparent = material;
-				  webglobject.opaque = null;
+        if ( overrideMaterial != null ) {
 
-				} else {
+          material = overrideMaterial;
 
-				  webglobject.opaque = material;
-				  webglobject.transparent = null;
+        } else {
 
-				}
+          material = (materialType == "opaque")? webglObject.opaque : webglObject.transparent;
 
-			}
+          if ( material == null ) continue;
 
-		} else {
+          if ( useBlending ) setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
 
-		  material = meshMaterial;
+          setDepthTest( material.depthTest );
+          setDepthWrite( material.depthWrite );
+          setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
-			if ( material != null ) {
+        }
 
-				if ( material.transparent != null ) {
+        setMaterialFaces( material );
 
-				  webglobject.transparent = material;
-				  webglobject.opaque = null;
+        if ( buffer is BufferGeometry ) {
 
-				} else {
+          renderBufferDirect( camera, lights, fog, material, buffer, object );
 
-				  webglobject.opaque = material;
-				  webglobject.transparent = null;
+        } else {
 
-				}
+          renderBuffer( camera, lights, fog, material, buffer, object );
 
-			}
+        }
 
-		}
+      }
 
-	}
+    }
 
-	// Geometry splitting
+  }
 
-	sortFacesByMaterial ( Geometry geometry, Material material ) {
+  renderObjectsImmediate ( renderList, materialType, camera, lights, fog, useBlending, [overrideMaterial] ) {
 
-		var f, fl, face, materialIndex, vertices,
-			materialHash, groupHash;
+    var webglObject, object, material, program, il;
 
-		Map<String, Map> hash_map = {};
+    il = renderList.length;
 
-		var numMorphTargets = geometry.morphTargets.length;
-		var numMorphNormals = geometry.morphNormals.length;
+    for ( var i = 0; i < il; i ++ ) {
 
-		var usesFaceMaterial = material is MeshFaceMaterial;
+      webglObject = renderList[ i ];
+      object = webglObject.object;
 
-		geometry.geometryGroups = {};
+      if ( object.visible ) {
 
-		fl = geometry.faces.length;
-		for ( f = 0; f < fl; f ++ ) {
+        if ( overrideMaterial ) {
 
-			face = geometry.faces[ f ];
-			materialIndex = usesFaceMaterial ? face.materialIndex.toString() : "0";
+          material = overrideMaterial;
 
-			if ( hash_map[ materialIndex ] == null ) {
+        } else {
 
-				hash_map[ materialIndex ] = { 'hash': materialIndex, 'counter': 0 };
+          material = webglObject[ materialType ];
 
-			}
+          if ( ! material ) continue;
 
-			groupHash = "${hash_map[ materialIndex ]["hash"]}_${hash_map[ materialIndex ]["counter"]}";
+          if ( useBlending ) setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst );
 
-			if ( geometry.geometryGroups[ groupHash ] == null ) {
+          setDepthTest( material.depthTest );
+          setDepthWrite( material.depthWrite );
+          setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 
-				geometry.geometryGroups[ groupHash ] = new WebGLGeometry()
-				  ..faces3 = []
-				  ..faces4 = []
-				  ..materialIndex = int.parse(materialIndex)
-				  ..verticesCount = 0
-				  ..numMorphTargets = numMorphTargets
-				  ..numMorphNormals = numMorphNormals;
-			}
+        }
 
-			vertices = face.size;
+        renderImmediateObject( camera, lights, fog, material, object );
 
-			if ( geometry.geometryGroups[ groupHash ].verticesCount + vertices > 65535 ) {
+      }
 
-				hash_map[ materialIndex ]["counter"] += 1;
-				groupHash = "${hash_map[ materialIndex ]["hash"]}_${hash_map[ materialIndex ]["counter"]}";
+    }
 
-				if ( geometry.geometryGroups[ groupHash ] == null ) {
+  }
 
-					geometry.geometryGroups[ groupHash ] = new WebGLGeometry()
-					  ..faces3 = []
+  renderImmediateObject( Camera camera, List<Light> lights, Fog fog, Material material, object ) {
+
+    var program = setProgram( camera, lights, fog, material, object );
+
+    _currentGeometryGroupHash = -1;
+
+    setMaterialFaces( material );
+
+    if ( object.immediateRenderCallback ) {
+
+      object.immediateRenderCallback( program, _gl, _frustum );
+
+    } else {
+
+      object.render( ( object ) { renderBufferImmediate( object, program, material ); } );
+
+    }
+
+  }
+
+  unrollImmediateBufferMaterial ( WebGLObject webglobject ) {
+
+    var object = webglobject.object,
+        material = object.material;
+
+    if ( material.transparent ) {
+
+      webglobject.transparent = material;
+      webglobject.opaque = null;
+
+    } else {
+
+      webglobject.opaque = material;
+      webglobject.transparent = null;
+
+    }
+
+  }
+
+  unrollBufferMaterial ( WebGLObject webglobject ) {
+
+    Object3D object = webglobject.object;
+    WebGLGeometry buffer = webglobject.buffer;
+    Material meshMaterial = object.material;
+    int materialIndex;
+    Material material;
+
+
+    if ( meshMaterial is MeshFaceMaterial ) {
+
+      materialIndex = buffer.materialIndex;
+
+      if ( materialIndex >= 0 ) {
+
+        material = meshMaterial.materials[ materialIndex ];
+
+        if ( material.transparent ) {
+
+          webglobject.transparent = material;
+          webglobject.opaque = null;
+
+        } else {
+
+          webglobject.opaque = material;
+          webglobject.transparent = null;
+
+        }
+
+      }
+
+    } else {
+
+      material = meshMaterial;
+
+      if ( material != null ) {
+
+        if ( material.transparent != null ) {
+
+          webglobject.transparent = material;
+          webglobject.opaque = null;
+
+        } else {
+
+          webglobject.opaque = material;
+          webglobject.transparent = null;
+
+        }
+
+      }
+
+    }
+
+  }
+
+  // Geometry splitting
+
+  sortFacesByMaterial ( Geometry geometry, Material material ) {
+
+    var f, fl, face, materialIndex, vertices,
+      materialHash, groupHash;
+
+    Map<String, Map> hash_map = {};
+
+    var numMorphTargets = geometry.morphTargets.length;
+    var numMorphNormals = geometry.morphNormals.length;
+
+    var usesFaceMaterial = material is MeshFaceMaterial;
+
+    geometry.geometryGroups = {};
+
+    fl = geometry.faces.length;
+    for ( f = 0; f < fl; f ++ ) {
+
+      face = geometry.faces[ f ];
+      materialIndex = usesFaceMaterial ? face.materialIndex.toString() : "0";
+
+      if ( hash_map[ materialIndex ] == null ) {
+
+        hash_map[ materialIndex ] = { 'hash': materialIndex, 'counter': 0 };
+
+      }
+
+      groupHash = "${hash_map[ materialIndex ]["hash"]}_${hash_map[ materialIndex ]["counter"]}";
+
+      if ( geometry.geometryGroups[ groupHash ] == null ) {
+
+        geometry.geometryGroups[ groupHash ] = new WebGLGeometry()
+          ..faces3 = []
+          ..faces4 = []
+          ..materialIndex = int.parse(materialIndex)
+          ..verticesCount = 0
+          ..numMorphTargets = numMorphTargets
+          ..numMorphNormals = numMorphNormals;
+      }
+
+      vertices = face.size;
+
+      if ( geometry.geometryGroups[ groupHash ].verticesCount + vertices > 65535 ) {
+
+        hash_map[ materialIndex ]["counter"] += 1;
+        groupHash = "${hash_map[ materialIndex ]["hash"]}_${hash_map[ materialIndex ]["counter"]}";
+
+        if ( geometry.geometryGroups[ groupHash ] == null ) {
+
+          geometry.geometryGroups[ groupHash ] = new WebGLGeometry()
+            ..faces3 = []
             ..faces4 = []
             ..materialIndex = int.parse(materialIndex)
             ..verticesCount = 0
             ..numMorphTargets = numMorphTargets
             ..numMorphNormals = numMorphNormals;
 
-				}
+        }
 
-			}
+      }
 
-			if ( face.size == 3 ) {
+      if ( face.size == 3 ) {
 
-				geometry.geometryGroups[ groupHash ].faces3.add( f );
+        geometry.geometryGroups[ groupHash ].faces3.add( f );
 
-			} else {
+      } else {
 
-				geometry.geometryGroups[ groupHash ].faces4.add( f );
+        geometry.geometryGroups[ groupHash ].faces4.add( f );
 
-			}
+      }
 
-			geometry.geometryGroups[ groupHash ].verticesCount += vertices;
+      geometry.geometryGroups[ groupHash ].verticesCount += vertices;
 
-		}
+    }
 
-		geometry.geometryGroupsList = [];
+    geometry.geometryGroupsList = [];
 
-		geometry.geometryGroups.forEach( (k,g) {
+    geometry.geometryGroups.forEach( (k,g) {
 
       g.id = _geometryGroupCounter ++;
 
@@ -4549,1066 +4549,1066 @@ class WebGLRenderer implements Renderer {
 
     });
 
-		return;
+    return;
 
-	}
+  }
 
-	// Objects refresh
+  // Objects refresh
 
-	initWebGLObjects( Scene scene ) {
+  initWebGLObjects( Scene scene ) {
 
-		if ( scene.__webglObjects == null ) {
+    if ( scene.__webglObjects == null ) {
 
-			scene.__webglObjects = [];
-			scene.__webglObjectsImmediate = [];
-			scene.__webglSprites = [];
-			scene.__webglFlares = [];
+      scene.__webglObjects = [];
+      scene.__webglObjectsImmediate = [];
+      scene.__webglSprites = [];
+      scene.__webglFlares = [];
 
-		}
+    }
 
-		while ( scene.__objectsAdded.length > 0 ) {
+    while ( scene.__objectsAdded.length > 0 ) {
 
-			addObject( scene.__objectsAdded[ 0 ], scene );
-			scene.__objectsAdded.removeAt( 0 );
+      addObject( scene.__objectsAdded[ 0 ], scene );
+      scene.__objectsAdded.removeAt( 0 );
 
-		}
+    }
 
-		while ( scene.__objectsRemoved.length > 0) {
+    while ( scene.__objectsRemoved.length > 0) {
 
-			removeObject( scene.__objectsRemoved[ 0 ], scene );
-			scene.__objectsRemoved.removeAt( 0 );
+      removeObject( scene.__objectsRemoved[ 0 ], scene );
+      scene.__objectsRemoved.removeAt( 0 );
 
-		}
+    }
 
-		// update must be called after objects adding / removal
+    // update must be called after objects adding / removal
 
-		for ( var o = 0, ol = scene.__webglObjects.length; o < ol; o ++ ) {
+    for ( var o = 0, ol = scene.__webglObjects.length; o < ol; o ++ ) {
 
-			updateObject( scene.__webglObjects[ o ].object );
+      updateObject( scene.__webglObjects[ o ].object );
 
-		}
+    }
 
-	}
+  }
 
-	// Objects adding
+  // Objects adding
 
-	addObject ( Object3D object, Scene scene ) {
+  addObject ( Object3D object, Scene scene ) {
 
     Geometry geometry = object.geometry;
 
     var material;
 
-		if (  !object.__webglInit ) {
+    if (  !object.__webglInit ) {
 
-		  object.__webglInit = true;
+      object.__webglInit = true;
 
-		  object._modelViewMatrix = new Matrix4.identity();
-		  object._normalMatrix = new Matrix3.zero();
+      object._modelViewMatrix = new Matrix4.identity();
+      object._normalMatrix = new Matrix3.zero();
 
-		  if ( geometry != null && !geometry.__webglInit ) {
+      if ( geometry != null && !geometry.__webglInit ) {
 
-				geometry.__webglInit = true;
-				//geometry.addEventListener( 'dispose', onGeometryDispose );
+        geometry.__webglInit = true;
+        //geometry.addEventListener( 'dispose', onGeometryDispose );
 
-			}
+      }
 
-			if ( object is Mesh ) {
+      if ( object is Mesh ) {
 
-				material = object.material;
+        material = object.material;
 
-				if ( (object.geometry is Geometry)  && (object.geometry is! BufferGeometry) ) {
+        if ( (object.geometry is Geometry)  && (object.geometry is! BufferGeometry) ) {
 
-					if ( geometry.geometryGroups == null) {
+          if ( geometry.geometryGroups == null) {
 
-						sortFacesByMaterial( geometry, material );
+            sortFacesByMaterial( geometry, material );
 
-					}
+          }
 
-					// create separate VBOs per geometry chunk
+          // create separate VBOs per geometry chunk
 
-					geometry.geometryGroups.forEach((k, geometryGroup) {
+          geometry.geometryGroups.forEach((k, geometryGroup) {
 
-						// initialise VBO on the first access
+            // initialise VBO on the first access
 
-						if ( geometryGroup.__webglVertexBuffer == null ) {
+            if ( geometryGroup.__webglVertexBuffer == null ) {
 
-							createMeshBuffers( geometryGroup );
-							initMeshBuffers( geometryGroup, object );
+              createMeshBuffers( geometryGroup );
+              initMeshBuffers( geometryGroup, object );
 
-							geometry.verticesNeedUpdate = true;
-							geometry.morphTargetsNeedUpdate = true;
-							geometry.elementsNeedUpdate = true;
-							geometry.uvsNeedUpdate = true;
-							geometry.normalsNeedUpdate = true;
-							geometry.tangentsNeedUpdate = true;
-							geometry.colorsNeedUpdate = true;
+              geometry.verticesNeedUpdate = true;
+              geometry.morphTargetsNeedUpdate = true;
+              geometry.elementsNeedUpdate = true;
+              geometry.uvsNeedUpdate = true;
+              geometry.normalsNeedUpdate = true;
+              geometry.tangentsNeedUpdate = true;
+              geometry.colorsNeedUpdate = true;
 
-						}
+            }
 
-					});
+          });
 
-				} else if ( object.geometry is BufferGeometry ) {
+        } else if ( object.geometry is BufferGeometry ) {
 
-					initDirectBuffers( object.geometry );
+          initDirectBuffers( object.geometry );
 
-				}
+        }
 
-			} else if ( object is Ribbon ) {
+      } else if ( object is Ribbon ) {
 
-				if( geometry.__webglVertexBuffer == null) {
+        if( geometry.__webglVertexBuffer == null) {
 
-					createRibbonBuffers( geometry );
-					initRibbonBuffers( geometry, object );
+          createRibbonBuffers( geometry );
+          initRibbonBuffers( geometry, object );
 
-					geometry.verticesNeedUpdate = true;
-					geometry.colorsNeedUpdate = true;
-					geometry.normalsNeedUpdate = true;
+          geometry.verticesNeedUpdate = true;
+          geometry.colorsNeedUpdate = true;
+          geometry.normalsNeedUpdate = true;
 
-				}
+        }
 
-			} else if ( object is Line ) {
+      } else if ( object is Line ) {
 
-				if( geometry.__webglVertexBuffer == null ) {
+        if( geometry.__webglVertexBuffer == null ) {
 
-					createLineBuffers( geometry );
-					initLineBuffers( geometry, object );
+          createLineBuffers( geometry );
+          initLineBuffers( geometry, object );
 
-					geometry.verticesNeedUpdate = true;
-					geometry.colorsNeedUpdate = true;
-					geometry.lineDistancesNeedUpdate = true;
+          geometry.verticesNeedUpdate = true;
+          geometry.colorsNeedUpdate = true;
+          geometry.lineDistancesNeedUpdate = true;
 
-				}
+        }
 
-			} else if ( object is ParticleSystem ) {
+      } else if ( object is ParticleSystem ) {
 
-				if ( geometry.__webglVertexBuffer == null ) {
+        if ( geometry.__webglVertexBuffer == null ) {
 
-					if ( (object.geometry is Geometry)  && (object.geometry is! BufferGeometry) ) {
-						createParticleBuffers( geometry );
-						initParticleBuffers( geometry, object );
+          if ( (object.geometry is Geometry)  && (object.geometry is! BufferGeometry) ) {
+            createParticleBuffers( geometry );
+            initParticleBuffers( geometry, object );
 
-						geometry.verticesNeedUpdate = true;
-						geometry.colorsNeedUpdate = true;
+            geometry.verticesNeedUpdate = true;
+            geometry.colorsNeedUpdate = true;
 
-					} else if ( object.geometry is BufferGeometry ) {
+          } else if ( object.geometry is BufferGeometry ) {
 
-						initDirectBuffers( object.geometry );
+            initDirectBuffers( object.geometry );
 
-					}
+          }
 
-				}
+        }
 
-			}
-		}
+      }
+    }
 
-		if (!object.__webglActive) {
+    if (!object.__webglActive) {
 
-			if ( object is Mesh ) {
+      if ( object is Mesh ) {
 
-				if ( object.geometry is BufferGeometry ) {
+        if ( object.geometry is BufferGeometry ) {
 
-					addBuffer( scene.__webglObjects, geometry, object );
+          addBuffer( scene.__webglObjects, geometry, object );
 
-				} else {
+        } else {
 
-				  geometry.geometryGroups.forEach( (k, geometryGroup) {
+          geometry.geometryGroups.forEach( (k, geometryGroup) {
 
-						addBuffer( scene.__webglObjects, geometryGroup, object );
+            addBuffer( scene.__webglObjects, geometryGroup, object );
 
-					});
+          });
 
-				}
+        }
 
-			} else if ( object is Ribbon ||
-						object is Line ||
-						object is ParticleSystem ) {
+      } else if ( object is Ribbon ||
+            object is Line ||
+            object is ParticleSystem ) {
 
-				addBuffer( scene.__webglObjects,  geometry, object );
+        addBuffer( scene.__webglObjects,  geometry, object );
 
-			} else if ( object is ImmediateRenderObject || (object.immediateRenderCallback != null) ) {
+      } else if ( object is ImmediateRenderObject || (object.immediateRenderCallback != null) ) {
 
-				addBufferImmediate( scene.__webglObjectsImmediate, object );
+        addBufferImmediate( scene.__webglObjectsImmediate, object );
 
-			} else if ( object is Sprite ) {
+      } else if ( object is Sprite ) {
 
-				scene.__webglSprites.add( object );
+        scene.__webglSprites.add( object );
 
-			} else if ( object is LensFlare ) {
+      } else if ( object is LensFlare ) {
 
-				scene.__webglFlares.add( object );
+        scene.__webglFlares.add( object );
 
-			}
+      }
 
-			object.__webglActive = true;
+      object.__webglActive = true;
 
-		}
+    }
 
-	}
+  }
 
-	addBuffer ( List objlist, WebGLGeometry buffer, Object3D object ) {
+  addBuffer ( List objlist, WebGLGeometry buffer, Object3D object ) {
 
-	  var o = new WebGLObject(object, null, null, buffer);
-		objlist.add(o);
+    var o = new WebGLObject(object, null, null, buffer);
+    objlist.add(o);
 
-	}
+  }
 
-	addBufferImmediate ( List objlist, Object3D object ) {
+  addBufferImmediate ( List objlist, Object3D object ) {
 
-	  var o = new WebGLObject(object, null, null, null);
+    var o = new WebGLObject(object, null, null, null);
 
-		objlist.add(o);
+    objlist.add(o);
 
-	}
+  }
 
-	// Objects updates
+  // Objects updates
 
-	updateObject ( Object3D object ) {
+  updateObject ( Object3D object ) {
 
-		Geometry geometry = object.geometry;
-		WebGLGeometry geometryGroup;
-		var customAttributesDirty;
+    Geometry geometry = object.geometry;
+    WebGLGeometry geometryGroup;
+    var customAttributesDirty;
 
-		Material material;
+    Material material;
 
-		bool hasAttributes = ((material is ShaderMaterial) && (material as ShaderMaterial).attributes != null);
+    bool hasAttributes = ((material is ShaderMaterial) && (material as ShaderMaterial).attributes != null);
 
-		if ( object is Mesh ) {
+    if ( object is Mesh ) {
 
-			if ( object.geometry is BufferGeometry ) {
+      if ( object.geometry is BufferGeometry ) {
 
-				if ( geometry.verticesNeedUpdate || geometry.elementsNeedUpdate ||
-					 geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
-					 geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate ) {
+        if ( geometry.verticesNeedUpdate || geometry.elementsNeedUpdate ||
+           geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
+           geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate ) {
 
-					setDirectBuffers( geometry, gl.DYNAMIC_DRAW, !geometry.isDynamic );
+          setDirectBuffers( geometry, gl.DYNAMIC_DRAW, !geometry.isDynamic );
 
-				}
+        }
 
-				geometry.verticesNeedUpdate = false;
-				geometry.elementsNeedUpdate = false;
-				geometry.uvsNeedUpdate = false;
-				geometry.normalsNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
-				geometry.tangentsNeedUpdate = false;
+        geometry.verticesNeedUpdate = false;
+        geometry.elementsNeedUpdate = false;
+        geometry.uvsNeedUpdate = false;
+        geometry.normalsNeedUpdate = false;
+        geometry.colorsNeedUpdate = false;
+        geometry.tangentsNeedUpdate = false;
 
-			} else {
+      } else {
 
-				// check all geometry groups
+        // check all geometry groups
 
-				for( var i = 0, il = geometry.geometryGroupsList.length; i < il; i ++ ) {
+        for( var i = 0, il = geometry.geometryGroupsList.length; i < il; i ++ ) {
 
-					geometryGroup = geometry.geometryGroupsList[ i ];
+          geometryGroup = geometry.geometryGroupsList[ i ];
 
-					material = getBufferMaterial( object, geometryGroup );
+          material = getBufferMaterial( object, geometryGroup );
 
-					if ( geometry.buffersNeedUpdate ) {
+          if ( geometry.buffersNeedUpdate ) {
 
-						initMeshBuffers( geometryGroup, object );
+            initMeshBuffers( geometryGroup, object );
 
-					}
+          }
 
-					customAttributesDirty = hasAttributes && areCustomAttributesDirty( material );
+          customAttributesDirty = hasAttributes && areCustomAttributesDirty( material );
 
-					if ( geometry.verticesNeedUpdate || geometry.morphTargetsNeedUpdate || geometry.elementsNeedUpdate ||
-						 geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
-						 geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate || customAttributesDirty ) {
+          if ( geometry.verticesNeedUpdate || geometry.morphTargetsNeedUpdate || geometry.elementsNeedUpdate ||
+             geometry.uvsNeedUpdate || geometry.normalsNeedUpdate ||
+             geometry.colorsNeedUpdate || geometry.tangentsNeedUpdate || customAttributesDirty ) {
 
-						setMeshBuffers( geometryGroup, object, gl.DYNAMIC_DRAW, !geometry.isDynamic, material );
+            setMeshBuffers( geometryGroup, object, gl.DYNAMIC_DRAW, !geometry.isDynamic, material );
 
-					}
+          }
 
-				}
+        }
 
-				geometry.verticesNeedUpdate = false;
-				geometry.morphTargetsNeedUpdate = false;
-				geometry.elementsNeedUpdate = false;
-				geometry.uvsNeedUpdate = false;
-				geometry.normalsNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
-				geometry.tangentsNeedUpdate = false;
+        geometry.verticesNeedUpdate = false;
+        geometry.morphTargetsNeedUpdate = false;
+        geometry.elementsNeedUpdate = false;
+        geometry.uvsNeedUpdate = false;
+        geometry.normalsNeedUpdate = false;
+        geometry.colorsNeedUpdate = false;
+        geometry.tangentsNeedUpdate = false;
 
-				geometry.buffersNeedUpdate = false;
+        geometry.buffersNeedUpdate = false;
 
-				if (hasAttributes) {
-				  clearCustomAttributes( material );
-				}
+        if (hasAttributes) {
+          clearCustomAttributes( material );
+        }
 
-			}
+      }
 
-		} else if ( object is Ribbon ) {
+    } else if ( object is Ribbon ) {
 
-			material = getBufferMaterial( object, geometry );
+      material = getBufferMaterial( object, geometry );
 
-			customAttributesDirty = ((material is ShaderMaterial) && (material as ShaderMaterial).attributes != null) && areCustomAttributesDirty( material );
+      customAttributesDirty = ((material is ShaderMaterial) && (material as ShaderMaterial).attributes != null) && areCustomAttributesDirty( material );
 
-			if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.normalsNeedUpdate || customAttributesDirty ) {
+      if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || geometry.normalsNeedUpdate || customAttributesDirty ) {
 
-				setRibbonBuffers( geometry, gl.DYNAMIC_DRAW );
+        setRibbonBuffers( geometry, gl.DYNAMIC_DRAW );
 
-			}
+      }
 
-			geometry.verticesNeedUpdate = false;
-			geometry.colorsNeedUpdate = false;
-			geometry.normalsNeedUpdate = false;
+      geometry.verticesNeedUpdate = false;
+      geometry.colorsNeedUpdate = false;
+      geometry.normalsNeedUpdate = false;
 
-			if (hasAttributes) {
-				clearCustomAttributes( material );
-			}
+      if (hasAttributes) {
+        clearCustomAttributes( material );
+      }
 
-		} else if ( object is Line ) {
+    } else if ( object is Line ) {
 
-			material = getBufferMaterial( object, geometry );
+      material = getBufferMaterial( object, geometry );
 
-			customAttributesDirty = (hasAttributes) && areCustomAttributesDirty( material );
+      customAttributesDirty = (hasAttributes) && areCustomAttributesDirty( material );
 
-			if ( geometry.verticesNeedUpdate ||  geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
+      if ( geometry.verticesNeedUpdate ||  geometry.colorsNeedUpdate || geometry.lineDistancesNeedUpdate || customAttributesDirty ) {
 
-				setLineBuffers( geometry, gl.DYNAMIC_DRAW );
+        setLineBuffers( geometry, gl.DYNAMIC_DRAW );
 
-			}
+      }
 
-			geometry.verticesNeedUpdate = false;
-			geometry.colorsNeedUpdate = false;
-			geometry.lineDistancesNeedUpdate = false;
+      geometry.verticesNeedUpdate = false;
+      geometry.colorsNeedUpdate = false;
+      geometry.lineDistancesNeedUpdate = false;
 
-			if (hasAttributes) clearCustomAttributes( material );
+      if (hasAttributes) clearCustomAttributes( material );
 
-		} else if ( object is ParticleSystem ) {
+    } else if ( object is ParticleSystem ) {
 
-			if ( geometry is BufferGeometry ) {
+      if ( geometry is BufferGeometry ) {
 
-				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
+        if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate ) {
 
-					setDirectBuffers( geometry, gl.DYNAMIC_DRAW, !geometry.isDynamic );
+          setDirectBuffers( geometry, gl.DYNAMIC_DRAW, !geometry.isDynamic );
 
-				}
+        }
 
-				geometry.verticesNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
+        geometry.verticesNeedUpdate = false;
+        geometry.colorsNeedUpdate = false;
 
-			} else {
+      } else {
 
-				material = getBufferMaterial( object, geometryGroup );
+        material = getBufferMaterial( object, geometryGroup );
 
-				customAttributesDirty = (hasAttributes) && areCustomAttributesDirty( material );
+        customAttributesDirty = (hasAttributes) && areCustomAttributesDirty( material );
 
-				if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || object.sortParticles || customAttributesDirty ) {
+        if ( geometry.verticesNeedUpdate || geometry.colorsNeedUpdate || object.sortParticles || customAttributesDirty ) {
 
-					setParticleBuffers( geometry, gl.DYNAMIC_DRAW, object );
+          setParticleBuffers( geometry, gl.DYNAMIC_DRAW, object );
 
-				}
+        }
 
-				geometry.verticesNeedUpdate = false;
-				geometry.colorsNeedUpdate = false;
+        geometry.verticesNeedUpdate = false;
+        geometry.colorsNeedUpdate = false;
 
-				if (hasAttributes) clearCustomAttributes( material );
-			}
+        if (hasAttributes) clearCustomAttributes( material );
+      }
 
-		}
+    }
 
-	}
+  }
 
-	// Objects updates - custom attributes check
+  // Objects updates - custom attributes check
 
-	areCustomAttributesDirty( material ) => material.attributes.values.any((a) => a.needsUpdate);
+  areCustomAttributesDirty( material ) => material.attributes.values.any((a) => a.needsUpdate);
 
-	clearCustomAttributes( material ) => material.attributes.forEach((_, a) { a.needsUpdate = false; });
+  clearCustomAttributes( material ) => material.attributes.forEach((_, a) { a.needsUpdate = false; });
 
-	// Objects removal
+  // Objects removal
 
-	removeObject ( Object3D object, Scene scene ) {
+  removeObject ( Object3D object, Scene scene ) {
 
-		if ( object is Mesh  ||
-			 object is ParticleSystem ||
-			 object is Ribbon ||
-			 object is Line ) {
+    if ( object is Mesh  ||
+       object is ParticleSystem ||
+       object is Ribbon ||
+       object is Line ) {
 
-			removeInstances( scene.__webglObjects, object );
+      removeInstances( scene.__webglObjects, object );
 
-		} else if ( object is Sprite ) {
+    } else if ( object is Sprite ) {
 
-			removeInstancesDirect( scene.__webglSprites, object );
+      removeInstancesDirect( scene.__webglSprites, object );
 
-		} else if ( object is LensFlare ) {
+    } else if ( object is LensFlare ) {
 
-			removeInstancesDirect( scene.__webglFlares, object );
+      removeInstancesDirect( scene.__webglFlares, object );
 
-		} else if ( object is ImmediateRenderObject || (object.immediateRenderCallback != null) ) {
+    } else if ( object is ImmediateRenderObject || (object.immediateRenderCallback != null) ) {
 
-			removeInstances( scene.__webglObjectsImmediate, object );
+      removeInstances( scene.__webglObjectsImmediate, object );
 
-		}
+    }
 
-		object.__webglActive = false;
+    object.__webglActive = false;
 
-	}
+  }
 
-	removeInstances ( List objlist, Object3D object ) {
+  removeInstances ( List objlist, Object3D object ) {
 
-		for ( var o = objlist.length - 1; o >= 0; o -- ) {
+    for ( var o = objlist.length - 1; o >= 0; o -- ) {
 
-			if ( objlist[ o ].object == object ) {
+      if ( objlist[ o ].object == object ) {
 
-				objlist.removeAt( o );
+        objlist.removeAt( o );
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	removeInstancesDirect ( List objlist, Object3D object ) {
+  removeInstancesDirect ( List objlist, Object3D object ) {
 
-		for ( var o = objlist.length - 1; o >= 0; o -- ) {
+    for ( var o = objlist.length - 1; o >= 0; o -- ) {
 
       if ( identical(objlist[ o ], object) ) {
 
-				objlist.removeAt( o );
+        objlist.removeAt( o );
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	// Materials
+  // Materials
 
-	initMaterial( Material material, List<Light> lights, Fog fog, Object3D object ) {
+  initMaterial( Material material, List<Light> lights, Fog fog, Object3D object ) {
 
-		//material.addEventListener( 'dispose', onMaterialDispose );
+    //material.addEventListener( 'dispose', onMaterialDispose );
 
-		var u, a, identifiers, i, parameters, maxLightCount, maxBones, maxShadows, shaderID;
+    var u, a, identifiers, i, parameters, maxLightCount, maxBones, maxShadows, shaderID;
 
-		if ( material is MeshDepthMaterial ) {
+    if ( material is MeshDepthMaterial ) {
 
-			shaderID = 'depth';
+      shaderID = 'depth';
 
-		} else if ( material is MeshNormalMaterial ) {
+    } else if ( material is MeshNormalMaterial ) {
 
-			shaderID = 'normal';
+      shaderID = 'normal';
 
-		} else if ( material is MeshBasicMaterial ) {
+    } else if ( material is MeshBasicMaterial ) {
 
-			shaderID = 'basic';
+      shaderID = 'basic';
 
-		} else if ( material is MeshLambertMaterial ) {
+    } else if ( material is MeshLambertMaterial ) {
 
-			shaderID = 'lambert';
+      shaderID = 'lambert';
 
-		} else if ( material is MeshPhongMaterial ) {
+    } else if ( material is MeshPhongMaterial ) {
 
-			shaderID = 'phong';
+      shaderID = 'phong';
 
-		} else if ( material is LineBasicMaterial ) {
+    } else if ( material is LineBasicMaterial ) {
 
-			shaderID = 'basic';
+      shaderID = 'basic';
 
-		// TODO - Added LineDashedMaterial
-		// } else if ( material.isLineDashedMaterial ) {
+    // TODO - Added LineDashedMaterial
+    // } else if ( material.isLineDashedMaterial ) {
 
-		//	shaderID = 'dashed';
+    //  shaderID = 'dashed';
 
-		} else if ( material is ParticleBasicMaterial ) {
+    } else if ( material is ParticleBasicMaterial ) {
 
-			shaderID = 'particle_basic';
+      shaderID = 'particle_basic';
 
-		}
+    }
 
-		if ( shaderID != null) {
+    if ( shaderID != null) {
 
-			setMaterialShaders( material, ShaderLib[ shaderID ] );
+      setMaterialShaders( material, ShaderLib[ shaderID ] );
 
-		}
+    }
 
-		// heuristics to create shader parameters according to lights in the scene
-		// (not to blow over maxLights budget)
+    // heuristics to create shader parameters according to lights in the scene
+    // (not to blow over maxLights budget)
 
-		maxLightCount = allocateLights( lights );
+    maxLightCount = allocateLights( lights );
 
-		maxShadows = allocateShadows( lights );
+    maxShadows = allocateShadows( lights );
 
-		maxBones = allocateBones( object );
+    maxBones = allocateBones( object );
 
-		material._program = buildProgram(
-			shaderID,
-			material._fragmentShader,
-			material._vertexShader,
-			material._uniforms,
-			(material is ShaderMaterial) ? material.attributes : {},
-			(material is ShaderMaterial) ? material.defines : {},
-			map: (material is TextureMapping) ? (material as TextureMapping).map : null,
-			envMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).envMap : null,
-			lightMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).lightMap : null,
-			bumpMap: (material is BumpMapping) ? (material as BumpMapping).bumpMap : null,
-			normalMap: (material is BumpMapping) ? (material as BumpMapping).normalMap : null,
-			specularMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).specularMap : null,
+    material._program = buildProgram(
+      shaderID,
+      material._fragmentShader,
+      material._vertexShader,
+      material._uniforms,
+      (material is ShaderMaterial) ? material.attributes : {},
+      (material is ShaderMaterial) ? material.defines : {},
+      map: (material is TextureMapping) ? (material as TextureMapping).map : null,
+      envMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).envMap : null,
+      lightMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).lightMap : null,
+      bumpMap: (material is BumpMapping) ? (material as BumpMapping).bumpMap : null,
+      normalMap: (material is BumpMapping) ? (material as BumpMapping).normalMap : null,
+      specularMap: (material is EnvironmentMapping) ? (material as EnvironmentMapping).specularMap : null,
 
-			vertexColors: material.vertexColors,
+      vertexColors: material.vertexColors,
 
-			fog: fog,
-			useFog: material.fog,
-			fogExp: fog is FogExp2,
+      fog: fog,
+      useFog: material.fog,
+      fogExp: fog is FogExp2,
 
-			sizeAttenuation: (material is ParticleBasicMaterial) ? material.sizeAttenuation : false,
+      sizeAttenuation: (material is ParticleBasicMaterial) ? material.sizeAttenuation : false,
 
-			skinning: (material is Skinning) ? (material as Skinning).skinning : false,
-			maxBones: maxBones,
-			useVertexTexture: supportsBoneTextures && object != null && object is SkinnedMesh && object.useVertexTexture,
-			boneTextureWidth: (object != null && object is SkinnedMesh) ? object.boneTextureWidth : 0,
-			boneTextureHeight: (object != null && object is SkinnedMesh) ? object.boneTextureHeight : 0,
+      skinning: (material is Skinning) ? (material as Skinning).skinning : false,
+      maxBones: maxBones,
+      useVertexTexture: supportsBoneTextures && object != null && object is SkinnedMesh && object.useVertexTexture,
+      boneTextureWidth: (object != null && object is SkinnedMesh) ? object.boneTextureWidth : 0,
+      boneTextureHeight: (object != null && object is SkinnedMesh) ? object.boneTextureHeight : 0,
 
-			morphTargets: (material is Morphing) ? (material as Morphing).morphTargets : false,
-			morphNormals: (material is Morphing) ? (material as Morphing).morphNormals : false,
-			maxMorphTargets: maxMorphTargets,
-			maxMorphNormals: maxMorphNormals,
+      morphTargets: (material is Morphing) ? (material as Morphing).morphTargets : false,
+      morphNormals: (material is Morphing) ? (material as Morphing).morphNormals : false,
+      maxMorphTargets: maxMorphTargets,
+      maxMorphNormals: maxMorphNormals,
 
-			maxDirLights: maxLightCount['directional'],
-			maxPointLights: maxLightCount['point'],
-			maxSpotLights: maxLightCount['spot'],
-			maxHemiLights: maxLightCount['hemi'],
+      maxDirLights: maxLightCount['directional'],
+      maxPointLights: maxLightCount['point'],
+      maxSpotLights: maxLightCount['spot'],
+      maxHemiLights: maxLightCount['hemi'],
 
-			maxShadows: maxShadows,
-			shadowMapEnabled: shadowMapEnabled && object.receiveShadow,
-			shadowMapType: shadowMapType,
-			shadowMapDebug: shadowMapDebug,
-			shadowMapCascade: shadowMapCascade,
+      maxShadows: maxShadows,
+      shadowMapEnabled: shadowMapEnabled && object.receiveShadow,
+      shadowMapType: shadowMapType,
+      shadowMapDebug: shadowMapDebug,
+      shadowMapCascade: shadowMapCascade,
 
-			alphaTest: material.alphaTest,
-			metal: (material is MeshPhongMaterial) ? material.metal : false,
-			perPixel: (material is MeshPhongMaterial) ? material.perPixel : false,
-			wrapAround: (material is Lighting) ? (material as Lighting).wrapAround : false,
-			doubleSided: material.side == DoubleSide,
-			flipSided: material.side == BackSide );
+      alphaTest: material.alphaTest,
+      metal: (material is MeshPhongMaterial) ? material.metal : false,
+      perPixel: (material is MeshPhongMaterial) ? material.perPixel : false,
+      wrapAround: (material is Lighting) ? (material as Lighting).wrapAround : false,
+      doubleSided: material.side == DoubleSide,
+      flipSided: material.side == BackSide );
 
-		var attributes = material._program.attributes;
+    var attributes = material._program.attributes;
 
-		if ( (material is Morphing) && (material as Morphing).morphTargets ) {
+    if ( (material is Morphing) && (material as Morphing).morphTargets ) {
 
-		  (material as Morphing).numSupportedMorphTargets = 0;
+      (material as Morphing).numSupportedMorphTargets = 0;
 
-			var id, base = "morphTarget";
+      var id, base = "morphTarget";
 
-			for ( i = 0; i < maxMorphTargets; i ++ ) {
+      for ( i = 0; i < maxMorphTargets; i ++ ) {
 
-				id = "$base$i";
+        id = "$base$i";
 
-				if ( attributes[ id ] >= 0 ) {
+        if ( attributes[ id ] >= 0 ) {
 
-				  (material as Morphing).numSupportedMorphTargets ++;
+          (material as Morphing).numSupportedMorphTargets ++;
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		if ( (material is Morphing) && (material as Morphing).morphNormals ) {
+    if ( (material is Morphing) && (material as Morphing).morphNormals ) {
 
-		  (material as Morphing).numSupportedMorphNormals = 0;
+      (material as Morphing).numSupportedMorphNormals = 0;
 
-			var id, base = "morphNormal";
+      var id, base = "morphNormal";
 
-			for ( i = 0; i < maxMorphNormals; i ++ ) {
+      for ( i = 0; i < maxMorphNormals; i ++ ) {
 
-				id = "$base$i";
+        id = "$base$i";
 
-				if ( attributes[ id ] >= 0 ) {
+        if ( attributes[ id ] >= 0 ) {
 
-				  (material as Morphing).numSupportedMorphNormals ++;
+          (material as Morphing).numSupportedMorphNormals ++;
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		material._uniformsList = [];
+    material._uniformsList = [];
 
-		material._uniforms.forEach( (k, u) => material._uniformsList.add( [ u, k ] ));
+    material._uniforms.forEach( (k, u) => material._uniformsList.add( [ u, k ] ));
 
-	}
+  }
 
-	setMaterialShaders( Material material, Map shaders ) {
+  setMaterialShaders( Material material, Map shaders ) {
 
-		material._uniforms = UniformsUtils.clone( shaders["uniforms"] );
-		material._vertexShader = shaders["vertexShader"];
-		material._fragmentShader = shaders["fragmentShader"];
+    material._uniforms = UniformsUtils.clone( shaders["uniforms"] );
+    material._vertexShader = shaders["vertexShader"];
+    material._fragmentShader = shaders["fragmentShader"];
 
-	}
+  }
 
-	setProgram( Camera camera, List<Light> lights, Fog fog, Material material, Object3D object ) {
+  setProgram( Camera camera, List<Light> lights, Fog fog, Material material, Object3D object ) {
 
-	  _usedTextureUnits = 0;
+    _usedTextureUnits = 0;
 
-		if ( material.needsUpdate ) {
+    if ( material.needsUpdate ) {
 
-			if ( material._program != null ) deallocateMaterial( material );
+      if ( material._program != null ) deallocateMaterial( material );
 
-			initMaterial( material, lights, fog, object );
-			material.needsUpdate = false;
+      initMaterial( material, lights, fog, object );
+      material.needsUpdate = false;
 
-		}
+    }
 
-		if ( (material is Morphing) && (material as Morphing).morphTargets ) {
+    if ( (material is Morphing) && (material as Morphing).morphTargets ) {
 
-			if ( (object as Mesh).__webglMorphTargetInfluences == null) {
+      if ( (object as Mesh).__webglMorphTargetInfluences == null) {
 
-			  (object as Mesh).__webglMorphTargetInfluences = new Float32List( maxMorphTargets );
+        (object as Mesh).__webglMorphTargetInfluences = new Float32List( maxMorphTargets );
 
-			}
+      }
 
-		}
+    }
 
-		var refreshMaterial = false;
+    var refreshMaterial = false;
 
-		var program = material._program,
-			p_uniforms = program.uniforms,
-			m_uniforms = material._uniforms;
+    var program = material._program,
+      p_uniforms = program.uniforms,
+      m_uniforms = material._uniforms;
 
     if ( !identical(program, _currentProgram) ) {
 
-			_gl.useProgram( program.glProgram );
-			_currentProgram = program;
+      _gl.useProgram( program.glProgram );
+      _currentProgram = program;
 
-			refreshMaterial = true;
+      refreshMaterial = true;
 
-		}
+    }
 
-		if ( material.id != _currentMaterialId ) {
+    if ( material.id != _currentMaterialId ) {
 
-			_currentMaterialId = material.id;
-			refreshMaterial = true;
+      _currentMaterialId = material.id;
+      refreshMaterial = true;
 
-		}
+    }
 
     if ( refreshMaterial || !identical(camera, _currentCamera) ) {
 
-			_gl.uniformMatrix4fv( p_uniforms["projectionMatrix"], false, camera.projectionMatrix.storage );
+      _gl.uniformMatrix4fv( p_uniforms["projectionMatrix"], false, camera.projectionMatrix.storage );
 
       if ( !identical(camera, _currentCamera) ) _currentCamera = camera;
 
-		}
+    }
 
 
-		// skinning uniforms must be set even if material didn't change
-		// auto-setting of texture unit for bone texture must go before other textures
-		// not sure why, but otherwise weird things happen
+    // skinning uniforms must be set even if material didn't change
+    // auto-setting of texture unit for bone texture must go before other textures
+    // not sure why, but otherwise weird things happen
 
-		if ( (object is SkinnedMesh) && (material is Skinning) && (material as Skinning).skinning ) {
+    if ( (object is SkinnedMesh) && (material is Skinning) && (material as Skinning).skinning ) {
 
-			if ( supportsBoneTextures && object.useVertexTexture ) {
+      if ( supportsBoneTextures && object.useVertexTexture ) {
 
-				if ( p_uniforms.boneTexture != null ) {
+        if ( p_uniforms.boneTexture != null ) {
 
-					var textureUnit = getTextureUnit();
+          var textureUnit = getTextureUnit();
 
-					_gl.uniform1i( p_uniforms.boneTexture, textureUnit );
-					setTexture( object.boneTexture, textureUnit );
+          _gl.uniform1i( p_uniforms.boneTexture, textureUnit );
+          setTexture( object.boneTexture, textureUnit );
 
-				}
+        }
 
-			} else {
+      } else {
 
-				if ( p_uniforms.boneGlobalMatrices != null ) {
+        if ( p_uniforms.boneGlobalMatrices != null ) {
 
-					_gl.uniformMatrix4fv( p_uniforms.boneGlobalMatrices, false, object.boneMatrices );
+          _gl.uniformMatrix4fv( p_uniforms.boneGlobalMatrices, false, object.boneMatrices );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		if ( refreshMaterial ) {
+    if ( refreshMaterial ) {
 
-			// refresh uniforms common to several materials
+      // refresh uniforms common to several materials
 
-			if ( (fog != null) && material.fog ) {
+      if ( (fog != null) && material.fog ) {
 
-				refreshUniformsFog( m_uniforms, fog );
+        refreshUniformsFog( m_uniforms, fog );
 
-			}
+      }
 
-			if ( (material is MeshPhongMaterial) ||
-				   (material is MeshLambertMaterial) ||
-				   ((material is ShaderMaterial) && material.lights )) {
+      if ( (material is MeshPhongMaterial) ||
+           (material is MeshLambertMaterial) ||
+           ((material is ShaderMaterial) && material.lights )) {
 
-				if ( _lightsNeedUpdate ) {
+        if ( _lightsNeedUpdate ) {
 
-					setupLights( program, lights );
-					_lightsNeedUpdate = false;
+          setupLights( program, lights );
+          _lightsNeedUpdate = false;
 
-				}
+        }
 
-				refreshUniformsLights( m_uniforms, _lights );
+        refreshUniformsLights( m_uniforms, _lights );
 
-			}
+      }
 
-			if ( (material is MeshBasicMaterial) ||
-				   (material is MeshLambertMaterial) ||
-				   (material is MeshPhongMaterial) ) {
+      if ( (material is MeshBasicMaterial) ||
+           (material is MeshLambertMaterial) ||
+           (material is MeshPhongMaterial) ) {
 
-				refreshUniformsCommon( m_uniforms, material );
+        refreshUniformsCommon( m_uniforms, material );
 
-			}
+      }
 
-			// refresh single material specific uniforms
+      // refresh single material specific uniforms
 
-			if ( material is LineBasicMaterial ) {
+      if ( material is LineBasicMaterial ) {
 
-				refreshUniformsLine( m_uniforms, material );
+        refreshUniformsLine( m_uniforms, material );
 
-			// TODO - Implement LineDashedMaterial
-			//} else if ( material instanceof THREE.LineDashedMaterial ) {
+      // TODO - Implement LineDashedMaterial
+      //} else if ( material instanceof THREE.LineDashedMaterial ) {
 
-			//	refreshUniformsLine( m_uniforms, material );
-			//	refreshUniformsDash( m_uniforms, material );
+      //  refreshUniformsLine( m_uniforms, material );
+      //  refreshUniformsDash( m_uniforms, material );
 
-			} else if ( material is ParticleBasicMaterial ) {
+      } else if ( material is ParticleBasicMaterial ) {
 
-				refreshUniformsParticle( m_uniforms, material );
+        refreshUniformsParticle( m_uniforms, material );
 
-			} else if ( material is MeshPhongMaterial ) {
+      } else if ( material is MeshPhongMaterial ) {
 
-				refreshUniformsPhong( m_uniforms, material );
+        refreshUniformsPhong( m_uniforms, material );
 
-			} else if ( material is MeshLambertMaterial ) {
+      } else if ( material is MeshLambertMaterial ) {
 
-				refreshUniformsLambert( m_uniforms, material );
+        refreshUniformsLambert( m_uniforms, material );
 
-			} else if ( material is MeshDepthMaterial ) {
+      } else if ( material is MeshDepthMaterial ) {
 
-				m_uniforms["mNear"].value = camera.near;
-				m_uniforms["mFar"].value = camera.far;
-				m_uniforms["opacity"].value = material.opacity;
+        m_uniforms["mNear"].value = camera.near;
+        m_uniforms["mFar"].value = camera.far;
+        m_uniforms["opacity"].value = material.opacity;
 
-			} else if ( material is MeshNormalMaterial ) {
+      } else if ( material is MeshNormalMaterial ) {
 
-				m_uniforms["opacity"].value = material.opacity;
+        m_uniforms["opacity"].value = material.opacity;
 
-			}
+      }
 
-			if ( object.receiveShadow && ! material.shadowPass ) {
+      if ( object.receiveShadow && ! material.shadowPass ) {
 
-				refreshUniformsShadow( m_uniforms, lights );
+        refreshUniformsShadow( m_uniforms, lights );
 
-			}
+      }
 
-			// load common uniforms
+      // load common uniforms
 
-			loadUniformsGeneric( program, material._uniformsList );
+      loadUniformsGeneric( program, material._uniformsList );
 
-			// load material specific uniforms
-			// (shader material also gets them for the sake of genericity)
+      // load material specific uniforms
+      // (shader material also gets them for the sake of genericity)
 
-			if ( (material is ShaderMaterial) ||
-				   (material is MeshPhongMaterial) ||
-				   ((material is EnvironmentMapping) && (material as EnvironmentMapping).envMap != null) ) {
+      if ( (material is ShaderMaterial) ||
+           (material is MeshPhongMaterial) ||
+           ((material is EnvironmentMapping) && (material as EnvironmentMapping).envMap != null) ) {
 
-				if ( p_uniforms["cameraPosition"] != null ) {
+        if ( p_uniforms["cameraPosition"] != null ) {
 
-					_vector3 = camera.matrixWorld.getTranslation();
-					_gl.uniform3f( p_uniforms["cameraPosition"], _vector3.x, _vector3.y, _vector3.z );
+          _vector3 = camera.matrixWorld.getTranslation();
+          _gl.uniform3f( p_uniforms["cameraPosition"], _vector3.x, _vector3.y, _vector3.z );
 
-				}
+        }
 
-			}
+      }
 
-			if ( (material is MeshPhongMaterial) ||
-				   (material is MeshLambertMaterial) ||
-				   (material is ShaderMaterial) ||
-				   ((material is Skinning) && (material as Skinning).skinning )) {
+      if ( (material is MeshPhongMaterial) ||
+           (material is MeshLambertMaterial) ||
+           (material is ShaderMaterial) ||
+           ((material is Skinning) && (material as Skinning).skinning )) {
 
-				if ( p_uniforms["viewMatrix"] != null ) {
+        if ( p_uniforms["viewMatrix"] != null ) {
 
-					_gl.uniformMatrix4fv( p_uniforms["viewMatrix"], false, camera.matrixWorldInverse.storage );
+          _gl.uniformMatrix4fv( p_uniforms["viewMatrix"], false, camera.matrixWorldInverse.storage );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-		loadUniformsMatrices( p_uniforms, object );
+    loadUniformsMatrices( p_uniforms, object );
 
-		if ( p_uniforms["modelMatrix"] != null ) {
+    if ( p_uniforms["modelMatrix"] != null ) {
 
-			_gl.uniformMatrix4fv( p_uniforms["modelMatrix"], false, object.matrixWorld.storage );
+      _gl.uniformMatrix4fv( p_uniforms["modelMatrix"], false, object.matrixWorld.storage );
 
-		}
+    }
 
-		return program;
+    return program;
 
-	}
+  }
 
-	// Uniforms (refresh uniforms objects)
+  // Uniforms (refresh uniforms objects)
 
-	refreshUniformsCommon ( Map<String, Uniform> uniforms, Material material ) {
+  refreshUniformsCommon ( Map<String, Uniform> uniforms, Material material ) {
 
-		uniforms["opacity"].value = material.opacity;
+    uniforms["opacity"].value = material.opacity;
 
-		if ( gammaInput ) {
+    if ( gammaInput ) {
 
-			uniforms["diffuse"].value.copyGammaToLinear( material.color );
+      uniforms["diffuse"].value.copyGammaToLinear( material.color );
 
-		} else {
+    } else {
 
-			uniforms["diffuse"].value = material.color;
+      uniforms["diffuse"].value = material.color;
 
-		}
+    }
 
-		if (material is TextureMapping) {
-		  uniforms["map"].value = (material as TextureMapping).map;
-		}
+    if (material is TextureMapping) {
+      uniforms["map"].value = (material as TextureMapping).map;
+    }
 
-		if (material is EnvironmentMapping) {
-		  uniforms["lightMap"].value = (material as EnvironmentMapping).lightMap;
-		  uniforms["specularMap"].value = (material as EnvironmentMapping).specularMap;
-		}
+    if (material is EnvironmentMapping) {
+      uniforms["lightMap"].value = (material as EnvironmentMapping).lightMap;
+      uniforms["specularMap"].value = (material as EnvironmentMapping).specularMap;
+    }
 
-		if ( (material is BumpMapping) && (material as BumpMapping).bumpMap != null ) {
+    if ( (material is BumpMapping) && (material as BumpMapping).bumpMap != null ) {
 
-			uniforms["bumpMap"].value = (material as BumpMapping).bumpMap;
-			uniforms["bumpScale"].value = (material as BumpMapping).bumpScale;
+      uniforms["bumpMap"].value = (material as BumpMapping).bumpMap;
+      uniforms["bumpScale"].value = (material as BumpMapping).bumpScale;
 
-		}
+    }
 
-		if ( (material is BumpMapping) && (material as BumpMapping).normalMap != null ) {
+    if ( (material is BumpMapping) && (material as BumpMapping).normalMap != null ) {
 
-			uniforms["normalMap"].value = (material as BumpMapping).normalMap;
-			uniforms["normalScale"].value.copy( (material as BumpMapping).normalScale );
+      uniforms["normalMap"].value = (material as BumpMapping).normalMap;
+      uniforms["normalScale"].value.copy( (material as BumpMapping).normalScale );
 
-		}
+    }
 
-		// uv repeat and offset setting priorities
-		//	1. color map
-		//	2. specular map
-		//	3. normal map
-		//	4. bump map
+    // uv repeat and offset setting priorities
+    //  1. color map
+    //  2. specular map
+    //  3. normal map
+    //  4. bump map
 
-		var uvScaleMap;
+    var uvScaleMap;
 
-		if ( (material is TextureMapping) && (material as TextureMapping).map != null) {
+    if ( (material is TextureMapping) && (material as TextureMapping).map != null) {
 
-			uvScaleMap = (material as TextureMapping).map;
+      uvScaleMap = (material as TextureMapping).map;
 
-		} else if ( (material is EnvironmentMapping ) && (material as EnvironmentMapping).specularMap != null ) {
+    } else if ( (material is EnvironmentMapping ) && (material as EnvironmentMapping).specularMap != null ) {
 
-			uvScaleMap = (material as EnvironmentMapping ).specularMap;
+      uvScaleMap = (material as EnvironmentMapping ).specularMap;
 
-		} else if ( ( material is BumpMapping ) && (material as BumpMapping).normalMap != null ) {
+    } else if ( ( material is BumpMapping ) && (material as BumpMapping).normalMap != null ) {
 
-			uvScaleMap = (material as BumpMapping ).normalMap;
+      uvScaleMap = (material as BumpMapping ).normalMap;
 
-		} else if ( ( material is BumpMapping ) && (material as BumpMapping).bumpMap != null ) {
+    } else if ( ( material is BumpMapping ) && (material as BumpMapping).bumpMap != null ) {
 
-			uvScaleMap = (material as BumpMapping).bumpMap;
+      uvScaleMap = (material as BumpMapping).bumpMap;
 
-		}
+    }
 
-		if ( uvScaleMap != null ) {
+    if ( uvScaleMap != null ) {
 
-			var offset = uvScaleMap.offset;
-			var repeat = uvScaleMap.repeat;
+      var offset = uvScaleMap.offset;
+      var repeat = uvScaleMap.repeat;
 
-			uniforms["offsetRepeat"].value.setValues( offset.x, offset.y, repeat.x, repeat.y );
+      uniforms["offsetRepeat"].value.setValues( offset.x, offset.y, repeat.x, repeat.y );
 
-		}
+    }
 
-		if (material is EnvironmentMapping) {
-		  EnvironmentMapping envMat = material as EnvironmentMapping;
+    if (material is EnvironmentMapping) {
+      EnvironmentMapping envMat = material as EnvironmentMapping;
 
-		  uniforms["envMap"].value = envMat.envMap;
-		  uniforms["flipEnvMap"].value = ( envMat.envMap is WebGLRenderTargetCube ) ? 1 : -1;
+      uniforms["envMap"].value = envMat.envMap;
+      uniforms["flipEnvMap"].value = ( envMat.envMap is WebGLRenderTargetCube ) ? 1 : -1;
 
 
-  		if ( gammaInput ) {
+      if ( gammaInput ) {
 
-  			//uniforms["reflectivity"].value = material.reflectivity * material.reflectivity;
-  			uniforms["reflectivity"].value = envMat.reflectivity;
+        //uniforms["reflectivity"].value = material.reflectivity * material.reflectivity;
+        uniforms["reflectivity"].value = envMat.reflectivity;
 
-  		} else {
+      } else {
 
-  			uniforms["reflectivity"].value = envMat.reflectivity;
+        uniforms["reflectivity"].value = envMat.reflectivity;
 
-  		}
+      }
 
-  		uniforms["refractionRatio"].value = envMat.refractionRatio;
-  		uniforms["combine"].value = envMat.combine;
-  		uniforms["useRefract"].value = ((envMat.envMap != null) && (envMat.envMap.mapping is CubeRefractionMapping))? 1:0;
-		}
-	}
+      uniforms["refractionRatio"].value = envMat.refractionRatio;
+      uniforms["combine"].value = envMat.combine;
+      uniforms["useRefract"].value = ((envMat.envMap != null) && (envMat.envMap.mapping is CubeRefractionMapping))? 1:0;
+    }
+  }
 
-	refreshUniformsLine ( Map<String, Uniform> uniforms, LineBasicMaterial material ) {
+  refreshUniformsLine ( Map<String, Uniform> uniforms, LineBasicMaterial material ) {
 
-		uniforms["diffuse"].value = material.color;
-		uniforms["opacity"].value = material.opacity;
+    uniforms["diffuse"].value = material.color;
+    uniforms["opacity"].value = material.opacity;
 
-	}
+  }
 
-	refreshUniformsDash ( Map<String, Uniform> uniforms, material ) {
+  refreshUniformsDash ( Map<String, Uniform> uniforms, material ) {
 
-		uniforms["dashSize"].value = material.dashSize;
-		uniforms["totalSize"].value = material.dashSize + material.gapSize;
-		uniforms["scale"].value = material.scale;
+    uniforms["dashSize"].value = material.dashSize;
+    uniforms["totalSize"].value = material.dashSize + material.gapSize;
+    uniforms["scale"].value = material.scale;
 
-	}
+  }
 
-	refreshUniformsParticle ( Map<String, Uniform> uniforms, material ) {
+  refreshUniformsParticle ( Map<String, Uniform> uniforms, material ) {
 
-		uniforms["psColor"].value = material.color;
-		uniforms["opacity"].value = material.opacity;
-		uniforms["size"].value = material.size;
-		uniforms["scale"].value = canvas.height / 2.0; // TODO: Cache
+    uniforms["psColor"].value = material.color;
+    uniforms["opacity"].value = material.opacity;
+    uniforms["size"].value = material.size;
+    uniforms["scale"].value = canvas.height / 2.0; // TODO: Cache
 
-		uniforms["map"].value = material.map;
+    uniforms["map"].value = material.map;
 
-	}
+  }
 
-	refreshUniformsFog ( Map<String, Uniform> uniforms, Fog fog ) {
+  refreshUniformsFog ( Map<String, Uniform> uniforms, Fog fog ) {
 
-		uniforms["fogColor"].value = fog.color;
+    uniforms["fogColor"].value = fog.color;
 
-		if ( fog is FogLinear ) {
+    if ( fog is FogLinear ) {
 
-			uniforms["fogNear"].value = fog.near;
-			uniforms["fogFar"].value = fog.far;
+      uniforms["fogNear"].value = fog.near;
+      uniforms["fogFar"].value = fog.far;
 
-		} else if ( fog is FogExp2 ) {
+    } else if ( fog is FogExp2 ) {
 
-			uniforms["fogDensity"].value = fog.density;
+      uniforms["fogDensity"].value = fog.density;
 
-		}
+    }
 
-	}
+  }
 
-	refreshUniformsPhong ( Map<String, Uniform> uniforms, MeshPhongMaterial material ) {
+  refreshUniformsPhong ( Map<String, Uniform> uniforms, MeshPhongMaterial material ) {
 
-		uniforms["shininess"].value = material.shininess;
+    uniforms["shininess"].value = material.shininess;
 
-		if ( gammaInput ) {
+    if ( gammaInput ) {
 
-			uniforms["ambient"].value.copyGammaToLinear( material.ambient );
-			uniforms["emissive"].value.copyGammaToLinear( material.emissive );
-			uniforms["specular"].value.copyGammaToLinear( material.specular );
+      uniforms["ambient"].value.copyGammaToLinear( material.ambient );
+      uniforms["emissive"].value.copyGammaToLinear( material.emissive );
+      uniforms["specular"].value.copyGammaToLinear( material.specular );
 
-		} else {
+    } else {
 
-			uniforms["ambient"].value = material.ambient;
-			uniforms["emissive"].value = material.emissive;
-			uniforms["specular"].value = material.specular;
+      uniforms["ambient"].value = material.ambient;
+      uniforms["emissive"].value = material.emissive;
+      uniforms["specular"].value = material.specular;
 
-		}
+    }
 
-		if ( material.wrapAround ) {
+    if ( material.wrapAround ) {
 
-			uniforms["wrapRGB"].value.copy( material.wrapRGB );
+      uniforms["wrapRGB"].value.copy( material.wrapRGB );
 
-		}
+    }
 
-	}
+  }
 
-	refreshUniformsLambert ( Map<String, Uniform> uniforms, MeshLambertMaterial material ) {
+  refreshUniformsLambert ( Map<String, Uniform> uniforms, MeshLambertMaterial material ) {
 
-		if ( gammaInput ) {
+    if ( gammaInput ) {
 
-			uniforms["ambient"].value.copyGammaToLinear( material.ambient );
-			uniforms["emissive"].value.copyGammaToLinear( material.emissive );
+      uniforms["ambient"].value.copyGammaToLinear( material.ambient );
+      uniforms["emissive"].value.copyGammaToLinear( material.emissive );
 
-		} else {
+    } else {
 
-			uniforms["ambient"].value = material.ambient;
-			uniforms["emissive"].value = material.emissive;
+      uniforms["ambient"].value = material.ambient;
+      uniforms["emissive"].value = material.emissive;
 
-		}
+    }
 
-		if ( material.wrapAround ) {
+    if ( material.wrapAround ) {
 
-			uniforms["wrapRGB"].value.copy( material.wrapRGB );
+      uniforms["wrapRGB"].value.copy( material.wrapRGB );
 
-		}
+    }
 
-	}
+  }
 
-	refreshUniformsLights ( Map<String, Uniform> uniforms, Map lights ) {
+  refreshUniformsLights ( Map<String, Uniform> uniforms, Map lights ) {
 
-		uniforms["ambientLightColor"].value = lights["ambient"];
+    uniforms["ambientLightColor"].value = lights["ambient"];
 
-		uniforms["directionalLightColor"].value = lights["directional"]["colors"];
-		uniforms["directionalLightDirection"].value = lights["directional"]["positions"];
+    uniforms["directionalLightColor"].value = lights["directional"]["colors"];
+    uniforms["directionalLightDirection"].value = lights["directional"]["positions"];
 
-		uniforms["pointLightColor"].value = lights["point"]["colors"];
-		uniforms["pointLightPosition"].value = lights["point"]["positions"];
-		uniforms["pointLightDistance"].value = lights["point"]["distances"];
+    uniforms["pointLightColor"].value = lights["point"]["colors"];
+    uniforms["pointLightPosition"].value = lights["point"]["positions"];
+    uniforms["pointLightDistance"].value = lights["point"]["distances"];
 
-		uniforms["spotLightColor"].value = lights["spot"]["colors"];
-		uniforms["spotLightPosition"].value = lights["spot"]["positions"];
-		uniforms["spotLightDistance"].value = lights["spot"]["distances"];
-		uniforms["spotLightDirection"].value = lights["spot"]["directions"];
-		uniforms["spotLightAngleCos"].value = lights["spot"]["anglesCos"];
-		uniforms["spotLightExponent"].value = lights["spot"]["exponents"];
+    uniforms["spotLightColor"].value = lights["spot"]["colors"];
+    uniforms["spotLightPosition"].value = lights["spot"]["positions"];
+    uniforms["spotLightDistance"].value = lights["spot"]["distances"];
+    uniforms["spotLightDirection"].value = lights["spot"]["directions"];
+    uniforms["spotLightAngleCos"].value = lights["spot"]["anglesCos"];
+    uniforms["spotLightExponent"].value = lights["spot"]["exponents"];
 
-		uniforms["hemisphereLightSkyColor"].value = lights["hemi"]["skyColors"];
-		uniforms["hemisphereLightGroundColor"].value = lights["hemi"]["groundColors"];
-		uniforms["hemisphereLightDirection"].value = lights["hemi"]["positions"];
-	}
+    uniforms["hemisphereLightSkyColor"].value = lights["hemi"]["skyColors"];
+    uniforms["hemisphereLightGroundColor"].value = lights["hemi"]["groundColors"];
+    uniforms["hemisphereLightDirection"].value = lights["hemi"]["positions"];
+  }
 
-	refreshUniformsShadow ( Map<String, Uniform> uniforms, lights ) {
+  refreshUniformsShadow ( Map<String, Uniform> uniforms, lights ) {
 
-		if ( uniforms.containsKey("shadowMatrix") ) {
+    if ( uniforms.containsKey("shadowMatrix") ) {
 
-			var j = 0;
+      var j = 0;
 
-			for ( var i = 0, il = lights.length; i < il; i ++ ) {
+      for ( var i = 0, il = lights.length; i < il; i ++ ) {
 
-				var light = lights[ i ];
+        var light = lights[ i ];
 
-				if ( ! light.castShadow ) continue;
+        if ( ! light.castShadow ) continue;
 
-				if ( light is SpotLight || ( light is DirectionalLight && ! light.shadowCascade ) ) {
+        if ( light is SpotLight || ( light is DirectionalLight && ! light.shadowCascade ) ) {
 
-				  // Grow the arrays
-				  if (uniforms["shadowMap"].value.length < j + 1) {
-				    uniforms["shadowMap"].value.length = j + 1;
-				    uniforms["shadowMapSize"].value.length = j + 1;
-				    uniforms["shadowMatrix"].value.length = j + 1;
-				    uniforms["shadowDarkness"].value.length = j + 1;
-				    uniforms["shadowBias"].value.length = j + 1;
-				  }
+          // Grow the arrays
+          if (uniforms["shadowMap"].value.length < j + 1) {
+            uniforms["shadowMap"].value.length = j + 1;
+            uniforms["shadowMapSize"].value.length = j + 1;
+            uniforms["shadowMatrix"].value.length = j + 1;
+            uniforms["shadowDarkness"].value.length = j + 1;
+            uniforms["shadowBias"].value.length = j + 1;
+          }
 
-					uniforms["shadowMap"].value[ j ] = light.shadowMap;
-					uniforms["shadowMapSize"].value[ j ] = light.shadowMapSize;
+          uniforms["shadowMap"].value[ j ] = light.shadowMap;
+          uniforms["shadowMapSize"].value[ j ] = light.shadowMapSize;
 
-					uniforms["shadowMatrix"].value[ j ] = light.shadowMatrix;
+          uniforms["shadowMatrix"].value[ j ] = light.shadowMatrix;
 
-					uniforms["shadowDarkness"].value[ j ] = light.shadowDarkness;
-					uniforms["shadowBias"].value[ j ] = light.shadowBias;
+          uniforms["shadowDarkness"].value[ j ] = light.shadowDarkness;
+          uniforms["shadowBias"].value[ j ] = light.shadowBias;
 
-					j ++;
+          j ++;
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	// Uniforms (load to GPU)
+  // Uniforms (load to GPU)
 
-	loadUniformsMatrices ( Map uniforms, Object3D object ) {
+  loadUniformsMatrices ( Map uniforms, Object3D object ) {
 
-		_gl.uniformMatrix4fv( uniforms["modelViewMatrix"], false, object._modelViewMatrix.storage );
+    _gl.uniformMatrix4fv( uniforms["modelViewMatrix"], false, object._modelViewMatrix.storage );
 
-		if ( uniforms["normalMatrix"] != null ) {
+    if ( uniforms["normalMatrix"] != null ) {
 
-			_gl.uniformMatrix3fv( uniforms["normalMatrix"], false, object._normalMatrix.storage );
+      _gl.uniformMatrix3fv( uniforms["normalMatrix"], false, object._normalMatrix.storage );
 
-		}
+    }
 
-	}
+  }
 
-	int getTextureUnit() {
+  int getTextureUnit() {
 
     var unit = _usedTextureUnits;
 
@@ -5622,254 +5622,254 @@ class WebGLRenderer implements Renderer {
 
   }
 
-	loadUniformsGeneric ( Program program, List<List<Uniform>> uniforms ) {
+  loadUniformsGeneric ( Program program, List<List<Uniform>> uniforms ) {
 
-		var uniform, value, type, location, texture, textureUnit, i, il, j, jl, offset;
+    var uniform, value, type, location, texture, textureUnit, i, il, j, jl, offset;
 
-		jl = uniforms.length;
-		for ( j = 0; j < jl; j ++ ) {
+    jl = uniforms.length;
+    for ( j = 0; j < jl; j ++ ) {
 
-			location = program.uniforms[ uniforms[ j ][ 1 ] ];
-			if ( location == null ) continue;
+      location = program.uniforms[ uniforms[ j ][ 1 ] ];
+      if ( location == null ) continue;
 
-			uniform = uniforms[ j ][ 0 ];
+      uniform = uniforms[ j ][ 0 ];
 
-			type = uniform.type;
-			value = uniform.typedValue; // Get the value properly typed
+      type = uniform.type;
+      value = uniform.typedValue; // Get the value properly typed
 
-			if ( type == "i" ) { // single integer
+      if ( type == "i" ) { // single integer
 
-				_gl.uniform1i( location, value );
+        _gl.uniform1i( location, value );
 
-			} else if ( type == "f" ) { // single float
+      } else if ( type == "f" ) { // single float
 
-				_gl.uniform1f( location, value );
+        _gl.uniform1f( location, value );
 
-			} else if ( type == "v2" ) { // single THREE.Vector2
+      } else if ( type == "v2" ) { // single THREE.Vector2
 
-				_gl.uniform2f( location, value.x, value.y );
+        _gl.uniform2f( location, value.x, value.y );
 
-			} else if ( type == "v3" ) { // single THREE.Vector3
+      } else if ( type == "v3" ) { // single THREE.Vector3
 
-				_gl.uniform3f( location, value.x, value.y, value.z );
+        _gl.uniform3f( location, value.x, value.y, value.z );
 
-			} else if ( type == "v4" ) { // single THREE.Vector4
+      } else if ( type == "v4" ) { // single THREE.Vector4
 
-				_gl.uniform4f( location, value.x, value.y, value.z, value.w );
+        _gl.uniform4f( location, value.x, value.y, value.z, value.w );
 
-			} else if ( type == "c" ) { // single THREE.Color
+      } else if ( type == "c" ) { // single THREE.Color
 
-				_gl.uniform3f( location, value.r, value.g, value.b );
+        _gl.uniform3f( location, value.r, value.g, value.b );
 
-			} else if ( type == "iv1" ) { // flat array of integers (JS or typed array)
+      } else if ( type == "iv1" ) { // flat array of integers (JS or typed array)
 
-				_gl.uniform1iv( location, value );
+        _gl.uniform1iv( location, value );
 
-			} else if ( type == "iv" ) { // flat array of integers with 3 x N size (JS or typed array)
+      } else if ( type == "iv" ) { // flat array of integers with 3 x N size (JS or typed array)
 
-				_gl.uniform3iv( location, value );
+        _gl.uniform3iv( location, value );
 
-			} else if ( type == "fv1" ) { // flat array of floats (JS or typed array)
+      } else if ( type == "fv1" ) { // flat array of floats (JS or typed array)
 
-				_gl.uniform1fv( location, value );
+        _gl.uniform1fv( location, value );
 
-			} else if ( type == "fv" ) { // flat array of floats with 3 x N size (JS or typed array)
+      } else if ( type == "fv" ) { // flat array of floats with 3 x N size (JS or typed array)
 
-				_gl.uniform3fv( location, value );
+        _gl.uniform3fv( location, value );
 
-			} else if ( type == "v2v" ) { // array of THREE.Vector2
+      } else if ( type == "v2v" ) { // array of THREE.Vector2
 
-				_gl.uniform2fv( location, value );
+        _gl.uniform2fv( location, value );
 
-			} else if ( type == "v3v" ) { // array of THREE.Vector3
+      } else if ( type == "v3v" ) { // array of THREE.Vector3
 
-				_gl.uniform3fv( location, value );
+        _gl.uniform3fv( location, value );
 
-			} else if ( type == "v4v" ) { // array of THREE.Vector4
+      } else if ( type == "v4v" ) { // array of THREE.Vector4
 
-				_gl.uniform4fv( location, value );
+        _gl.uniform4fv( location, value );
 
-			} else if ( type == "m2") { // single THREE.Matrix2
+      } else if ( type == "m2") { // single THREE.Matrix2
 
-				_gl.uniformMatrix2fv( location, false, value );
+        _gl.uniformMatrix2fv( location, false, value );
 
-			} else if ( type == "m3") { // single THREE.Matrix3
+      } else if ( type == "m3") { // single THREE.Matrix3
 
-				_gl.uniformMatrix3fv( location, false, value );
+        _gl.uniformMatrix3fv( location, false, value );
 
-			} else if ( type == "m4") { // single THREE.Matrix4
+      } else if ( type == "m4") { // single THREE.Matrix4
 
-				_gl.uniformMatrix4fv( location, false, value );
+        _gl.uniformMatrix4fv( location, false, value );
 
-			} else if ( type == "m4v" ) { // array of THREE.Matrix4
+      } else if ( type == "m4v" ) { // array of THREE.Matrix4
 
-				_gl.uniformMatrix4fv( location, false, value );
+        _gl.uniformMatrix4fv( location, false, value );
 
-			} else if ( type == "t" ) { // single THREE.Texture (2d or cube)
+      } else if ( type == "t" ) { // single THREE.Texture (2d or cube)
 
-	       texture = uniform.value;
-	       textureUnit = getTextureUnit();
+         texture = uniform.value;
+         textureUnit = getTextureUnit();
 
-				_gl.uniform1i( location, textureUnit );
+        _gl.uniform1i( location, textureUnit );
 
-				if ( texture == null ) continue;
+        if ( texture == null ) continue;
 
-				if ( (texture.image is List) && texture.image.length == 6 ) {
+        if ( (texture.image is List) && texture.image.length == 6 ) {
 
-					setCubeTexture( texture, textureUnit );
+          setCubeTexture( texture, textureUnit );
 
-				} else if ( texture is WebGLRenderTargetCube ) {
+        } else if ( texture is WebGLRenderTargetCube ) {
 
-					setCubeTextureDynamic( texture, textureUnit );
+          setCubeTextureDynamic( texture, textureUnit );
 
-				} else {
+        } else {
 
-					setTexture( texture, textureUnit );
+          setTexture( texture, textureUnit );
 
-				}
+        }
 
-			} else if ( type == "tv" ) { // array of THREE.Texture (2d)
+      } else if ( type == "tv" ) { // array of THREE.Texture (2d)
 
-			  List<Texture> textures = uniform.value;
+        List<Texture> textures = uniform.value;
 
-			  uniform._array = new Int32List.fromList(textures.map((_) => getTextureUnit()).toList());
+        uniform._array = new Int32List.fromList(textures.map((_) => getTextureUnit()).toList());
 
-				_gl.uniform1iv( location, uniform._array );
+        _gl.uniform1iv( location, uniform._array );
 
-				il = textures.length;
-				for( i = 0; i < il; i ++ ) {
+        il = textures.length;
+        for( i = 0; i < il; i ++ ) {
 
-					texture = uniform.value[ i ];
+          texture = uniform.value[ i ];
           textureUnit = uniform._array[i];
 
-					if ( texture == null) continue;
+          if ( texture == null) continue;
 
-					setTexture( texture, textureUnit );
+          setTexture( texture, textureUnit );
 
-				}
+        }
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	setColorGamma( List<double> array, int offset, Color color, double intensitySq ) {
+  setColorGamma( List<double> array, int offset, Color color, double intensitySq ) {
 
-		array[ offset ]     = color.r * color.r * intensitySq;
-		array[ offset + 1 ] = color.g * color.g * intensitySq;
-		array[ offset + 2 ] = color.b * color.b * intensitySq;
+    array[ offset ]     = color.r * color.r * intensitySq;
+    array[ offset + 1 ] = color.g * color.g * intensitySq;
+    array[ offset + 2 ] = color.b * color.b * intensitySq;
 
-	}
+  }
 
-	setColorLinear( List<double> array, int offset, Color color, double intensity ) {
+  setColorLinear( List<double> array, int offset, Color color, double intensity ) {
 
-		array[ offset ]     = color.r * intensity;
-		array[ offset + 1 ] = color.g * intensity;
-		array[ offset + 2 ] = color.b * intensity;
+    array[ offset ]     = color.r * intensity;
+    array[ offset + 1 ] = color.g * intensity;
+    array[ offset + 2 ] = color.b * intensity;
 
-	}
+  }
 
-	setupMatrices ( Object3D object, Camera camera ) {
+  setupMatrices ( Object3D object, Camera camera ) {
 
-		object._modelViewMatrix = camera.matrixWorldInverse * object.matrixWorld;
+    object._modelViewMatrix = camera.matrixWorldInverse * object.matrixWorld;
 
-		object._normalMatrix = calcInverse( object._modelViewMatrix );
-		object._normalMatrix.transpose();
+    object._normalMatrix = calcInverse( object._modelViewMatrix );
+    object._normalMatrix.transpose();
 
-	}
+  }
 
-	setupLights ( Program program, List<Light> lights ) {
+  setupLights ( Program program, List<Light> lights ) {
 
-		var l, ll, light, n,
-		r = 0.0, g = 0.0, b = 0.0,
-		color, skyColor, groundColor,
-		intensity,  intensitySq,
-		position,
-		distance,
+    var l, ll, light, n,
+    r = 0.0, g = 0.0, b = 0.0,
+    color, skyColor, groundColor,
+    intensity,  intensitySq,
+    position,
+    distance,
 
-		zlights = _lights;
+    zlights = _lights;
 
-		List dirColors = zlights["directional"]["colors"],
-		     dirPositions = zlights["directional"]["positions"],
+    List dirColors = zlights["directional"]["colors"],
+         dirPositions = zlights["directional"]["positions"],
 
-		     pointColors = zlights["point"]["colors"],
-		     pointPositions = zlights["point"]["positions"],
-      	 pointDistances = zlights["point"]["distances"],
+         pointColors = zlights["point"]["colors"],
+         pointPositions = zlights["point"]["positions"],
+         pointDistances = zlights["point"]["distances"],
 
-      	 spotColors = zlights["spot"]["colors"],
-      	 spotPositions = zlights["spot"]["positions"],
-      	 spotDistances = zlights["spot"]["distances"],
-      	 spotDirections = zlights["spot"]["directions"],
-      	 spotAnglesCos = zlights["spot"]["anglesCos"],
-      	 spotExponents = zlights["spot"]["exponents"],
+         spotColors = zlights["spot"]["colors"],
+         spotPositions = zlights["spot"]["positions"],
+         spotDistances = zlights["spot"]["distances"],
+         spotDirections = zlights["spot"]["directions"],
+         spotAnglesCos = zlights["spot"]["anglesCos"],
+         spotExponents = zlights["spot"]["exponents"],
 
-      	 hemiSkyColors = zlights["hemi"]["skyColors"],
-		 hemiGroundColors = zlights["hemi"]["groundColors"],
-		 hemiPositions = zlights["hemi"]["positions"];
+         hemiSkyColors = zlights["hemi"]["skyColors"],
+     hemiGroundColors = zlights["hemi"]["groundColors"],
+     hemiPositions = zlights["hemi"]["positions"];
 
-		var dirLength = 0,
-    		pointLength = 0,
-    		spotLength = 0,
-   			hemiLength = 0,
+    var dirLength = 0,
+        pointLength = 0,
+        spotLength = 0,
+         hemiLength = 0,
 
-			dirCount = 0,
-			pointCount = 0,
-			spotCount = 0,
-			hemiCount = 0,
+      dirCount = 0,
+      pointCount = 0,
+      spotCount = 0,
+      hemiCount = 0,
 
-    		dirOffset = 0,
-			pointOffset = 0,
-			spotOffset = 0,
-			hemiOffset = 0;
+        dirOffset = 0,
+      pointOffset = 0,
+      spotOffset = 0,
+      hemiOffset = 0;
 
-		ll = lights.length;
-		for ( l = 0; l < ll; l ++ ) {
+    ll = lights.length;
+    for ( l = 0; l < ll; l ++ ) {
 
-			light = lights[ l ];
+      light = lights[ l ];
 
-			// TODO - Setup proper interfaces for Light to avoid type checks
-			if ( (((light is DirectionalLight) || (light is SpotLight)) && (light as dynamic).onlyShadow) ||
-			    ! light.visible ) { continue;
-			}
+      // TODO - Setup proper interfaces for Light to avoid type checks
+      if ( (((light is DirectionalLight) || (light is SpotLight)) && (light as dynamic).onlyShadow) ||
+          ! light.visible ) { continue;
+      }
 
-			color = light.color;
+      color = light.color;
 
-			if ( (light is DirectionalLight) || (light is SpotLight) || (light is PointLight)) {
-  			intensity = (light as dynamic).intensity;
-  			distance = (light as dynamic).distance;
-			}
+      if ( (light is DirectionalLight) || (light is SpotLight) || (light is PointLight)) {
+        intensity = (light as dynamic).intensity;
+        distance = (light as dynamic).distance;
+      }
 
-			if ( light is AmbientLight ) {
+      if ( light is AmbientLight ) {
 
-				if ( ! light.visible ) continue;
+        if ( ! light.visible ) continue;
 
-				if ( gammaInput ) {
+        if ( gammaInput ) {
 
-					r += color.r * color.r;
-					g += color.g * color.g;
-					b += color.b * color.b;
+          r += color.r * color.r;
+          g += color.g * color.g;
+          b += color.b * color.b;
 
-				} else {
+        } else {
 
-					r += color.r;
-					g += color.g;
-					b += color.b;
+          r += color.r;
+          g += color.g;
+          b += color.b;
 
-				}
+        }
 
-			} else if ( light is DirectionalLight ) {
+      } else if ( light is DirectionalLight ) {
 
-				dirCount += 1;
+        dirCount += 1;
 
-				if ( ! light.visible ) continue;
+        if ( ! light.visible ) continue;
 
-				_direction = light.matrixWorld.getTranslation();
-				_vector3 = light.target.matrixWorld.getTranslation();
-				_direction.sub(_vector3);
-				_direction.normalize();
+        _direction = light.matrixWorld.getTranslation();
+        _vector3 = light.target.matrixWorld.getTranslation();
+        _direction.sub(_vector3);
+        _direction.normalize();
 
-				 // skip lights with undefined direction
+         // skip lights with undefined direction
         // these create troubles in OpenGL (making pixel black)
 
         if (_direction.x == 0 && _direction.y == 0 && _direction.z == 0)
@@ -5881,1605 +5881,1605 @@ class WebGLRenderer implements Renderer {
         dirColors.length = dirOffset + 3;
         dirPositions.length = dirOffset + 3;
 
-				dirPositions[ dirOffset ]     = _direction.x;
-				dirPositions[ dirOffset + 1 ] = _direction.y;
-				dirPositions[ dirOffset + 2 ] = _direction.z;
+        dirPositions[ dirOffset ]     = _direction.x;
+        dirPositions[ dirOffset + 1 ] = _direction.y;
+        dirPositions[ dirOffset + 2 ] = _direction.z;
 
 
-				if ( gammaInput ) {
+        if ( gammaInput ) {
 
-					setColorGamma( dirColors, dirOffset, color, intensity * intensity );
+          setColorGamma( dirColors, dirOffset, color, intensity * intensity );
 
-				} else {
+        } else {
 
-					setColorLinear( dirColors, dirOffset, color, intensity );
+          setColorLinear( dirColors, dirOffset, color, intensity );
 
-				}
+        }
 
-				dirLength += 1;
+        dirLength += 1;
 
-			} else if( light is PointLight ) {
+      } else if( light is PointLight ) {
 
-				pointCount += 1;
+        pointCount += 1;
 
-				if ( ! light.visible ) continue;
+        if ( ! light.visible ) continue;
 
-				pointOffset = pointLength * 3;
+        pointOffset = pointLength * 3;
 
-        		// Grow the lists
-				pointColors.length = pointOffset + 3;
-				pointPositions.length = pointOffset + 3;
+            // Grow the lists
+        pointColors.length = pointOffset + 3;
+        pointPositions.length = pointOffset + 3;
 
-				if ( gammaInput ) {
+        if ( gammaInput ) {
 
-					setColorGamma( pointColors, pointOffset, color, intensity * intensity );
+          setColorGamma( pointColors, pointOffset, color, intensity * intensity );
 
-				} else {
+        } else {
 
-					setColorLinear( pointColors, pointOffset, color, intensity );
+          setColorLinear( pointColors, pointOffset, color, intensity );
 
-				}
+        }
 
-				position = light.matrixWorld.getTranslation();
+        position = light.matrixWorld.getTranslation();
 
-				pointPositions[ pointOffset ]     = position.x;
-				pointPositions[ pointOffset + 1 ] = position.y;
-				pointPositions[ pointOffset + 2 ] = position.z;
+        pointPositions[ pointOffset ]     = position.x;
+        pointPositions[ pointOffset + 1 ] = position.y;
+        pointPositions[ pointOffset + 2 ] = position.z;
 
-				if (pointDistances==null) { pointDistances = new List(); pointDistances.add(0); }
-				while (pointDistances.length <= pointLength) {pointDistances.add(0);}
-				pointDistances[ pointLength ] = distance;
+        if (pointDistances==null) { pointDistances = new List(); pointDistances.add(0); }
+        while (pointDistances.length <= pointLength) {pointDistances.add(0);}
+        pointDistances[ pointLength ] = distance;
 
-				pointLength += 1;
+        pointLength += 1;
 
-			} else if( light is SpotLight ) {
+      } else if( light is SpotLight ) {
 
-				spotCount += 1;
+        spotCount += 1;
 
-				spotOffset = spotLength * 3;
+        spotOffset = spotLength * 3;
 
-				if ( ! light.visible ) continue;
+        if ( ! light.visible ) continue;
 
-        		// Grow the lists
-				spotColors.length = spotOffset + 3;
-				spotPositions.length = spotOffset + 3;
-				spotDirections.length = spotOffset + 3;
-				spotDistances.length = spotLength + 1;
+            // Grow the lists
+        spotColors.length = spotOffset + 3;
+        spotPositions.length = spotOffset + 3;
+        spotDirections.length = spotOffset + 3;
+        spotDistances.length = spotLength + 1;
 
-				if ( gammaInput ) {
+        if ( gammaInput ) {
 
-					setColorGamma( spotColors, spotOffset, color, intensity * intensity );
+          setColorGamma( spotColors, spotOffset, color, intensity * intensity );
 
-				} else {
+        } else {
 
-					setColorLinear( spotColors, spotOffset, color, intensity );
+          setColorLinear( spotColors, spotOffset, color, intensity );
 
-				}
+        }
 
-				position = light.matrixWorld.getTranslation();
+        position = light.matrixWorld.getTranslation();
 
-				spotPositions[ spotOffset ]     = position.x;
-				spotPositions[ spotOffset + 1 ] = position.y;
-				spotPositions[ spotOffset + 2 ] = position.z;
+        spotPositions[ spotOffset ]     = position.x;
+        spotPositions[ spotOffset + 1 ] = position.y;
+        spotPositions[ spotOffset + 2 ] = position.z;
 
-				spotDistances[ spotLength ] = distance;
+        spotDistances[ spotLength ] = distance;
 
-				_direction.setFrom( position );
-				_direction.sub( light.target.matrixWorld.getTranslation() );
-				_direction.normalize();
+        _direction.setFrom( position );
+        _direction.sub( light.target.matrixWorld.getTranslation() );
+        _direction.normalize();
 
-				spotDirections[ spotOffset ]     = _direction.x;
-				spotDirections[ spotOffset + 1 ] = _direction.y;
-				spotDirections[ spotOffset + 2 ] = _direction.z;
+        spotDirections[ spotOffset ]     = _direction.x;
+        spotDirections[ spotOffset + 1 ] = _direction.y;
+        spotDirections[ spotOffset + 2 ] = _direction.z;
 
-				// grow the arrays
-				spotAnglesCos.length = spotLength + 1;
-				spotExponents.length = spotLength + 1;
+        // grow the arrays
+        spotAnglesCos.length = spotLength + 1;
+        spotExponents.length = spotLength + 1;
 
-				spotAnglesCos[ spotLength ] = Math.cos( light.angle );
-				spotExponents[ spotLength ] = light.exponent;
+        spotAnglesCos[ spotLength ] = Math.cos( light.angle );
+        spotExponents[ spotLength ] = light.exponent;
 
-				spotLength += 1;
+        spotLength += 1;
 
-			} else if ( light is HemisphereLight ) {
+      } else if ( light is HemisphereLight ) {
 
-				hemiCount += 1;
+        hemiCount += 1;
 
-				if ( ! light.visible ) continue;
+        if ( ! light.visible ) continue;
 
-				position = light.matrixWorld.getTranslation();
-				_direction.setFrom( position );
-				_direction.normalize();
+        position = light.matrixWorld.getTranslation();
+        _direction.setFrom( position );
+        _direction.normalize();
 
-				// skip lights with undefined direction
-				// these create troubles in OpenGL (making pixel black)
+        // skip lights with undefined direction
+        // these create troubles in OpenGL (making pixel black)
 
-				if ( _direction.x == 0 && _direction.y == 0 && _direction.z == 0 ) continue;
+        if ( _direction.x == 0 && _direction.y == 0 && _direction.z == 0 ) continue;
 
-				hemiOffset = hemiLength * 3;
+        hemiOffset = hemiLength * 3;
 
-				// Grow the lists
-				hemiSkyColors.length = hemiOffset + 3;
-				hemiGroundColors.length = hemiOffset + 3;
-				hemiPositions.length = hemiOffset + 3;
+        // Grow the lists
+        hemiSkyColors.length = hemiOffset + 3;
+        hemiGroundColors.length = hemiOffset + 3;
+        hemiPositions.length = hemiOffset + 3;
 
-				hemiPositions[ hemiOffset ]     = _direction.x;
-				hemiPositions[ hemiOffset + 1 ] = _direction.y;
-				hemiPositions[ hemiOffset + 2 ] = _direction.z;
+        hemiPositions[ hemiOffset ]     = _direction.x;
+        hemiPositions[ hemiOffset + 1 ] = _direction.y;
+        hemiPositions[ hemiOffset + 2 ] = _direction.z;
 
-				skyColor = light.color;
-				groundColor = light.groundColor;
+        skyColor = light.color;
+        groundColor = light.groundColor;
 
-				if ( gammaInput ) {
+        if ( gammaInput ) {
 
-					intensitySq = intensity * intensity;
+          intensitySq = intensity * intensity;
 
-					setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensitySq );
-					setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensitySq );
+          setColorGamma( hemiSkyColors, hemiOffset, skyColor, intensitySq );
+          setColorGamma( hemiGroundColors, hemiOffset, groundColor, intensitySq );
 
-				} else {
+        } else {
 
-					setColorLinear( hemiSkyColors, hemiOffset, skyColor, intensity );
-					setColorLinear( hemiGroundColors, hemiOffset, groundColor, intensity );
+          setColorLinear( hemiSkyColors, hemiOffset, skyColor, intensity );
+          setColorLinear( hemiGroundColors, hemiOffset, groundColor, intensity );
 
-				}
+        }
 
-				hemiLength += 1;
+        hemiLength += 1;
 
-			}
+      }
 
-		}
+    }
 
-		// null eventual remains from removed lights
-		// (this is to avoid if in shader)
+    // null eventual remains from removed lights
+    // (this is to avoid if in shader)
 
-		ll =  Math.max( dirColors.length, dirCount * 3 );
-		for ( l = dirLength * 3; l < ll; l ++ ) dirColors[ l ] = 0.0;
-		ll = Math.max( pointColors.length, pointCount * 3 );
-		for ( l = pointLength * 3; l < ll; l ++ ) pointColors[ l ] = 0.0;
-		ll = Math.max( spotColors.length, spotCount * 3 );
-		for ( l = spotLength * 3; l < ll; l ++ ) spotColors[ l ] = 0.0;
-		ll = Math.max( hemiSkyColors.length, hemiCount * 3 );
-		for ( l = hemiLength * 3; l < ll; l ++ ) hemiSkyColors[ l ] = 0.0;
-		ll = Math.max( hemiGroundColors.length, hemiCount * 3 );
-		for ( l = hemiLength * 3; l < ll; l ++ ) hemiGroundColors[ l ] = 0.0;
+    ll =  Math.max( dirColors.length, dirCount * 3 );
+    for ( l = dirLength * 3; l < ll; l ++ ) dirColors[ l ] = 0.0;
+    ll = Math.max( pointColors.length, pointCount * 3 );
+    for ( l = pointLength * 3; l < ll; l ++ ) pointColors[ l ] = 0.0;
+    ll = Math.max( spotColors.length, spotCount * 3 );
+    for ( l = spotLength * 3; l < ll; l ++ ) spotColors[ l ] = 0.0;
+    ll = Math.max( hemiSkyColors.length, hemiCount * 3 );
+    for ( l = hemiLength * 3; l < ll; l ++ ) hemiSkyColors[ l ] = 0.0;
+    ll = Math.max( hemiGroundColors.length, hemiCount * 3 );
+    for ( l = hemiLength * 3; l < ll; l ++ ) hemiGroundColors[ l ] = 0.0;
 
-		zlights["directional"]["length"] = dirLength;
-		zlights["point"]["length"] = pointLength;
-		zlights["spot"]["length"] = spotLength;
-		zlights["hemi"]["length"] = hemiLength;
+    zlights["directional"]["length"] = dirLength;
+    zlights["point"]["length"] = pointLength;
+    zlights["spot"]["length"] = spotLength;
+    zlights["hemi"]["length"] = hemiLength;
 
-		zlights["ambient"][ 0 ] = r;
-		zlights["ambient"][ 1 ] = g;
-		zlights["ambient"][ 2 ] = b;
+    zlights["ambient"][ 0 ] = r;
+    zlights["ambient"][ 1 ] = g;
+    zlights["ambient"][ 2 ] = b;
 
-	}
+  }
 
-	// GL state setting
+  // GL state setting
 
-	setFaceCulling( int cullFace, int frontFaceDirection ) {
+  setFaceCulling( int cullFace, int frontFaceDirection ) {
 
-		if ( cullFace == CullFaceNone ) {
+    if ( cullFace == CullFaceNone ) {
 
-			_gl.disable( gl.CULL_FACE );
+      _gl.disable( gl.CULL_FACE );
 
-		} else {
+    } else {
 
-			if ( frontFaceDirection == FrontFaceDirectionCW ) {
+      if ( frontFaceDirection == FrontFaceDirectionCW ) {
 
-				_gl.frontFace( gl.CW );
+        _gl.frontFace( gl.CW );
 
-			} else {
+      } else {
 
-				_gl.frontFace( gl.CCW );
+        _gl.frontFace( gl.CCW );
 
-			}
+      }
 
-			if ( cullFace == CullFaceBack ) {
+      if ( cullFace == CullFaceBack ) {
 
-				_gl.cullFace( gl.BACK );
+        _gl.cullFace( gl.BACK );
 
-			} else if ( cullFace == CullFaceFront ) {
+      } else if ( cullFace == CullFaceFront ) {
 
-				_gl.cullFace( gl.FRONT );
+        _gl.cullFace( gl.FRONT );
 
-			} else {
+      } else {
 
-				_gl.cullFace( gl.FRONT_AND_BACK );
+        _gl.cullFace( gl.FRONT_AND_BACK );
 
-			}
+      }
 
-			_gl.enable( gl.CULL_FACE );
+      _gl.enable( gl.CULL_FACE );
 
-		}
+    }
 
-	}
+  }
 
-	setMaterialFaces( Material material ) {
+  setMaterialFaces( Material material ) {
 
-		var doubleSided = material.side == DoubleSide;
-		var flipSided = material.side == BackSide;
+    var doubleSided = material.side == DoubleSide;
+    var flipSided = material.side == BackSide;
 
-		if ( _oldDoubleSided != doubleSided ) {
+    if ( _oldDoubleSided != doubleSided ) {
 
-			if ( doubleSided ) {
+      if ( doubleSided ) {
 
-				_gl.disable( gl.CULL_FACE );
+        _gl.disable( gl.CULL_FACE );
 
-			} else {
+      } else {
 
-				_gl.enable( gl.CULL_FACE );
+        _gl.enable( gl.CULL_FACE );
 
-			}
+      }
 
-			_oldDoubleSided = doubleSided;
+      _oldDoubleSided = doubleSided;
 
-		}
+    }
 
-		if ( _oldFlipSided != flipSided ) {
+    if ( _oldFlipSided != flipSided ) {
 
-			if ( flipSided ) {
+      if ( flipSided ) {
 
-				_gl.frontFace( gl.CW );
+        _gl.frontFace( gl.CW );
 
-			} else {
+      } else {
 
-				_gl.frontFace( gl.CCW );
+        _gl.frontFace( gl.CCW );
 
-			}
+      }
 
-			_oldFlipSided = flipSided;
+      _oldFlipSided = flipSided;
 
-		}
+    }
 
-	}
+  }
 
-	setDepthTest( bool depthTest ) {
+  setDepthTest( bool depthTest ) {
 
-		if ( _oldDepthTest != depthTest ) {
+    if ( _oldDepthTest != depthTest ) {
 
-			if ( depthTest ) {
+      if ( depthTest ) {
 
-				_gl.enable( gl.DEPTH_TEST );
+        _gl.enable( gl.DEPTH_TEST );
 
-			} else {
+      } else {
 
-				_gl.disable( gl.DEPTH_TEST );
+        _gl.disable( gl.DEPTH_TEST );
 
-			}
+      }
 
-			_oldDepthTest = depthTest;
+      _oldDepthTest = depthTest;
 
-		}
+    }
 
-	}
+  }
 
-	setDepthWrite( bool depthWrite ) {
+  setDepthWrite( bool depthWrite ) {
 
-		if ( _oldDepthWrite != depthWrite ) {
+    if ( _oldDepthWrite != depthWrite ) {
 
-			_gl.depthMask( depthWrite );
-			_oldDepthWrite = depthWrite;
+      _gl.depthMask( depthWrite );
+      _oldDepthWrite = depthWrite;
 
-		}
+    }
 
-	}
+  }
 
-	setLineWidth ( num width ) {
+  setLineWidth ( num width ) {
 
-		if ( width != _oldLineWidth ) {
+    if ( width != _oldLineWidth ) {
 
-			_gl.lineWidth( width );
+      _gl.lineWidth( width );
 
-			_oldLineWidth = width;
+      _oldLineWidth = width;
 
-		}
+    }
 
-	}
+  }
 
-	setPolygonOffset ( bool polygonoffset, num factor, num units ) {
+  setPolygonOffset ( bool polygonoffset, num factor, num units ) {
 
-		if ( _oldPolygonOffset != polygonoffset ) {
+    if ( _oldPolygonOffset != polygonoffset ) {
 
-			if ( polygonoffset ) {
+      if ( polygonoffset ) {
 
-				_gl.enable( gl.POLYGON_OFFSET_FILL );
+        _gl.enable( gl.POLYGON_OFFSET_FILL );
 
-			} else {
+      } else {
 
-				_gl.disable( gl.POLYGON_OFFSET_FILL );
+        _gl.disable( gl.POLYGON_OFFSET_FILL );
 
-			}
+      }
 
-			_oldPolygonOffset = polygonoffset;
+      _oldPolygonOffset = polygonoffset;
 
-		}
+    }
 
-		if ( polygonoffset && ( _oldPolygonOffsetFactor != factor || _oldPolygonOffsetUnits != units ) ) {
+    if ( polygonoffset && ( _oldPolygonOffsetFactor != factor || _oldPolygonOffsetUnits != units ) ) {
 
-			_gl.polygonOffset( factor, units );
+      _gl.polygonOffset( factor, units );
 
-			_oldPolygonOffsetFactor = factor;
-			_oldPolygonOffsetUnits = units;
+      _oldPolygonOffsetFactor = factor;
+      _oldPolygonOffsetUnits = units;
 
-		}
+    }
 
-	}
+  }
 
-	setBlending( int blending, [blendEquation, blendSrc, blendDst] ) {
+  setBlending( int blending, [blendEquation, blendSrc, blendDst] ) {
 
-		if ( blending != _oldBlending ) {
+    if ( blending != _oldBlending ) {
 
-			if ( blending == NoBlending ) {
+      if ( blending == NoBlending ) {
 
-				_gl.disable( gl.BLEND );
+        _gl.disable( gl.BLEND );
 
-			} else if ( blending == AdditiveBlending ) {
+      } else if ( blending == AdditiveBlending ) {
 
-				_gl.enable( gl.BLEND );
-				_gl.blendEquation( gl.FUNC_ADD );
-				_gl.blendFunc( gl.SRC_ALPHA, gl.ONE );
+        _gl.enable( gl.BLEND );
+        _gl.blendEquation( gl.FUNC_ADD );
+        _gl.blendFunc( gl.SRC_ALPHA, gl.ONE );
 
-			} else if ( blending == SubtractiveBlending ) {
+      } else if ( blending == SubtractiveBlending ) {
 
-				// TODO: Find blendFuncSeparate() combination
-				_gl.enable( gl.BLEND );
-				_gl.blendEquation( gl.FUNC_ADD );
-				_gl.blendFunc( gl.ZERO, gl.ONE_MINUS_SRC_COLOR );
+        // TODO: Find blendFuncSeparate() combination
+        _gl.enable( gl.BLEND );
+        _gl.blendEquation( gl.FUNC_ADD );
+        _gl.blendFunc( gl.ZERO, gl.ONE_MINUS_SRC_COLOR );
 
-			} else if ( blending == MultiplyBlending ) {
+      } else if ( blending == MultiplyBlending ) {
 
-				// TODO: Find blendFuncSeparate() combination
-				_gl.enable( gl.BLEND );
-				_gl.blendEquation( gl.FUNC_ADD );
-				_gl.blendFunc( gl.ZERO, gl.SRC_COLOR );
+        // TODO: Find blendFuncSeparate() combination
+        _gl.enable( gl.BLEND );
+        _gl.blendEquation( gl.FUNC_ADD );
+        _gl.blendFunc( gl.ZERO, gl.SRC_COLOR );
 
-			} else if ( blending == CustomBlending ) {
+      } else if ( blending == CustomBlending ) {
 
-				_gl.enable( gl.BLEND );
+        _gl.enable( gl.BLEND );
 
-			} else {
+      } else {
 
-				_gl.enable( gl.BLEND );
-				_gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
-				_gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
+        _gl.enable( gl.BLEND );
+        _gl.blendEquationSeparate( gl.FUNC_ADD, gl.FUNC_ADD );
+        _gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA );
 
-			}
+      }
 
-			_oldBlending = blending;
+      _oldBlending = blending;
 
-		}
+    }
 
-		if ( blending == CustomBlending ) {
+    if ( blending == CustomBlending ) {
 
-			if ( blendEquation != _oldBlendEquation ) {
+      if ( blendEquation != _oldBlendEquation ) {
 
-				_gl.blendEquation( paramThreeToGL( blendEquation ) );
+        _gl.blendEquation( paramThreeToGL( blendEquation ) );
 
-				_oldBlendEquation = blendEquation;
+        _oldBlendEquation = blendEquation;
 
-			}
+      }
 
-			if ( blendSrc != _oldBlendSrc || blendDst != _oldBlendDst ) {
+      if ( blendSrc != _oldBlendSrc || blendDst != _oldBlendDst ) {
 
-				_gl.blendFunc( paramThreeToGL( blendSrc ), paramThreeToGL( blendDst ) );
+        _gl.blendFunc( paramThreeToGL( blendSrc ), paramThreeToGL( blendDst ) );
 
-				_oldBlendSrc = blendSrc;
-				_oldBlendDst = blendDst;
+        _oldBlendSrc = blendSrc;
+        _oldBlendDst = blendDst;
 
-			}
+      }
 
-		} else {
+    } else {
 
-			_oldBlendEquation = null;
-			_oldBlendSrc = null;
-			_oldBlendDst = null;
+      _oldBlendEquation = null;
+      _oldBlendSrc = null;
+      _oldBlendDst = null;
 
-		}
+    }
 
-	}
+  }
 
-	// Defines
+  // Defines
 
-	String generateDefines ( Map defines ) {
+  String generateDefines ( Map defines ) {
 
-		var chunk, chunks = [];
+    var chunk, chunks = [];
 
-		defines.forEach((d, value) {
+    defines.forEach((d, value) {
 
-			if ( value != false ) {
-				chunk = "#define $d $value";
-				chunks.add( chunk );
-			}
+      if ( value != false ) {
+        chunk = "#define $d $value";
+        chunks.add( chunk );
+      }
 
-		});
+    });
 
-		return chunks.join( "\n" );
+    return chunks.join( "\n" );
 
-	}
+  }
 
-	// Shaders
+  // Shaders
 
-	Program buildProgram( String shaderID, String fragmentShader, String vertexShader, Map uniforms, Map attributes, Map defines,
-	                      {	int maxDirLights: 0,
-					int maxPointLights: 0,
-					int maxSpotLights: 0,
-					int maxHemiLights: 0,
-					int maxShadows: 0,
-					int maxBones: 0,
-					Texture map: null,
-					Texture envMap: null,
-					bool lightMap: false,
-					bool bumpMap: false,
-					bool normalMap: false,
-					bool specularMap: false,
-					var vertexColors: NoColors,
-					bool skinning: false,
-					bool useVertexTexture: false,
-					num boneTextureWidth: null,
-					num boneTextureHeight: null,
-					bool morphTargets: false,
-					bool morphNormals: false,
-					bool perPixel: false,
-					bool wrapAround: false,
-					bool doubleSided: false,
-					bool flipSided: false,
-					bool shadowMapEnabled: false,
-					int shadowMapType,
-					bool shadowMapDebug: false,
-					bool shadowMapCascade: false,
-					bool sizeAttenuation: false,
-					Fog fog: null,
-		      bool useFog: false,
-		      bool fogExp: false,
-		      int maxMorphTargets: 8,
-		      int maxMorphNormals: 4,
-		      num alphaTest: 0,
-		      bool metal: false} ) {
+  Program buildProgram( String shaderID, String fragmentShader, String vertexShader, Map uniforms, Map attributes, Map defines,
+                        {  int maxDirLights: 0,
+          int maxPointLights: 0,
+          int maxSpotLights: 0,
+          int maxHemiLights: 0,
+          int maxShadows: 0,
+          int maxBones: 0,
+          Texture map: null,
+          Texture envMap: null,
+          bool lightMap: false,
+          bool bumpMap: false,
+          bool normalMap: false,
+          bool specularMap: false,
+          var vertexColors: NoColors,
+          bool skinning: false,
+          bool useVertexTexture: false,
+          num boneTextureWidth: null,
+          num boneTextureHeight: null,
+          bool morphTargets: false,
+          bool morphNormals: false,
+          bool perPixel: false,
+          bool wrapAround: false,
+          bool doubleSided: false,
+          bool flipSided: false,
+          bool shadowMapEnabled: false,
+          int shadowMapType,
+          bool shadowMapDebug: false,
+          bool shadowMapCascade: false,
+          bool sizeAttenuation: false,
+          Fog fog: null,
+          bool useFog: false,
+          bool fogExp: false,
+          int maxMorphTargets: 8,
+          int maxMorphNormals: 4,
+          num alphaTest: 0,
+          bool metal: false} ) {
 
-		var p, pl, glprogram, code;
-		var chunks = [];
+    var p, pl, glprogram, code;
+    var chunks = [];
 
-		// Generate code
+    // Generate code
 
-		if ( shaderID != null ) {
+    if ( shaderID != null ) {
 
-			chunks.add( shaderID );
+      chunks.add( shaderID );
 
-		} else {
+    } else {
 
-			chunks.add( fragmentShader );
-			chunks.add( vertexShader );
+      chunks.add( fragmentShader );
+      chunks.add( vertexShader );
 
-		}
+    }
 
-		defines.forEach((d, define) {
-			chunks.add( d );
-			chunks.add( define );
-		});
+    defines.forEach((d, define) {
+      chunks.add( d );
+      chunks.add( define );
+    });
 
-		code =  "${chunks.join()}"
-		        "maxDirLights$maxDirLights"
-		        "maxPointLights$maxPointLights"
-		        "maxSpotLights$maxSpotLights"
-		        "maxHemiLights$maxHemiLights"
-		        "maxShadows$maxShadows"
-		        "maxBones$maxBones"
-		        "map$map"
-		        "envMap$envMap"
-		        "lightMap$lightMap"
-		        "bumpMap$bumpMap"
-		        "normalMap$normalMap"
-		        "specularMap$specularMap"
-		        "vertexColors$vertexColors"
-		        "fog$fog"
-	          "useFog$useFog"
-	          "fogExp$fogExp"
-		        "skinning$skinning"
-		        "useVertexTexture$useVertexTexture"
-		        "boneTextureWidth$boneTextureWidth"
-		        "boneTextureHeight$boneTextureHeight"
-		        "morphTargets$morphTargets"
+    code =  "${chunks.join()}"
+            "maxDirLights$maxDirLights"
+            "maxPointLights$maxPointLights"
+            "maxSpotLights$maxSpotLights"
+            "maxHemiLights$maxHemiLights"
+            "maxShadows$maxShadows"
+            "maxBones$maxBones"
+            "map$map"
+            "envMap$envMap"
+            "lightMap$lightMap"
+            "bumpMap$bumpMap"
+            "normalMap$normalMap"
+            "specularMap$specularMap"
+            "vertexColors$vertexColors"
+            "fog$fog"
+            "useFog$useFog"
+            "fogExp$fogExp"
+            "skinning$skinning"
+            "useVertexTexture$useVertexTexture"
+            "boneTextureWidth$boneTextureWidth"
+            "boneTextureHeight$boneTextureHeight"
+            "morphTargets$morphTargets"
             "morphNormals$morphNormals"
             "perPixel$perPixel"
             "wrapAround$wrapAround"
-		        "doubleSided$doubleSided"
-		        "flipSided$flipSided"
+            "doubleSided$doubleSided"
+            "flipSided$flipSided"
             "shadowMapEnabled$shadowMapEnabled"
             "shadowMapType$shadowMapType"
             "shadowMapDebug$shadowMapDebug"
-		        "shadowMapCascade$shadowMapCascade"
+            "shadowMapCascade$shadowMapCascade"
             "sizeAttenuation$sizeAttenuation";
 
 
-		// Check if code has been already compiled
+    // Check if code has been already compiled
 
-		pl = _programs.length;
-		for ( p = 0; p < pl; p ++ ) {
+    pl = _programs.length;
+    for ( p = 0; p < pl; p ++ ) {
 
-			Program program = _programs[ p ];
+      Program program = _programs[ p ];
 
-			// TODO - why do we need identical here ?!
+      // TODO - why do we need identical here ?!
       if ( program.code == code ) {
 
-				//print( "Code already compiled: $program$code" );
+        //print( "Code already compiled: $program$code" );
 
-			  program.usedTimes ++;
+        program.usedTimes ++;
 
-				return program;
+        return program;
 
-			}
+      }
 
-		}
+    }
 
-		var shadowMapTypeDefine = "SHADOWMAP_TYPE_BASIC";
+    var shadowMapTypeDefine = "SHADOWMAP_TYPE_BASIC";
 
-		if ( shadowMapType == PCFShadowMap ) {
+    if ( shadowMapType == PCFShadowMap ) {
 
-			shadowMapTypeDefine = "SHADOWMAP_TYPE_PCF";
+      shadowMapTypeDefine = "SHADOWMAP_TYPE_PCF";
 
-		} else if ( shadowMapType == PCFSoftShadowMap ) {
+    } else if ( shadowMapType == PCFSoftShadowMap ) {
 
-			shadowMapTypeDefine = "SHADOWMAP_TYPE_PCF_SOFT";
+      shadowMapTypeDefine = "SHADOWMAP_TYPE_PCF_SOFT";
 
-		}
+    }
 
-		//print( "building new program " );
+    //print( "building new program " );
 
-		//
+    //
 
-		var customDefines = generateDefines( defines );
+    var customDefines = generateDefines( defines );
 
-		glprogram = _gl.createProgram();
+    glprogram = _gl.createProgram();
 
-		var prefix_vertex = [
+    var prefix_vertex = [
 
-			"precision $precision float;",
+      "precision $precision float;",
 
-			customDefines,
+      customDefines,
 
-			supportsVertexTextures ? "#define VERTEX_TEXTURES" : "",
+      supportsVertexTextures ? "#define VERTEX_TEXTURES" : "",
 
-			gammaInput ? "#define GAMMA_INPUT" : "",
-			gammaOutput ? "#define GAMMA_OUTPUT" : "",
-			physicallyBasedShading ? "#define PHYSICALLY_BASED_SHADING" : "",
+      gammaInput ? "#define GAMMA_INPUT" : "",
+      gammaOutput ? "#define GAMMA_OUTPUT" : "",
+      physicallyBasedShading ? "#define PHYSICALLY_BASED_SHADING" : "",
 
-			"#define MAX_DIR_LIGHTS $maxDirLights",
-			"#define MAX_POINT_LIGHTS $maxPointLights",
-			"#define MAX_SPOT_LIGHTS $maxSpotLights",
-			"#define MAX_HEMI_LIGHTS $maxHemiLights",
+      "#define MAX_DIR_LIGHTS $maxDirLights",
+      "#define MAX_POINT_LIGHTS $maxPointLights",
+      "#define MAX_SPOT_LIGHTS $maxSpotLights",
+      "#define MAX_HEMI_LIGHTS $maxHemiLights",
 
-			"#define MAX_SHADOWS $maxShadows",
+      "#define MAX_SHADOWS $maxShadows",
 
-			"#define MAX_BONES $maxBones",
+      "#define MAX_BONES $maxBones",
 
-			(map != null) ? "#define USE_MAP" : "",
-			(envMap != null) ? "#define USE_ENVMAP" : "",
-			(lightMap != null) ? "#define USE_LIGHTMAP" : "",
-			(bumpMap != null) ? "#define USE_BUMPMAP" : "",
-			(normalMap != null) ? "#define USE_NORMALMAP" : "",
-			(specularMap != null) ? "#define USE_SPECULARMAP" : "",
-			(((vertexColors is bool) && vertexColors) || ((vertexColors is int) && (vertexColors != NoColors))) ? "#define USE_COLOR" : "",
+      (map != null) ? "#define USE_MAP" : "",
+      (envMap != null) ? "#define USE_ENVMAP" : "",
+      (lightMap != null) ? "#define USE_LIGHTMAP" : "",
+      (bumpMap != null) ? "#define USE_BUMPMAP" : "",
+      (normalMap != null) ? "#define USE_NORMALMAP" : "",
+      (specularMap != null) ? "#define USE_SPECULARMAP" : "",
+      (((vertexColors is bool) && vertexColors) || ((vertexColors is int) && (vertexColors != NoColors))) ? "#define USE_COLOR" : "",
 
-			skinning ? "#define USE_SKINNING" : "",
-			useVertexTexture ? "#define BONE_TEXTURE" : "",
-			(boneTextureWidth != null) ? "#define N_BONE_PIXEL_X ${boneTextureWidth.toStringAsFixed(1)}" : "",
-			(boneTextureHeight != null) ? "#define N_BONE_PIXEL_Y ${boneTextureHeight.toStringAsFixed( 1 )}" : "",
+      skinning ? "#define USE_SKINNING" : "",
+      useVertexTexture ? "#define BONE_TEXTURE" : "",
+      (boneTextureWidth != null) ? "#define N_BONE_PIXEL_X ${boneTextureWidth.toStringAsFixed(1)}" : "",
+      (boneTextureHeight != null) ? "#define N_BONE_PIXEL_Y ${boneTextureHeight.toStringAsFixed( 1 )}" : "",
 
-			morphTargets ? "#define USE_MORPHTARGETS" : "",
-			morphNormals ? "#define USE_MORPHNORMALS" : "",
-			perPixel ? "#define PHONG_PER_PIXEL" : "",
-			wrapAround ? "#define WRAP_AROUND" : "",
-			doubleSided ? "#define DOUBLE_SIDED" : "",
-			flipSided ? "#define FLIP_SIDED" : "",
+      morphTargets ? "#define USE_MORPHTARGETS" : "",
+      morphNormals ? "#define USE_MORPHNORMALS" : "",
+      perPixel ? "#define PHONG_PER_PIXEL" : "",
+      wrapAround ? "#define WRAP_AROUND" : "",
+      doubleSided ? "#define DOUBLE_SIDED" : "",
+      flipSided ? "#define FLIP_SIDED" : "",
 
-			shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
-			shadowMapEnabled ? "#define $shadowMapTypeDefine" : "",
-			shadowMapDebug ? "#define SHADOWMAP_DEBUG" : "",
-			shadowMapCascade ? "#define SHADOWMAP_CASCADE" : "",
+      shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
+      shadowMapEnabled ? "#define $shadowMapTypeDefine" : "",
+      shadowMapDebug ? "#define SHADOWMAP_DEBUG" : "",
+      shadowMapCascade ? "#define SHADOWMAP_CASCADE" : "",
 
-			sizeAttenuation ? "#define USE_SIZEATTENUATION" : "",
+      sizeAttenuation ? "#define USE_SIZEATTENUATION" : "",
 
-			"uniform mat4 modelMatrix;",
-			"uniform mat4 modelViewMatrix;",
-			"uniform mat4 projectionMatrix;",
-			"uniform mat4 viewMatrix;",
-			"uniform mat3 normalMatrix;",
-			"uniform vec3 cameraPosition;",
+      "uniform mat4 modelMatrix;",
+      "uniform mat4 modelViewMatrix;",
+      "uniform mat4 projectionMatrix;",
+      "uniform mat4 viewMatrix;",
+      "uniform mat3 normalMatrix;",
+      "uniform vec3 cameraPosition;",
 
-			"attribute vec3 position;",
-			"attribute vec3 normal;",
-			"attribute vec2 uv;",
-			"attribute vec2 uv2;",
+      "attribute vec3 position;",
+      "attribute vec3 normal;",
+      "attribute vec2 uv;",
+      "attribute vec2 uv2;",
 
-			"#ifdef USE_COLOR",
+      "#ifdef USE_COLOR",
 
-				"attribute vec3 color;",
+        "attribute vec3 color;",
 
-			"#endif",
+      "#endif",
 
-			"#ifdef USE_MORPHTARGETS",
+      "#ifdef USE_MORPHTARGETS",
 
-				"attribute vec3 morphTarget0;",
-				"attribute vec3 morphTarget1;",
-				"attribute vec3 morphTarget2;",
-				"attribute vec3 morphTarget3;",
+        "attribute vec3 morphTarget0;",
+        "attribute vec3 morphTarget1;",
+        "attribute vec3 morphTarget2;",
+        "attribute vec3 morphTarget3;",
 
-				"#ifdef USE_MORPHNORMALS",
+        "#ifdef USE_MORPHNORMALS",
 
-					"attribute vec3 morphNormal0;",
-					"attribute vec3 morphNormal1;",
-					"attribute vec3 morphNormal2;",
-					"attribute vec3 morphNormal3;",
+          "attribute vec3 morphNormal0;",
+          "attribute vec3 morphNormal1;",
+          "attribute vec3 morphNormal2;",
+          "attribute vec3 morphNormal3;",
 
-				"#else",
+        "#else",
 
-					"attribute vec3 morphTarget4;",
-					"attribute vec3 morphTarget5;",
-					"attribute vec3 morphTarget6;",
-					"attribute vec3 morphTarget7;",
+          "attribute vec3 morphTarget4;",
+          "attribute vec3 morphTarget5;",
+          "attribute vec3 morphTarget6;",
+          "attribute vec3 morphTarget7;",
 
-				"#endif",
+        "#endif",
 
-			"#endif",
+      "#endif",
 
-			"#ifdef USE_SKINNING",
+      "#ifdef USE_SKINNING",
 
-				"attribute vec4 skinIndex;",
-				"attribute vec4 skinWeight;",
+        "attribute vec4 skinIndex;",
+        "attribute vec4 skinWeight;",
 
-			"#endif",
+      "#endif",
 
-			""
+      ""
 
-		].join("\n");
+    ].join("\n");
 
-		var prefix_fragment = [
+    var prefix_fragment = [
 
-			"precision $precision float;",
+      "precision $precision float;",
 
-			( bumpMap != null || normalMap != null ) ? "#extension GL_OES_standard_derivatives : enable" : "",
+      ( bumpMap != null || normalMap != null ) ? "#extension GL_OES_standard_derivatives : enable" : "",
 
-			customDefines,
+      customDefines,
 
-			(bumpMap != null) ? "#extension GL_OES_standard_derivatives : enable" : "",
+      (bumpMap != null) ? "#extension GL_OES_standard_derivatives : enable" : "",
 
-			"#define MAX_DIR_LIGHTS $maxDirLights",
-			"#define MAX_POINT_LIGHTS $maxPointLights",
-			"#define MAX_SPOT_LIGHTS $maxSpotLights",
-			"#define MAX_HEMI_LIGHTS $maxHemiLights",
+      "#define MAX_DIR_LIGHTS $maxDirLights",
+      "#define MAX_POINT_LIGHTS $maxPointLights",
+      "#define MAX_SPOT_LIGHTS $maxSpotLights",
+      "#define MAX_HEMI_LIGHTS $maxHemiLights",
 
-			"#define MAX_SHADOWS $maxShadows",
+      "#define MAX_SHADOWS $maxShadows",
 
-			(alphaTest != 0) ? "#define ALPHATEST $alphaTest": "",
+      (alphaTest != 0) ? "#define ALPHATEST $alphaTest": "",
 
-			gammaInput ? "#define GAMMA_INPUT" : "",
-			gammaOutput ? "#define GAMMA_OUTPUT" : "",
-			physicallyBasedShading ? "#define PHYSICALLY_BASED_SHADING" : "",
+      gammaInput ? "#define GAMMA_INPUT" : "",
+      gammaOutput ? "#define GAMMA_OUTPUT" : "",
+      physicallyBasedShading ? "#define PHYSICALLY_BASED_SHADING" : "",
 
-			( useFog && (fog != null) ) ? "#define USE_FOG" : "",
-			( useFog && (fog is FogExp2) ) ? "#define FOG_EXP2" : "",
+      ( useFog && (fog != null) ) ? "#define USE_FOG" : "",
+      ( useFog && (fog is FogExp2) ) ? "#define FOG_EXP2" : "",
 
-			(map != null) ? "#define USE_MAP" : "",
-			(envMap != null) ? "#define USE_ENVMAP" : "",
-			(lightMap != null) ? "#define USE_LIGHTMAP" : "",
-			(bumpMap != null) ? "#define USE_BUMPMAP" : "",
-			(normalMap != null) ? "#define USE_NORMALMAP" : "",
-			(specularMap != null) ? "#define USE_SPECULARMAP" : "",
-			(((vertexColors is bool) && vertexColors) || ((vertexColors is int) && (vertexColors != NoColors))) ? "#define USE_COLOR" : "",
+      (map != null) ? "#define USE_MAP" : "",
+      (envMap != null) ? "#define USE_ENVMAP" : "",
+      (lightMap != null) ? "#define USE_LIGHTMAP" : "",
+      (bumpMap != null) ? "#define USE_BUMPMAP" : "",
+      (normalMap != null) ? "#define USE_NORMALMAP" : "",
+      (specularMap != null) ? "#define USE_SPECULARMAP" : "",
+      (((vertexColors is bool) && vertexColors) || ((vertexColors is int) && (vertexColors != NoColors))) ? "#define USE_COLOR" : "",
 
-			metal ? "#define METAL" : "",
-			perPixel ? "#define PHONG_PER_PIXEL" : "",
-			wrapAround ? "#define WRAP_AROUND" : "",
-			doubleSided ? "#define DOUBLE_SIDED" : "",
-			flipSided ? "#define FLIP_SIDED" : "",
+      metal ? "#define METAL" : "",
+      perPixel ? "#define PHONG_PER_PIXEL" : "",
+      wrapAround ? "#define WRAP_AROUND" : "",
+      doubleSided ? "#define DOUBLE_SIDED" : "",
+      flipSided ? "#define FLIP_SIDED" : "",
 
-			shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
-			shadowMapEnabled ? "#define $shadowMapTypeDefine" : "",
-			shadowMapDebug ? "#define SHADOWMAP_DEBUG" : "",
-			shadowMapCascade ? "#define SHADOWMAP_CASCADE" : "",
+      shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
+      shadowMapEnabled ? "#define $shadowMapTypeDefine" : "",
+      shadowMapDebug ? "#define SHADOWMAP_DEBUG" : "",
+      shadowMapCascade ? "#define SHADOWMAP_CASCADE" : "",
 
-			"uniform mat4 viewMatrix;",
-			"uniform vec3 cameraPosition;",
-			""
+      "uniform mat4 viewMatrix;",
+      "uniform vec3 cameraPosition;",
+      ""
 
-		].join("\n");
+    ].join("\n");
 
-		var glFragmentShader = getShader( "fragment", "$prefix_fragment$fragmentShader" );
-		var glVertexShader = getShader( "vertex", "$prefix_vertex$vertexShader" );
+    var glFragmentShader = getShader( "fragment", "$prefix_fragment$fragmentShader" );
+    var glVertexShader = getShader( "vertex", "$prefix_vertex$vertexShader" );
 
-		_gl.attachShader( glprogram, glVertexShader );
-		_gl.attachShader( glprogram, glFragmentShader );
+    _gl.attachShader( glprogram, glVertexShader );
+    _gl.attachShader( glprogram, glFragmentShader );
 
-		_gl.linkProgram( glprogram );
+    _gl.linkProgram( glprogram );
 
-		if ( !_gl.getProgramParameter( glprogram, gl.LINK_STATUS ) ) {
+    if ( !_gl.getProgramParameter( glprogram, gl.LINK_STATUS ) ) {
 
-		  var status = _gl.getProgramParameter( glprogram, gl.VALIDATE_STATUS );
-		  var error = _gl.getError();
-			print( "Could not initialise shader\nVALIDATE_STATUS: $status, gl error [$error]" );
+      var status = _gl.getProgramParameter( glprogram, gl.VALIDATE_STATUS );
+      var error = _gl.getError();
+      print( "Could not initialise shader\nVALIDATE_STATUS: $status, gl error [$error]" );
 
-		}
+    }
 
-		// clean up
+    // clean up
 
-		_gl.deleteShader( glFragmentShader );
-		_gl.deleteShader( glVertexShader );
+    _gl.deleteShader( glFragmentShader );
+    _gl.deleteShader( glVertexShader );
 
-		//print( prefix_fragment + fragmentShader );
-		//print( prefix_vertex + vertexShader );
+    //print( prefix_fragment + fragmentShader );
+    //print( prefix_vertex + vertexShader );
 
-		//program.uniforms = {};
-		//program.attributes = {};
+    //program.uniforms = {};
+    //program.attributes = {};
 
-		var program = new Program( _programs_counter++,  glprogram, code, usedTimes: 1 );
+    var program = new Program( _programs_counter++,  glprogram, code, usedTimes: 1 );
 
-		var identifiers, u, a, i;
+    var identifiers, u, a, i;
 
-		// cache uniform locations
+    // cache uniform locations
 
-		identifiers = [
+    identifiers = [
 
-			'viewMatrix', 'modelViewMatrix', 'projectionMatrix', 'normalMatrix', 'modelMatrix', 'cameraPosition',
-			'morphTargetInfluences'
+      'viewMatrix', 'modelViewMatrix', 'projectionMatrix', 'normalMatrix', 'modelMatrix', 'cameraPosition',
+      'morphTargetInfluences'
 
-		];
+    ];
 
-		if ( useVertexTexture ) {
+    if ( useVertexTexture ) {
 
-			identifiers.add( 'boneTexture' );
+      identifiers.add( 'boneTexture' );
 
-		} else {
+    } else {
 
-			identifiers.add( 'boneGlobalMatrices' );
+      identifiers.add( 'boneGlobalMatrices' );
 
-		}
+    }
 
-		uniforms.forEach((u, _) => identifiers.add( u ));
+    uniforms.forEach((u, _) => identifiers.add( u ));
 
-		cacheUniformLocations( program, identifiers );
+    cacheUniformLocations( program, identifiers );
 
-		// cache attributes locations
+    // cache attributes locations
 
-		identifiers = [
+    identifiers = [
 
-			"position", "normal", "uv", "uv2", "tangent", "color",
-			"skinIndex", "skinWeight", "lineDistance"
+      "position", "normal", "uv", "uv2", "tangent", "color",
+      "skinIndex", "skinWeight", "lineDistance"
 
-		];
+    ];
 
-		for ( i = 0; i < maxMorphTargets; i ++ ) {
+    for ( i = 0; i < maxMorphTargets; i ++ ) {
 
-			identifiers.add( "morphTarget$i" );
+      identifiers.add( "morphTarget$i" );
 
-		}
+    }
 
-		for ( i = 0; i < maxMorphNormals; i ++ ) {
+    for ( i = 0; i < maxMorphNormals; i ++ ) {
 
-			identifiers.add( "morphNormal$i" );
+      identifiers.add( "morphNormal$i" );
 
-		}
+    }
 
-		if (attributes != null) {
-		  attributes.forEach((a, _) => identifiers.add( a ));
-		}
+    if (attributes != null) {
+      attributes.forEach((a, _) => identifiers.add( a ));
+    }
 
-		cacheAttributeLocations( program, identifiers );
+    cacheAttributeLocations( program, identifiers );
 
-		_programs.add( program );
+    _programs.add( program );
 
-		info.memory.programs = _programs.length;
+    info.memory.programs = _programs.length;
 
-		return program;
+    return program;
 
-	}
+  }
 
-	// Shader parameters cache
+  // Shader parameters cache
 
-	cacheUniformLocations ( Program program, List<String> identifiers ) {
+  cacheUniformLocations ( Program program, List<String> identifiers ) {
 
-		var i, l, id;
+    var i, l, id;
 
-		l = identifiers.length;
-		for( i = 0; i < l; i ++ ) {
+    l = identifiers.length;
+    for( i = 0; i < l; i ++ ) {
 
-			id = identifiers[ i ];
-			program.uniforms[ id ] = _gl.getUniformLocation( program.glProgram, id );
+      id = identifiers[ i ];
+      program.uniforms[ id ] = _gl.getUniformLocation( program.glProgram, id );
 
-		}
+    }
 
-	}
+  }
 
-	cacheAttributeLocations ( Program program, List<String> identifiers ) {
+  cacheAttributeLocations ( Program program, List<String> identifiers ) {
 
-		var i, l, id;
+    var i, l, id;
 
-		l = identifiers.length;
-		for( i = 0; i < l; i ++ ) {
+    l = identifiers.length;
+    for( i = 0; i < l; i ++ ) {
 
-			id = identifiers[ i ];
-			program.attributes[ id ] = _gl.getAttribLocation( program.glProgram, id );
+      id = identifiers[ i ];
+      program.attributes[ id ] = _gl.getAttribLocation( program.glProgram, id );
 
-		}
+    }
 
-	}
+  }
 
-	addLineNumbers ( String string ) {
+  addLineNumbers ( String string ) {
 
-		var chunks = string.split( "\n" );
+    var chunks = string.split( "\n" );
 
-		var il = chunks.length;
-		for ( var i = 0; i < il; i ++ ) {
+    var il = chunks.length;
+    for ( var i = 0; i < il; i ++ ) {
 
-			// Chrome reports shader errors on lines
-			// starting counting from 1
+      // Chrome reports shader errors on lines
+      // starting counting from 1
 
-			chunks[ i ] = "${i + 1}:${chunks[i]}";
+      chunks[ i ] = "${i + 1}:${chunks[i]}";
 
-		}
+    }
 
-		return chunks.join( "\n" );
+    return chunks.join( "\n" );
 
-	}
+  }
 
-	gl.Shader getShader ( String type, String string ) {
+  gl.Shader getShader ( String type, String string ) {
 
-		var shader;
+    var shader;
 
-		if ( type == "fragment" ) {
+    if ( type == "fragment" ) {
 
-			shader = _gl.createShader( gl.FRAGMENT_SHADER );
+      shader = _gl.createShader( gl.FRAGMENT_SHADER );
 
-		} else if ( type == "vertex" ) {
+    } else if ( type == "vertex" ) {
 
-			shader = _gl.createShader( gl.VERTEX_SHADER );
+      shader = _gl.createShader( gl.VERTEX_SHADER );
 
-		}
+    }
 
-		_gl.shaderSource( shader, string );
-		_gl.compileShader( shader );
+    _gl.shaderSource( shader, string );
+    _gl.compileShader( shader );
 
-		if ( !_gl.getShaderParameter( shader, gl.COMPILE_STATUS ) ) {
+    if ( !_gl.getShaderParameter( shader, gl.COMPILE_STATUS ) ) {
 
-			print( _gl.getShaderInfoLog( shader ) );
-			print( addLineNumbers( string ) );
-			return null;
+      print( _gl.getShaderInfoLog( shader ) );
+      print( addLineNumbers( string ) );
+      return null;
 
-		}
+    }
 
-		return shader;
+    return shader;
 
-	}
+  }
 
-	// Textures
+  // Textures
 
 
-	bool isPowerOfTwo ( int value ) => ( value & ( value - 1 ) ) == 0;
+  bool isPowerOfTwo ( int value ) => ( value & ( value - 1 ) ) == 0;
 
-	setTextureParameters ( int textureType, Texture texture, bool isImagePowerOfTwo ) {
+  setTextureParameters ( int textureType, Texture texture, bool isImagePowerOfTwo ) {
 
-		if ( isImagePowerOfTwo ) {
+    if ( isImagePowerOfTwo ) {
 
-			_gl.texParameteri( textureType, gl.TEXTURE_WRAP_S, paramThreeToGL( texture.wrapS ) );
-			_gl.texParameteri( textureType, gl.TEXTURE_WRAP_T, paramThreeToGL( texture.wrapT ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_WRAP_S, paramThreeToGL( texture.wrapS ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_WRAP_T, paramThreeToGL( texture.wrapT ) );
 
-			_gl.texParameteri( textureType, gl.TEXTURE_MAG_FILTER, paramThreeToGL( texture.magFilter ) );
-			_gl.texParameteri( textureType, gl.TEXTURE_MIN_FILTER, paramThreeToGL( texture.minFilter ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_MAG_FILTER, paramThreeToGL( texture.magFilter ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_MIN_FILTER, paramThreeToGL( texture.minFilter ) );
 
-		} else {
+    } else {
 
-			_gl.texParameteri( textureType, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE );
-			_gl.texParameteri( textureType, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE );
+      _gl.texParameteri( textureType, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE );
+      _gl.texParameteri( textureType, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE );
 
-			_gl.texParameteri( textureType, gl.TEXTURE_MAG_FILTER, filterFallback( texture.magFilter ) );
-			_gl.texParameteri( textureType, gl.TEXTURE_MIN_FILTER, filterFallback( texture.minFilter ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_MAG_FILTER, filterFallback( texture.magFilter ) );
+      _gl.texParameteri( textureType, gl.TEXTURE_MIN_FILTER, filterFallback( texture.minFilter ) );
 
-		}
+    }
 
-		if ( (_glExtensionTextureFilterAnisotropic != null) && texture.type != FloatType ) {
+    if ( (_glExtensionTextureFilterAnisotropic != null) && texture.type != FloatType ) {
 
-			if ( texture.anisotropy > 1 || ( texture["__oldAnisotropy"] != null) ) {
+      if ( texture.anisotropy > 1 || ( texture["__oldAnisotropy"] != null) ) {
 
-				_gl.texParameterf( textureType, gl.ExtTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, Math.min( texture.anisotropy, maxAnisotropy ) );
-				texture["__oldAnisotropy"] = texture.anisotropy;
+        _gl.texParameterf( textureType, gl.ExtTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, Math.min( texture.anisotropy, maxAnisotropy ) );
+        texture["__oldAnisotropy"] = texture.anisotropy;
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	_checkGLError() {
+  _checkGLError() {
     int error = _gl.getError();
     if (error != 0) {
       print( "gl error [$error]" );
     }
-	}
+  }
 
-	setTexture( Texture texture, int slot ) {
+  setTexture( Texture texture, int slot ) {
 
-		if ( texture.needsUpdate ) {
+    if ( texture.needsUpdate ) {
 
-			if ( texture["__webglInit"] == null ) {
+      if ( texture["__webglInit"] == null ) {
 
-				texture["__webglInit"] = true;
+        texture["__webglInit"] = true;
 
-				//texture.addEventListener( 'dispose', onTextureDispose );
+        //texture.addEventListener( 'dispose', onTextureDispose );
 
-				texture["__webglTexture"] = _gl.createTexture();
+        texture["__webglTexture"] = _gl.createTexture();
 
-				info.memory.textures ++;
+        info.memory.textures ++;
 
-			}
+      }
 
-			_gl.activeTexture( gl.TEXTURE0 + slot );
-			_gl.bindTexture( gl.TEXTURE_2D, texture["__webglTexture"] );
+      _gl.activeTexture( gl.TEXTURE0 + slot );
+      _gl.bindTexture( gl.TEXTURE_2D, texture["__webglTexture"] );
 
-			_gl.pixelStorei( gl.UNPACK_FLIP_Y_WEBGL, (texture.flipY) ? 1 : 0 );
-			_gl.pixelStorei( gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, (texture.premultiplyAlpha) ? 1 : 0 );
-			_gl.pixelStorei( gl.UNPACK_ALIGNMENT, texture.unpackAlignment );
+      _gl.pixelStorei( gl.UNPACK_FLIP_Y_WEBGL, (texture.flipY) ? 1 : 0 );
+      _gl.pixelStorei( gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, (texture.premultiplyAlpha) ? 1 : 0 );
+      _gl.pixelStorei( gl.UNPACK_ALIGNMENT, texture.unpackAlignment );
 
-			var image = texture.image,
-			isImagePowerOfTwo = isPowerOfTwo( image.width ) && isPowerOfTwo( image.height ),
-			glFormat = paramThreeToGL( texture.format ),
-			glType = paramThreeToGL( texture.type );
+      var image = texture.image,
+      isImagePowerOfTwo = isPowerOfTwo( image.width ) && isPowerOfTwo( image.height ),
+      glFormat = paramThreeToGL( texture.format ),
+      glType = paramThreeToGL( texture.type );
 
-			setTextureParameters( gl.TEXTURE_2D, texture, isImagePowerOfTwo );
+      setTextureParameters( gl.TEXTURE_2D, texture, isImagePowerOfTwo );
 
-			var mipmap, mipmaps = texture.mipmaps;
+      var mipmap, mipmaps = texture.mipmaps;
 
-			if ( texture is DataTexture ) {
+      if ( texture is DataTexture ) {
 
-				// use manually created mipmaps if available
-				// if there are no manual mipmaps
-				// set 0 level mipmap and then use GL to generate other mipmap levels
+        // use manually created mipmaps if available
+        // if there are no manual mipmaps
+        // set 0 level mipmap and then use GL to generate other mipmap levels
 
-				if ( mipmaps.length > 0 && isImagePowerOfTwo ) {
+        if ( mipmaps.length > 0 && isImagePowerOfTwo ) {
 
-					for ( var i = 0, il = mipmaps.length; i < il; i ++ ) {
+          for ( var i = 0, il = mipmaps.length; i < il; i ++ ) {
 
-						mipmap = mipmaps[ i ];
-						_gl.texImage2DTyped( gl.TEXTURE_2D, i, glFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
+            mipmap = mipmaps[ i ];
+            _gl.texImage2DTyped( gl.TEXTURE_2D, i, glFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
 
-					}
+          }
 
-					texture.generateMipmaps = false;
+          texture.generateMipmaps = false;
 
-				} else {
+        } else {
 
-					_gl.texImage2DTyped( gl.TEXTURE_2D, 0, glFormat, image.width, image.height, 0, glFormat, glType, image.data );
+          _gl.texImage2DTyped( gl.TEXTURE_2D, 0, glFormat, image.width, image.height, 0, glFormat, glType, image.data );
 
-				}
+        }
 
-			} else if ( texture is CompressedTexture ) {
+      } else if ( texture is CompressedTexture ) {
 
-				// compressed textures can only use manually created mipmaps
-				// WebGL can't generate mipmaps for DDS textures
+        // compressed textures can only use manually created mipmaps
+        // WebGL can't generate mipmaps for DDS textures
 
-				for( var i = 0, il = mipmaps.length; i < il; i ++ ) {
+        for( var i = 0, il = mipmaps.length; i < il; i ++ ) {
 
-					mipmap = mipmaps[ i ];
-					_gl.compressedTexImage2D( gl.TEXTURE_2D, i, glFormat, mipmap.width, mipmap.height, 0, mipmap.data );
+          mipmap = mipmaps[ i ];
+          _gl.compressedTexImage2D( gl.TEXTURE_2D, i, glFormat, mipmap.width, mipmap.height, 0, mipmap.data );
 
-				}
+        }
 
-			} else {// regular Texture (image, video, canvas)
+      } else {// regular Texture (image, video, canvas)
 
-				// use manually created mipmaps if available
-				// if there are no manual mipmaps
-				// set 0 level mipmap and then use GL to generate other mipmap levels
+        // use manually created mipmaps if available
+        // if there are no manual mipmaps
+        // set 0 level mipmap and then use GL to generate other mipmap levels
 
-				if ( mipmaps.length > 0 && isImagePowerOfTwo ) {
+        if ( mipmaps.length > 0 && isImagePowerOfTwo ) {
 
-					for ( var i = 0, il = mipmaps.length; i < il; i ++ ) {
+          for ( var i = 0, il = mipmaps.length; i < il; i ++ ) {
 
-						mipmap = mipmaps[ i ];
-						_gl.texImage2D( gl.TEXTURE_2D, i, glFormat, glFormat, glType, mipmap );
+            mipmap = mipmaps[ i ];
+            _gl.texImage2D( gl.TEXTURE_2D, i, glFormat, glFormat, glType, mipmap );
 
-					}
+          }
 
-					texture.generateMipmaps = false;
+          texture.generateMipmaps = false;
 
-				} else if ( texture.image is ImageElement) {
+        } else if ( texture.image is ImageElement) {
 
-					_gl.texImage2DImage( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+          _gl.texImage2DImage( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
 
-				} else if ( texture.image is CanvasElement ) {
+        } else if ( texture.image is CanvasElement ) {
 
-				  _gl.texImage2DCanvas( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+          _gl.texImage2DCanvas( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
 
-				} else if ( texture.image is VideoElement ) {
+        } else if ( texture.image is VideoElement ) {
 
-				  _gl.texImage2DVideo( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
+          _gl.texImage2DVideo( gl.TEXTURE_2D, 0, glFormat, glFormat, glType, texture.image );
 
-				}
+        }
 
-			}
+      }
 
-			if ( texture.generateMipmaps && isImagePowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_2D );
+      if ( texture.generateMipmaps && isImagePowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_2D );
 
-			texture.needsUpdate = false;
+      texture.needsUpdate = false;
 
-			if ( texture.onUpdate != null ) texture.onUpdate();
+      if ( texture.onUpdate != null ) texture.onUpdate();
 
-		} else {
+    } else {
 
-			_gl.activeTexture( gl.TEXTURE0 + slot );
-			_gl.bindTexture( gl.TEXTURE_2D, texture["__webglTexture"] );
+      _gl.activeTexture( gl.TEXTURE0 + slot );
+      _gl.bindTexture( gl.TEXTURE_2D, texture["__webglTexture"] );
 
-		}
+    }
 
-	}
+  }
 
-	clampToMaxSize ( image, num maxSize ) {
+  clampToMaxSize ( image, num maxSize ) {
 
-		if ( image.width <= maxSize && image.height <= maxSize ) {
+    if ( image.width <= maxSize && image.height <= maxSize ) {
 
-			return image;
+      return image;
 
-		}
+    }
 
-		// Warning: Scaling through the canvas will only work with images that use
-		// premultiplied alpha.
+    // Warning: Scaling through the canvas will only work with images that use
+    // premultiplied alpha.
 
-		var maxDimension = Math.max( image.width, image.height );
-		var newWidth = ( image.width * maxSize / maxDimension ).floor();
-		var newHeight = ( image.height * maxSize / maxDimension ).floor();
+    var maxDimension = Math.max( image.width, image.height );
+    var newWidth = ( image.width * maxSize / maxDimension ).floor();
+    var newHeight = ( image.height * maxSize / maxDimension ).floor();
 
-		var canvas = new CanvasElement();
-		canvas.width = newWidth;
-		canvas.height = newHeight;
+    var canvas = new CanvasElement();
+    canvas.width = newWidth;
+    canvas.height = newHeight;
 
-		var ctx = canvas.context2D;
-		ctx.drawImageScaledFromSource( image, 0, 0, image.width, image.height, 0, 0, newWidth, newHeight );
+    var ctx = canvas.context2D;
+    ctx.drawImageScaledFromSource( image, 0, 0, image.width, image.height, 0, 0, newWidth, newHeight );
 
-		return canvas;
+    return canvas;
 
-	}
+  }
 
-	setCubeTexture ( Texture texture, int slot ) {
+  setCubeTexture ( Texture texture, int slot ) {
 
-		if ( texture.image.length == 6 ) {
-		  if(texture.image is ImageList){
-		    texture.image = new ImageList(texture.image);
-		  }
-			if ( texture.needsUpdate ) {
+    if ( texture.image.length == 6 ) {
+      if(texture.image is ImageList){
+        texture.image = new ImageList(texture.image);
+      }
+      if ( texture.needsUpdate ) {
 
-				if ( texture.image.webglTextureCube == null ) {
+        if ( texture.image.webglTextureCube == null ) {
 
-					texture.image.webglTextureCube = _gl.createTexture();
+          texture.image.webglTextureCube = _gl.createTexture();
 
-					info.memory.textures ++;
-				}
+          info.memory.textures ++;
+        }
 
-				_gl.activeTexture( gl.TEXTURE0 + slot );
-				_gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.image.webglTextureCube);
+        _gl.activeTexture( gl.TEXTURE0 + slot );
+        _gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.image.webglTextureCube);
 
-				_gl.pixelStorei( gl.UNPACK_FLIP_Y_WEBGL, (texture.flipY) ? 1 : 0 );
+        _gl.pixelStorei( gl.UNPACK_FLIP_Y_WEBGL, (texture.flipY) ? 1 : 0 );
 
-				var isCompressed = texture is CompressedTexture;
+        var isCompressed = texture is CompressedTexture;
 
-				var cubeImage = new List(6);
+        var cubeImage = new List(6);
 
-				for ( var i = 0; i < 6; i ++ ) {
+        for ( var i = 0; i < 6; i ++ ) {
 
-					if ( autoScaleCubemaps && ! isCompressed ) {
+          if ( autoScaleCubemaps && ! isCompressed ) {
 
-						cubeImage[ i ] = clampToMaxSize( texture.image[ i ], maxCubemapSize );
+            cubeImage[ i ] = clampToMaxSize( texture.image[ i ], maxCubemapSize );
 
-					} else {
+          } else {
 
-						cubeImage[ i ] = texture.image[ i ];
+            cubeImage[ i ] = texture.image[ i ];
 
-					}
+          }
 
-				}
+        }
 
-				var image = cubeImage[ 0 ],
-				isImagePowerOfTwo = isPowerOfTwo( image.width ) && isPowerOfTwo( image.height ),
-				glFormat = paramThreeToGL( texture.format ),
-				glType = paramThreeToGL( texture.type );
+        var image = cubeImage[ 0 ],
+        isImagePowerOfTwo = isPowerOfTwo( image.width ) && isPowerOfTwo( image.height ),
+        glFormat = paramThreeToGL( texture.format ),
+        glType = paramThreeToGL( texture.type );
 
-				setTextureParameters( gl.TEXTURE_CUBE_MAP, texture, isImagePowerOfTwo );
+        setTextureParameters( gl.TEXTURE_CUBE_MAP, texture, isImagePowerOfTwo );
 
-				for ( var i = 0; i < 6; i ++ ) {
+        for ( var i = 0; i < 6; i ++ ) {
 
-					if ( isCompressed ) {
+          if ( isCompressed ) {
 
-						var mipmap, mipmaps = cubeImage[ i ].mipmaps;
+            var mipmap, mipmaps = cubeImage[ i ].mipmaps;
 
-						for( var j = 0, jl = mipmaps.length; j < jl; j ++ ) {
+            for( var j = 0, jl = mipmaps.length; j < jl; j ++ ) {
 
-							mipmap = mipmaps[ j ];
-							_gl.compressedTexImage2D( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, j, glFormat, mipmap.width, mipmap.height, 0, mipmap.data );
+              mipmap = mipmaps[ j ];
+              _gl.compressedTexImage2D( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, j, glFormat, mipmap.width, mipmap.height, 0, mipmap.data );
 
-						}
+            }
 
-					} else {
+          } else {
 
-						_gl.texImage2DImage( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, glFormat, glType, cubeImage[ i ] );
+            _gl.texImage2DImage( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, glFormat, glType, cubeImage[ i ] );
 
-					}
+          }
 
-				}
+        }
 
-				if ( texture.generateMipmaps && isImagePowerOfTwo ) {
+        if ( texture.generateMipmaps && isImagePowerOfTwo ) {
 
-					_gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
+          _gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
 
-				}
+        }
 
-				texture.needsUpdate = false;
+        texture.needsUpdate = false;
 
-				if ( texture.onUpdate != null) texture.onUpdate();
+        if ( texture.onUpdate != null) texture.onUpdate();
 
-			} else {
+      } else {
 
-				_gl.activeTexture( gl.TEXTURE0 + slot );
-				_gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.image.webglTextureCube );
+        _gl.activeTexture( gl.TEXTURE0 + slot );
+        _gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.image.webglTextureCube );
 
-			}
+      }
 
-		}
+    }
 
-	}
+  }
 
-	setCubeTextureDynamic ( Texture texture, int slot ) {
+  setCubeTextureDynamic ( Texture texture, int slot ) {
 
-		_gl.activeTexture( gl.TEXTURE0 + slot );
-		_gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.__webglTexture );
+    _gl.activeTexture( gl.TEXTURE0 + slot );
+    _gl.bindTexture( gl.TEXTURE_CUBE_MAP, texture.__webglTexture );
 
-	}
+  }
 
-	// Render targets
+  // Render targets
 
-	setupFrameBuffer ( gl.Framebuffer framebuffer, WebGLRenderTarget renderTarget, int textureTarget ) {
+  setupFrameBuffer ( gl.Framebuffer framebuffer, WebGLRenderTarget renderTarget, int textureTarget ) {
 
-		_gl.bindFramebuffer( gl.FRAMEBUFFER, framebuffer );
-		_gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, textureTarget, renderTarget.__webglTexture, 0 );
+    _gl.bindFramebuffer( gl.FRAMEBUFFER, framebuffer );
+    _gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, textureTarget, renderTarget.__webglTexture, 0 );
 
-	}
+  }
 
-	setupRenderBuffer ( gl.Renderbuffer renderbuffer, WebGLRenderTarget renderTarget  ) {
+  setupRenderBuffer ( gl.Renderbuffer renderbuffer, WebGLRenderTarget renderTarget  ) {
 
-		_gl.bindRenderbuffer( gl.RENDERBUFFER, renderbuffer );
+    _gl.bindRenderbuffer( gl.RENDERBUFFER, renderbuffer );
 
-		if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
+    if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
 
-			_gl.renderbufferStorage( gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, renderTarget.width, renderTarget.height );
-			_gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, renderbuffer );
+      _gl.renderbufferStorage( gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, renderTarget.width, renderTarget.height );
+      _gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, renderbuffer );
 
-		/* For some reason this is not working. Defaulting to RGBA4.
-		} else if( ! renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
+    /* For some reason this is not working. Defaulting to RGBA4.
+    } else if( ! renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
 
-			_gl.renderbufferStorage( gl.RENDERBUFFER, gl.STENCIL_INDEX8, renderTarget.width, renderTarget.height );
-			_gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, WebGLRenderingContext.RENDERBUFFER, renderbuffer );
-		*/
-		} else if( renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
+      _gl.renderbufferStorage( gl.RENDERBUFFER, gl.STENCIL_INDEX8, renderTarget.width, renderTarget.height );
+      _gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, WebGLRenderingContext.RENDERBUFFER, renderbuffer );
+    */
+    } else if( renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
 
-			_gl.renderbufferStorage( gl.RENDERBUFFER, gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
-			_gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, renderbuffer );
+      _gl.renderbufferStorage( gl.RENDERBUFFER, gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
+      _gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, renderbuffer );
 
-		} else {
+    } else {
 
-			_gl.renderbufferStorage( gl.RENDERBUFFER, gl.RGBA4, renderTarget.width, renderTarget.height );
+      _gl.renderbufferStorage( gl.RENDERBUFFER, gl.RGBA4, renderTarget.width, renderTarget.height );
 
-		}
+    }
 
-	}
+  }
 
-	setRenderTarget ( WebGLRenderTarget renderTarget ) {
+  setRenderTarget ( WebGLRenderTarget renderTarget ) {
 
-		var isCube = ( renderTarget is WebGLRenderTargetCube );
+    var isCube = ( renderTarget is WebGLRenderTargetCube );
 
-		if ( (renderTarget != null ) && ( renderTarget.__webglFramebuffer == null) ) {
+    if ( (renderTarget != null ) && ( renderTarget.__webglFramebuffer == null) ) {
 
-			if ( renderTarget.depthBuffer == null ) renderTarget.depthBuffer = true;
-			if ( renderTarget.stencilBuffer == null ) renderTarget.stencilBuffer = true;
+      if ( renderTarget.depthBuffer == null ) renderTarget.depthBuffer = true;
+      if ( renderTarget.stencilBuffer == null ) renderTarget.stencilBuffer = true;
 
-			//renderTarget.addEventListener( 'dispose', onRenderTargetDispose );
+      //renderTarget.addEventListener( 'dispose', onRenderTargetDispose );
 
-			renderTarget.__webglTexture = _gl.createTexture();
+      renderTarget.__webglTexture = _gl.createTexture();
 
-			info.memory.textures ++;
+      info.memory.textures ++;
 
-			// Setup texture, create render and frame buffers
+      // Setup texture, create render and frame buffers
 
-			var isTargetPowerOfTwo = isPowerOfTwo( renderTarget.width ) && isPowerOfTwo( renderTarget.height ),
-				glFormat = paramThreeToGL( renderTarget.format ),
-				glType = paramThreeToGL( renderTarget.type );
+      var isTargetPowerOfTwo = isPowerOfTwo( renderTarget.width ) && isPowerOfTwo( renderTarget.height ),
+        glFormat = paramThreeToGL( renderTarget.format ),
+        glType = paramThreeToGL( renderTarget.type );
 
-			if ( isCube ) {
+      if ( isCube ) {
 
-				renderTarget.__webglFramebuffer = [];
-				renderTarget.__webglRenderbuffer = [];
+        renderTarget.__webglFramebuffer = [];
+        renderTarget.__webglRenderbuffer = [];
 
-				_gl.bindTexture( gl.TEXTURE_CUBE_MAP, renderTarget.__webglTexture );
-				setTextureParameters( gl.TEXTURE_CUBE_MAP, renderTarget, isTargetPowerOfTwo );
+        _gl.bindTexture( gl.TEXTURE_CUBE_MAP, renderTarget.__webglTexture );
+        setTextureParameters( gl.TEXTURE_CUBE_MAP, renderTarget, isTargetPowerOfTwo );
 
-				for ( var i = 0; i < 6; i ++ ) {
+        for ( var i = 0; i < 6; i ++ ) {
 
-					renderTarget.__webglFramebuffer[ i ] = _gl.createFramebuffer();
-					renderTarget.__webglRenderbuffer[ i ] = _gl.createRenderbuffer();
+          renderTarget.__webglFramebuffer[ i ] = _gl.createFramebuffer();
+          renderTarget.__webglRenderbuffer[ i ] = _gl.createRenderbuffer();
 
-					_gl.texImage2DTyped( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
+          _gl.texImage2DTyped( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, glFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
 
-					setupFrameBuffer( renderTarget.__webglFramebuffer[ i ], renderTarget, gl.TEXTURE_CUBE_MAP_POSITIVE_X + i );
-					setupRenderBuffer( renderTarget.__webglRenderbuffer[ i ], renderTarget );
+          setupFrameBuffer( renderTarget.__webglFramebuffer[ i ], renderTarget, gl.TEXTURE_CUBE_MAP_POSITIVE_X + i );
+          setupRenderBuffer( renderTarget.__webglRenderbuffer[ i ], renderTarget );
 
-				}
+        }
 
-				if ( isTargetPowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
+        if ( isTargetPowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
 
-			} else {
+      } else {
 
-				renderTarget.__webglFramebuffer = _gl.createFramebuffer();
+        renderTarget.__webglFramebuffer = _gl.createFramebuffer();
 
-				if ( renderTarget.shareDepthFrom != null ) {
+        if ( renderTarget.shareDepthFrom != null ) {
 
-					renderTarget.__webglRenderbuffer = renderTarget.shareDepthFrom.__webglRenderbuffer;
+          renderTarget.__webglRenderbuffer = renderTarget.shareDepthFrom.__webglRenderbuffer;
 
-				} else {
+        } else {
 
-					renderTarget.__webglRenderbuffer = _gl.createRenderbuffer();
+          renderTarget.__webglRenderbuffer = _gl.createRenderbuffer();
 
-				}
+        }
 
-				_gl.bindTexture( gl.TEXTURE_2D, renderTarget.__webglTexture );
-				setTextureParameters( gl.TEXTURE_2D, renderTarget, isTargetPowerOfTwo );
+        _gl.bindTexture( gl.TEXTURE_2D, renderTarget.__webglTexture );
+        setTextureParameters( gl.TEXTURE_2D, renderTarget, isTargetPowerOfTwo );
 
-				_gl.texImage2DTyped( gl.TEXTURE_2D, 0, glFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null);
+        _gl.texImage2DTyped( gl.TEXTURE_2D, 0, glFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null);
 
-				setupFrameBuffer( renderTarget.__webglFramebuffer, renderTarget, gl.TEXTURE_2D );
+        setupFrameBuffer( renderTarget.__webglFramebuffer, renderTarget, gl.TEXTURE_2D );
 
-				if ( renderTarget.shareDepthFrom != null) {
+        if ( renderTarget.shareDepthFrom != null) {
 
-					if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
+          if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
 
-						_gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, renderTarget.__webglRenderbuffer );
+            _gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, renderTarget.__webglRenderbuffer );
 
-					} else if ( renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
+          } else if ( renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
 
-						_gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, renderTarget.__webglRenderbuffer );
+            _gl.framebufferRenderbuffer( gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, renderTarget.__webglRenderbuffer );
 
-					}
+          }
 
-				} else {
+        } else {
 
-					setupRenderBuffer( renderTarget.__webglRenderbuffer, renderTarget );
+          setupRenderBuffer( renderTarget.__webglRenderbuffer, renderTarget );
 
-				}
+        }
 
-				if ( isTargetPowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_2D );
+        if ( isTargetPowerOfTwo ) _gl.generateMipmap( gl.TEXTURE_2D );
 
-			}
+      }
 
-			// Release everything
+      // Release everything
 
-			if ( isCube ) {
+      if ( isCube ) {
 
-				_gl.bindTexture( gl.TEXTURE_CUBE_MAP, null );
+        _gl.bindTexture( gl.TEXTURE_CUBE_MAP, null );
 
-			} else {
+      } else {
 
-				_gl.bindTexture( gl.TEXTURE_2D, null );
+        _gl.bindTexture( gl.TEXTURE_2D, null );
 
-			}
+      }
 
-			_gl.bindRenderbuffer( gl.RENDERBUFFER, null );
-			_gl.bindFramebuffer( gl.FRAMEBUFFER, null );
+      _gl.bindRenderbuffer( gl.RENDERBUFFER, null );
+      _gl.bindFramebuffer( gl.FRAMEBUFFER, null );
 
-		}
+    }
 
-		var framebuffer, width, height, vx, vy;
+    var framebuffer, width, height, vx, vy;
 
-		if ( renderTarget != null ) {
+    if ( renderTarget != null ) {
 
-			if ( isCube ) {
+      if ( isCube ) {
 
-				framebuffer = renderTarget.__webglFramebuffer[ (renderTarget as WebGLRenderTargetCube).activeCubeFace ];
+        framebuffer = renderTarget.__webglFramebuffer[ (renderTarget as WebGLRenderTargetCube).activeCubeFace ];
 
-			} else {
+      } else {
 
-				framebuffer = renderTarget.__webglFramebuffer;
+        framebuffer = renderTarget.__webglFramebuffer;
 
-			}
+      }
 
-			width = renderTarget.width;
-			height = renderTarget.height;
+      width = renderTarget.width;
+      height = renderTarget.height;
 
-			vx = 0;
-			vy = 0;
+      vx = 0;
+      vy = 0;
 
-		} else {
+    } else {
 
-			framebuffer = null;
+      framebuffer = null;
 
-			width = _viewportWidth;
-			height = _viewportHeight;
+      width = _viewportWidth;
+      height = _viewportHeight;
 
-			vx = _viewportX;
-			vy = _viewportY;
+      vx = _viewportX;
+      vy = _viewportY;
 
-		}
+    }
 
     if ( !identical(framebuffer, _currentFramebuffer) ) {
 
-			_gl.bindFramebuffer( gl.FRAMEBUFFER, framebuffer );
-			_gl.viewport( vx, vy, width, height );
+      _gl.bindFramebuffer( gl.FRAMEBUFFER, framebuffer );
+      _gl.viewport( vx, vy, width, height );
 
-			_currentFramebuffer = framebuffer;
+      _currentFramebuffer = framebuffer;
 
-		}
+    }
 
-		_currentWidth = width;
-		_currentHeight = height;
+    _currentWidth = width;
+    _currentHeight = height;
 
-	}
+  }
 
-	updateRenderTargetMipmap ( WebGLRenderTarget renderTarget ) {
+  updateRenderTargetMipmap ( WebGLRenderTarget renderTarget ) {
 
-		if ( renderTarget is WebGLRenderTargetCube ) {
+    if ( renderTarget is WebGLRenderTargetCube ) {
 
-			_gl.bindTexture( gl.TEXTURE_CUBE_MAP, renderTarget.__webglTexture );
-			_gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
-			_gl.bindTexture( gl.TEXTURE_CUBE_MAP, null );
+      _gl.bindTexture( gl.TEXTURE_CUBE_MAP, renderTarget.__webglTexture );
+      _gl.generateMipmap( gl.TEXTURE_CUBE_MAP );
+      _gl.bindTexture( gl.TEXTURE_CUBE_MAP, null );
 
-		} else {
+    } else {
 
-			_gl.bindTexture( gl.TEXTURE_2D, renderTarget.__webglTexture );
-			_gl.generateMipmap( gl.TEXTURE_2D );
-			_gl.bindTexture( gl.TEXTURE_2D, null );
+      _gl.bindTexture( gl.TEXTURE_2D, renderTarget.__webglTexture );
+      _gl.generateMipmap( gl.TEXTURE_2D );
+      _gl.bindTexture( gl.TEXTURE_2D, null );
 
-		}
+    }
 
-	}
+  }
 
-	// Fallback filters for non-power-of-2 textures
+  // Fallback filters for non-power-of-2 textures
 
-	int filterFallback ( int f ) {
+  int filterFallback ( int f ) {
 
-		if ( f == NearestFilter || f == NearestMipMapNearestFilter || f == NearestMipMapLinearFilter ) {
+    if ( f == NearestFilter || f == NearestMipMapNearestFilter || f == NearestMipMapLinearFilter ) {
 
-			return gl.NEAREST;
+      return gl.NEAREST;
 
-		}
+    }
 
-		return gl.LINEAR;
+    return gl.LINEAR;
 
-	}
+  }
 
-	// Map three.js constants to WebGL constants
+  // Map three.js constants to WebGL constants
 
-	int paramThreeToGL ( int p ) {
+  int paramThreeToGL ( int p ) {
 
-		if ( p == RepeatWrapping ) return gl.REPEAT;
-		if ( p == ClampToEdgeWrapping ) return gl.CLAMP_TO_EDGE;
-		if ( p == MirroredRepeatWrapping ) return gl.MIRRORED_REPEAT;
+    if ( p == RepeatWrapping ) return gl.REPEAT;
+    if ( p == ClampToEdgeWrapping ) return gl.CLAMP_TO_EDGE;
+    if ( p == MirroredRepeatWrapping ) return gl.MIRRORED_REPEAT;
 
-		if ( p == NearestFilter ) return gl.NEAREST;
-		if ( p == NearestMipMapNearestFilter ) return gl.NEAREST_MIPMAP_NEAREST;
-		if ( p == NearestMipMapLinearFilter ) return gl.NEAREST_MIPMAP_LINEAR;
+    if ( p == NearestFilter ) return gl.NEAREST;
+    if ( p == NearestMipMapNearestFilter ) return gl.NEAREST_MIPMAP_NEAREST;
+    if ( p == NearestMipMapLinearFilter ) return gl.NEAREST_MIPMAP_LINEAR;
 
-		if ( p == LinearFilter ) return gl.LINEAR;
-		if ( p == LinearMipMapNearestFilter ) return gl.LINEAR_MIPMAP_NEAREST;
-		if ( p == LinearMipMapLinearFilter ) return gl.LINEAR_MIPMAP_LINEAR;
+    if ( p == LinearFilter ) return gl.LINEAR;
+    if ( p == LinearMipMapNearestFilter ) return gl.LINEAR_MIPMAP_NEAREST;
+    if ( p == LinearMipMapLinearFilter ) return gl.LINEAR_MIPMAP_LINEAR;
 
-		if ( p == UnsignedByteType ) return gl.UNSIGNED_BYTE;
-		if ( p == UnsignedShort4444Type ) return gl.UNSIGNED_SHORT_4_4_4_4;
-		if ( p == UnsignedShort5551Type ) return gl.UNSIGNED_SHORT_5_5_5_1;
-		if ( p == UnsignedShort565Type ) return gl.UNSIGNED_SHORT_5_6_5;
+    if ( p == UnsignedByteType ) return gl.UNSIGNED_BYTE;
+    if ( p == UnsignedShort4444Type ) return gl.UNSIGNED_SHORT_4_4_4_4;
+    if ( p == UnsignedShort5551Type ) return gl.UNSIGNED_SHORT_5_5_5_1;
+    if ( p == UnsignedShort565Type ) return gl.UNSIGNED_SHORT_5_6_5;
 
-		if ( p == ByteType ) return gl.BYTE;
-		if ( p == ShortType ) return gl.SHORT;
-		if ( p == UnsignedShortType ) return gl.UNSIGNED_SHORT;
-		if ( p == IntType ) return gl.INT;
-		if ( p == UnsignedIntType ) return gl.UNSIGNED_INT;
-		if ( p == FloatType ) return gl.FLOAT;
+    if ( p == ByteType ) return gl.BYTE;
+    if ( p == ShortType ) return gl.SHORT;
+    if ( p == UnsignedShortType ) return gl.UNSIGNED_SHORT;
+    if ( p == IntType ) return gl.INT;
+    if ( p == UnsignedIntType ) return gl.UNSIGNED_INT;
+    if ( p == FloatType ) return gl.FLOAT;
 
-		if ( p == AlphaFormat ) return gl.ALPHA;
-		if ( p == RGBFormat ) return gl.RGB;
-		if ( p == RGBAFormat ) return gl.RGBA;
-		if ( p == LuminanceFormat ) return gl.LUMINANCE;
-		if ( p == LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
+    if ( p == AlphaFormat ) return gl.ALPHA;
+    if ( p == RGBFormat ) return gl.RGB;
+    if ( p == RGBAFormat ) return gl.RGBA;
+    if ( p == LuminanceFormat ) return gl.LUMINANCE;
+    if ( p == LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
 
-		if ( p == AddEquation ) return gl.FUNC_ADD;
-		if ( p == SubtractEquation ) return gl.FUNC_SUBTRACT;
-		if ( p == ReverseSubtractEquation ) return gl.FUNC_REVERSE_SUBTRACT;
+    if ( p == AddEquation ) return gl.FUNC_ADD;
+    if ( p == SubtractEquation ) return gl.FUNC_SUBTRACT;
+    if ( p == ReverseSubtractEquation ) return gl.FUNC_REVERSE_SUBTRACT;
 
-		if ( p == ZeroFactor ) return gl.ZERO;
-		if ( p == OneFactor ) return gl.ONE;
-		if ( p == SrcColorFactor ) return gl.SRC_COLOR;
-		if ( p == OneMinusSrcColorFactor ) return gl.ONE_MINUS_SRC_COLOR;
-		if ( p == SrcAlphaFactor ) return gl.SRC_ALPHA;
-		if ( p == OneMinusSrcAlphaFactor ) return gl.ONE_MINUS_SRC_ALPHA;
-		if ( p == DstAlphaFactor ) return gl.DST_ALPHA;
-		if ( p == OneMinusDstAlphaFactor ) return gl.ONE_MINUS_DST_ALPHA;
+    if ( p == ZeroFactor ) return gl.ZERO;
+    if ( p == OneFactor ) return gl.ONE;
+    if ( p == SrcColorFactor ) return gl.SRC_COLOR;
+    if ( p == OneMinusSrcColorFactor ) return gl.ONE_MINUS_SRC_COLOR;
+    if ( p == SrcAlphaFactor ) return gl.SRC_ALPHA;
+    if ( p == OneMinusSrcAlphaFactor ) return gl.ONE_MINUS_SRC_ALPHA;
+    if ( p == DstAlphaFactor ) return gl.DST_ALPHA;
+    if ( p == OneMinusDstAlphaFactor ) return gl.ONE_MINUS_DST_ALPHA;
 
-		if ( p == DstColorFactor ) return gl.DST_COLOR;
-		if ( p == OneMinusDstColorFactor ) return gl.ONE_MINUS_DST_COLOR;
-		if ( p == SrcAlphaSaturateFactor ) return gl.SRC_ALPHA_SATURATE;
+    if ( p == DstColorFactor ) return gl.DST_COLOR;
+    if ( p == OneMinusDstColorFactor ) return gl.ONE_MINUS_DST_COLOR;
+    if ( p == SrcAlphaSaturateFactor ) return gl.SRC_ALPHA_SATURATE;
 
-		if ( _glExtensionCompressedTextureS3TC != null ) {
+    if ( _glExtensionCompressedTextureS3TC != null ) {
 
-			if ( p == RGB_S3TC_DXT1_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGB_S3TC_DXT1_EXT;
-			if ( p == RGBA_S3TC_DXT1_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT1_EXT;
-			if ( p == RGBA_S3TC_DXT3_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT3_EXT;
-			if ( p == RGBA_S3TC_DXT5_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+      if ( p == RGB_S3TC_DXT1_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGB_S3TC_DXT1_EXT;
+      if ( p == RGBA_S3TC_DXT1_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT1_EXT;
+      if ( p == RGBA_S3TC_DXT3_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT3_EXT;
+      if ( p == RGBA_S3TC_DXT5_Format ) return gl.CompressedTextureS3TC.COMPRESSED_RGBA_S3TC_DXT5_EXT;
 
-		}
-		return 0;
+    }
+    return 0;
 
-	}
+  }
 
-	// Allocations
+  // Allocations
 
-	int allocateBones ( Object3D object ) {
+  int allocateBones ( Object3D object ) {
 
-		if ( supportsBoneTextures && (object != null) && object is SkinnedMesh && object.useVertexTexture ) {
+    if ( supportsBoneTextures && (object != null) && object is SkinnedMesh && object.useVertexTexture ) {
 
-			return 1024;
+      return 1024;
 
-		} else {
+    } else {
 
-			// default for when object is not specified
-			// ( for example when prebuilding shader
-			//   to be used with multiple objects )
-			//
-			// 	- leave some extra space for other uniforms
-			//  - limit here is ANGLE's 254 max uniform vectors
-			//    (up to 54 should be safe)
+      // default for when object is not specified
+      // ( for example when prebuilding shader
+      //   to be used with multiple objects )
+      //
+      //   - leave some extra space for other uniforms
+      //  - limit here is ANGLE's 254 max uniform vectors
+      //    (up to 54 should be safe)
 
-			int nVertexUniforms = _gl.getParameter( gl.MAX_VERTEX_UNIFORM_VECTORS );
-			int nVertexMatrices = ( ( nVertexUniforms - 20 ) / 4 ).floor().toInt();
+      int nVertexUniforms = _gl.getParameter( gl.MAX_VERTEX_UNIFORM_VECTORS );
+      int nVertexMatrices = ( ( nVertexUniforms - 20 ) / 4 ).floor().toInt();
 
-			var maxBones = nVertexMatrices;
+      var maxBones = nVertexMatrices;
 
-			if ( object != null && object is SkinnedMesh ) {
+      if ( object != null && object is SkinnedMesh ) {
 
-				maxBones = Math.min( object.bones.length, maxBones );
+        maxBones = Math.min( object.bones.length, maxBones );
 
-				if ( maxBones < object.bones.length ) {
+        if ( maxBones < object.bones.length ) {
 
-					print( "WebGLRenderer: too many bones - ${object.bones.length} , this GPU supports just $maxBones  (try OpenGL instead of ANGLE)" );
+          print( "WebGLRenderer: too many bones - ${object.bones.length} , this GPU supports just $maxBones  (try OpenGL instead of ANGLE)" );
 
-				}
+        }
 
-			}
+      }
 
-			return maxBones;
+      return maxBones;
 
-		}
+    }
 
-	}
+  }
 
-	Map<String, int> allocateLights ( List<Light> lights ) {
+  Map<String, int> allocateLights ( List<Light> lights ) {
 
-		var l, ll, light, dirLights, pointLights, spotLights, hemiLights;
+    var l, ll, light, dirLights, pointLights, spotLights, hemiLights;
 
-		dirLights = pointLights = spotLights = hemiLights = 0;
+    dirLights = pointLights = spotLights = hemiLights = 0;
 
-		ll = lights.length;
-		for ( l = 0; l < ll; l ++ ) {
+    ll = lights.length;
+    for ( l = 0; l < ll; l ++ ) {
 
-			light = lights[ l ];
+      light = lights[ l ];
 
-			if ( (( light is DirectionalLight ) || ( light is SpotLight )) &&
-			    (light as dynamic).onlyShadow ) { continue;
-			}
+      if ( (( light is DirectionalLight ) || ( light is SpotLight )) &&
+          (light as dynamic).onlyShadow ) { continue;
+      }
 
-			if ( light is DirectionalLight ) dirLights ++;
-			if ( light is PointLight ) pointLights ++;
-			if ( light is SpotLight ) spotLights ++;
-			if ( light is HemisphereLight ) hemiLights ++;
+      if ( light is DirectionalLight ) dirLights ++;
+      if ( light is PointLight ) pointLights ++;
+      if ( light is SpotLight ) spotLights ++;
+      if ( light is HemisphereLight ) hemiLights ++;
 
-		}
+    }
 
-		return { 'directional' : dirLights, 'point' : pointLights, 'spot': spotLights, 'hemi':  hemiLights};
+    return { 'directional' : dirLights, 'point' : pointLights, 'spot': spotLights, 'hemi':  hemiLights};
 
-	}
+  }
 
-	int allocateShadows ( List<Light> lights ) {
+  int allocateShadows ( List<Light> lights ) {
 
-		var l, ll, light, maxShadows = 0;
+    var l, ll, light, maxShadows = 0;
 
-		ll = lights.length;
-		for ( l = 0; l < ll; l++ ) {
+    ll = lights.length;
+    for ( l = 0; l < ll; l++ ) {
 
-			light = lights[ l ];
+      light = lights[ l ];
 
-			if ( ! light.castShadow ) continue;
+      if ( ! light.castShadow ) continue;
 
-			if ( light is SpotLight ) maxShadows ++;
-			if ( light is DirectionalLight && ! light.shadowCascade ) maxShadows ++;
+      if ( light is SpotLight ) maxShadows ++;
+      if ( light is DirectionalLight && ! light.shadowCascade ) maxShadows ++;
 
-		}
+    }
 
-		return maxShadows;
+    return maxShadows;
 
-	}
+  }
 
-	// Initialization
+  // Initialization
 
-	initGL () {
+  initGL () {
 
-		try {
-			_gl = canvas.getContext3d(alpha: alpha, premultipliedAlpha: premultipliedAlpha, antialias: antialias, stencil: stencil, preserveDrawingBuffer: preserveDrawingBuffer );
-			if ( _gl == null ) {
+    try {
+      _gl = canvas.getContext3d(alpha: alpha, premultipliedAlpha: premultipliedAlpha, antialias: antialias, stencil: stencil, preserveDrawingBuffer: preserveDrawingBuffer );
+      if ( _gl == null ) {
 
-				throw 'Error creating WebGL context.';
+        throw 'Error creating WebGL context.';
 
-			}
-		} catch ( error ) {
+      }
+    } catch ( error ) {
 
-			print( error );
+      print( error );
 
-		}
-		_glExtensionTextureFloat = _gl.getExtension( 'OES_texture_float' );
-		_glExtensionStandardDerivatives = _gl.getExtension( 'OES_standard_derivatives' );
+    }
+    _glExtensionTextureFloat = _gl.getExtension( 'OES_texture_float' );
+    _glExtensionStandardDerivatives = _gl.getExtension( 'OES_standard_derivatives' );
 
-		_glExtensionTextureFilterAnisotropic = _gl.getExtension( 'EXT_texture_filter_anisotropic' );
-		if (_glExtensionTextureFilterAnisotropic == null) {
-		  _glExtensionTextureFilterAnisotropic = _gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' );
-		}
-		if (_glExtensionTextureFilterAnisotropic == null) {
-		  _glExtensionTextureFilterAnisotropic = _gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
-		}
-		if (_glExtensionCompressedTextureS3TC == null) {
-			_glExtensionCompressedTextureS3TC = _gl.getExtension( 'WEBGL_compressed_texture_s3tc' );
-		}
-		if (_glExtensionCompressedTextureS3TC == null) {
-		  _glExtensionCompressedTextureS3TC = _gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' );
-		}
-		if (_glExtensionCompressedTextureS3TC == null) {
-		  _glExtensionCompressedTextureS3TC = _gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
-		}
+    _glExtensionTextureFilterAnisotropic = _gl.getExtension( 'EXT_texture_filter_anisotropic' );
+    if (_glExtensionTextureFilterAnisotropic == null) {
+      _glExtensionTextureFilterAnisotropic = _gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' );
+    }
+    if (_glExtensionTextureFilterAnisotropic == null) {
+      _glExtensionTextureFilterAnisotropic = _gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
+    }
+    if (_glExtensionCompressedTextureS3TC == null) {
+      _glExtensionCompressedTextureS3TC = _gl.getExtension( 'WEBGL_compressed_texture_s3tc' );
+    }
+    if (_glExtensionCompressedTextureS3TC == null) {
+      _glExtensionCompressedTextureS3TC = _gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' );
+    }
+    if (_glExtensionCompressedTextureS3TC == null) {
+      _glExtensionCompressedTextureS3TC = _gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
+    }
 
-		if ( _glExtensionTextureFloat == null ) {
+    if ( _glExtensionTextureFloat == null ) {
 
-			print( 'THREE.WebGLRenderer: Float textures not supported.' );
+      print( 'THREE.WebGLRenderer: Float textures not supported.' );
 
-		}
+    }
 
-		if ( _glExtensionStandardDerivatives == null ) {
+    if ( _glExtensionStandardDerivatives == null ) {
 
-		  print( 'THREE.WebGLRenderer: Standard derivatives not supported.' );
+      print( 'THREE.WebGLRenderer: Standard derivatives not supported.' );
 
-		}
+    }
 
-		if ( _glExtensionTextureFilterAnisotropic == null ) {
+    if ( _glExtensionTextureFilterAnisotropic == null ) {
 
-		  print( 'THREE.WebGLRenderer: Anisotropic texture filtering not supported.' );
+      print( 'THREE.WebGLRenderer: Anisotropic texture filtering not supported.' );
 
-		}
+    }
 
-		if ( _glExtensionCompressedTextureS3TC == null ) {
+    if ( _glExtensionCompressedTextureS3TC == null ) {
 
-			print( 'THREE.WebGLRenderer: S3TC compressed textures not supported.' );
+      print( 'THREE.WebGLRenderer: S3TC compressed textures not supported.' );
 
-		}
-	}
+    }
+  }
 
-	setDefaultGLState () {
+  setDefaultGLState () {
 
-		_gl.clearColor( 0, 0, 0, 1 );
-		_gl.clearDepth( 1 );
-		_gl.clearStencil( 0 );
+    _gl.clearColor( 0, 0, 0, 1 );
+    _gl.clearDepth( 1 );
+    _gl.clearStencil( 0 );
 
-		_gl.enable( gl.DEPTH_TEST );
-		_gl.depthFunc( gl.LEQUAL );
+    _gl.enable( gl.DEPTH_TEST );
+    _gl.depthFunc( gl.LEQUAL );
 
-		_gl.frontFace( gl.CCW );
-		_gl.cullFace( gl.BACK );
-		_gl.enable( gl.CULL_FACE );
+    _gl.frontFace( gl.CCW );
+    _gl.cullFace( gl.BACK );
+    _gl.enable( gl.CULL_FACE );
 
-		_gl.enable( gl.BLEND );
-		_gl.blendEquation( gl.FUNC_ADD );
-		_gl.blendFunc( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA );
+    _gl.enable( gl.BLEND );
+    _gl.blendEquation( gl.FUNC_ADD );
+    _gl.blendFunc( gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA );
 
-		_gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
+    _gl.clearColor( _clearColor.r, _clearColor.g, _clearColor.b, _clearAlpha );
 
-	}
+  }
 
 
 }
@@ -7493,40 +7493,40 @@ class WebGLRenderer implements Renderer {
 ///
 /// Useful for debugging or just for the sake of curiosity.
 class WebGLRendererInfo {
-	WebGLRendererMemoryInfo memory;
-	WebGLRendererRenderInfo render;
+  WebGLRendererMemoryInfo memory;
+  WebGLRendererRenderInfo render;
 
-	WebGLRendererInfo() {
-		memory = new WebGLRendererMemoryInfo();
-		render = new WebGLRendererRenderInfo();
-	}
+  WebGLRendererInfo() {
+    memory = new WebGLRendererMemoryInfo();
+    render = new WebGLRendererRenderInfo();
+  }
 }
 
 class WebGLRendererMemoryInfo {
-	int programs = 0,
-	    geometries = 0,
-	    textures = 0;
+  int programs = 0,
+      geometries = 0,
+      textures = 0;
 }
 
 class WebGLRendererRenderInfo {
-	int calls = 0,
-	    vertices = 0,
-	    faces = 0,
-	    points = 0;
+  int calls = 0,
+      vertices = 0,
+      faces = 0,
+      points = 0;
 }
 
 //
 // Wrapper classes for WebGL stuff by nelsonsilva
 //
 class Program {
-	int id;
-	gl.Program glProgram;
-	String code;
-	int usedTimes;
-	Map attributes;
-	Map uniforms;
+  int id;
+  gl.Program glProgram;
+  String code;
+  int usedTimes;
+  Map attributes;
+  Map uniforms;
 
-	Program( this.id, this.glProgram, this.code, {this.usedTimes: 0} ) : uniforms = {}, attributes = {};
+  Program( this.id, this.glProgram, this.code, {this.usedTimes: 0} ) : uniforms = {}, attributes = {};
 }
 
 class Buffer {
@@ -7599,11 +7599,11 @@ class WebGLGeometry {
 class WebGLObject {
 
   WebGLGeometry buffer;
-	Object3D object;
-	Material opaque, transparent;
-	bool render;
-	var z;
+  Object3D object;
+  Material opaque, transparent;
+  bool render;
+  var z;
 
-	WebGLObject(this.object, this.opaque, this.transparent, this.buffer, [this.render = true, this.z = 0]) ;
+  WebGLObject(this.object, this.opaque, this.transparent, this.buffer, [this.render = true, this.z = 0]) ;
 
 }

--- a/lib/src/textures/data_texture.dart
+++ b/lib/src/textures/data_texture.dart
@@ -6,9 +6,9 @@ class DataTexture extends Texture {
   : super(image, mapping, wrapS, wrapT, magFilter, minFilter, format, type ) ;
 
   factory DataTexture ( data, width, height, format, {type, mapping, wrapS, wrapT, magFilter, minFilter} ) {
-		  return new DataTexture._internal(
-		      { "data": data, "width": width, "height": height },
-		      data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter);
-		}
+      return new DataTexture._internal(
+          { "data": data, "width": width, "height": height },
+          data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter);
+    }
 
 }


### PR DESCRIPTION
I used Dart Editor when prepping #165, and that did automatic tabs -> spaces conversion (which I manually fixed before submitting). I think fixing this will make diffs merged before `dartfmt` is run cleaner.

In case it matters, to create this diff, I ran (on Linux):

    find -name '*.dart' -exec sed -i 's:	:  :g' {} \;

There may be some oddness if any of the code was edited assuming a tab width != 4, but that should be fixed by `dartfmt`.