### PR TITLE
Fixed bug where getChildByName allways return null

### DIFF
--- a/lib/src/core/object3d.dart
+++ b/lib/src/core/object3d.dart
@@ -249,7 +249,7 @@ class Object3D {
     int cl = children.length;
     Object3D child, recurseResult;
 
-    children.forEach((child) {
+    for (Object3D child in children) {
 
       if (child.name == name) {
         return child;
@@ -262,7 +262,7 @@ class Object3D {
           return recurseResult;
         }
       }
-    });
+    }
 
     return null;
   }


### PR DESCRIPTION
This is my pull request for issue https://github.com/threeDart/three.dart/issues/193
