### PR TITLE
Update data_texture.dart

### DIFF
--- a/lib/src/textures/data_texture.dart
+++ b/lib/src/textures/data_texture.dart
@@ -5,10 +5,21 @@ class DataTexture extends Texture {
   DataTexture._internal( image, data, width, height, format, [type, mapping, wrapS, wrapT, magFilter, minFilter] )
   : super(image, mapping, wrapS, wrapT, magFilter, minFilter, format, type ) ;
 
-  factory DataTexture ( data, width, height, format, {type, mapping, wrapS, wrapT, magFilter, minFilter} ) {
+  factory DataTexture ( data, width, height, format, {type:UnsignedByteType, mapping, wrapS:ClampToEdgeWrapping, wrapT:ClampToEdgeWrapping, magFilter:LinearFilter, minFilter:LinearMipMapLinearFilter} ) {
       return new DataTexture._internal(
-          { "data": data, "width": width, "height": height },
+          new DataImage(data,width,height),
           data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter);
     }
 
+}
+
+class DataImage {
+  var data;
+  int width,height;
+  
+  DataImage(var data,int width,int height) {
+    this.data = data;
+		this.width = width;
+		this.height = height;
+	}
 }


### PR DESCRIPTION
Using DataTexture fails in web_gl_renderer.dart:6837, because image parameter is instance of LinkedHashMap and there is no "width" nor "height" getter. Creating and passing  instance of DataImage class instead of {"data":data,"width":width,"height":height} solves the problem.
Other problem is that all optional parameters are automatically passed as null and WebGL prints out warning about illegal texture parameters value.